### PR TITLE
add code coverage with reporting to codecov.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules/
 .DS_Store
 dist/
 public_html/
+.nyc_output
+coverage.lcov

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,6 @@
+machine:
+  node:
+    # version: 0.11.8
+test:
+  pre:
+    - npm run eslint

--- a/circle.yml
+++ b/circle.yml
@@ -4,3 +4,6 @@ machine:
 test:
   pre:
     - npm run eslint
+  post:
+    - npm run test-report
+    - bash <(curl -s https://codecov.io/bash)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Cleopatra, the gecko profiler UI",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --compilers js:babel-core/register test/**/*.js src/**/test/*.js",
+    "test": "nyc mocha --compilers js:babel-core/register test/**/*.js src/**/test/*.js",
+    "test-report": "nyc report --reporter=text-lcov > coverage.lcov",
     "start": "NODE_ENV=development node server.js",
     "start-no-hot": "npm run start",
     "start-prod": "npm run build-prod && npm run serve-static",
@@ -54,6 +55,7 @@
     "local-web-server": "^1.2.6",
     "mkdirp": "^0.5.1",
     "mocha": "^3.1.1",
+    "nyc": "^10.0.0",
     "offline-plugin": "^4.5.2",
     "pretty-bytes": "^4.0.2",
     "query-string": "^4.2.3",

--- a/src/common/test/summarize-profile.js
+++ b/src/common/test/summarize-profile.js
@@ -37,7 +37,7 @@ describe('summarize-profile', function () {
       { category: 'script.compile.ion', samples: 2, percentage: 0.006825938566552901 },
       { category: 'wait', samples: 2, percentage: 0.006825938566552901 },
       { category: 'script.icupdate', samples: 2, percentage: 0.006825938566552901 },
-      { category: 'restyle', samples: 1, percentage: 0.0034129692832764505 }
+      { category: 'restyle', samples: 1, percentage: 0.0034129692832764505 },
     ]) {
       assert.equal(summary[i].category, category,
                    `summary ${i} should be category ${category}, not ${summary[i].category}`);

--- a/src/content/actions/index.js
+++ b/src/content/actions/index.js
@@ -302,7 +302,7 @@ export function retrieveProfileFromFile(file) {
       }
 
       dispatch(receiveProfileFromFile(profile));
-    }).catch(error => {
+    }).catch(() => {
       return (new Promise((resolve, reject) => {
         const reader = new FileReader();
         reader.onload = () => resolve(reader.result);

--- a/src/content/components/ProfileThreadHeaderBar.js
+++ b/src/content/components/ProfileThreadHeaderBar.js
@@ -26,7 +26,7 @@ class ProfileThreadHeaderBar extends Component {
     const { threadIndex, changeSelectedThread } = this.props;
     changeSelectedThread(threadIndex);
     if (time !== undefined) {
-    const { thread, funcStackInfo, changeSelectedFuncStack } = this.props;
+      const { thread, funcStackInfo, changeSelectedFuncStack } = this.props;
       const sampleIndex = getSampleIndexClosestToTime(thread.samples, time);
       const newSelectedStack = thread.samples.stack[sampleIndex];
       const newSelectedFuncStack = newSelectedStack === null ? -1 : funcStackInfo.stackIndexToFuncStackIndex[newSelectedStack];
@@ -35,7 +35,7 @@ class ProfileThreadHeaderBar extends Component {
     }
   }
 
-  _onMarkerSelect(markerIndex) {
+  _onMarkerSelect(/* markerIndex */) {
   }
 
   render() {
@@ -54,7 +54,7 @@ class ProfileThreadHeaderBar extends Component {
                           onClick={this._onGraphClick}
                           onMarkerSelect={this._onMarkerSelect}/>
       </li>
-    );    
+    );
   }
 
 }

--- a/src/content/components/ThreadMarkerOverlay.js
+++ b/src/content/components/ThreadMarkerOverlay.js
@@ -23,7 +23,7 @@ class ThreadMarkerOverlay extends Component {
 
   render() {
     const { thread, rangeStart, rangeEnd } = this.props;
-    const { markers, stringTable } = thread;
+    const { markers } = thread;
     return (
       <ol className='threadMarkerOverlay'
           onMouseDown={this._mouseDownListener}>
@@ -33,14 +33,10 @@ class ThreadMarkerOverlay extends Component {
             if (time < rangeStart || time > rangeEnd) {
               return null;
             }
-            let category = 'unknown';
             const data = markers.data[markerIndex];
             if (data) {
               if ('interval' in data) {
                 return null;
-              }
-              if ('category' in data) {
-                category = data.category;
               }
             }
             return (

--- a/src/content/components/ThreadStackGraph.js
+++ b/src/content/components/ThreadStackGraph.js
@@ -3,7 +3,6 @@ import shallowCompare from 'react-addons-shallow-compare';
 import classNames from 'classnames';
 import { timeCode } from '../../common/time-code';
 import { getSampleFuncStacks } from '../profile-data';
-import ThreadMarkerOverlay from './ThreadMarkerOverlay';
 
 class ThreadStackGraph extends Component {
 

--- a/src/content/containers/Home.js
+++ b/src/content/containers/Home.js
@@ -12,7 +12,13 @@ const InstallButton = ({ name, xpiURL, children }) => {
     }
     e.preventDefault();
   }}>{children}</a>;
-}
+};
+
+InstallButton.propTypes = {
+  name: PropTypes.string.isRequired,
+  xpiURL: PropTypes.string.isRequired,
+  children: PropTypes.node,
+};
 
 const Home = ({ className, profilerURL }) => {
   return (

--- a/src/content/containers/ProfileUploadField.js
+++ b/src/content/containers/ProfileUploadField.js
@@ -30,4 +30,4 @@ ProfileUploadField.propTypes = {
   retrieveProfileFromFile: PropTypes.func.isRequired,
 };
 
-export default connect(state => ({}), actions)(ProfileUploadField);
+export default connect(() => ({}), actions)(ProfileUploadField);

--- a/src/content/preprocess-profile.js
+++ b/src/content/preprocess-profile.js
@@ -124,7 +124,7 @@ function preprocessThreadStageTwo(thread, libs) {
         }
       }
     } else {
-      const cppMatch = 
+      const cppMatch =
         /^(.*) \(in ([^)]*)\) (\+ [0-9]+)$/.exec(locationString) ||
         /^(.*) \(in ([^)]*)\) (\(.*:.*\))$/.exec(locationString) ||
         /^(.*) \(in ([^)]*)\)$/.exec(locationString);
@@ -557,7 +557,7 @@ function preprocessThreadFromProfileJSONWithSymbolicationTable(thread, symbolica
   }
 
   let threadName = thread.name;
-  let processType = thread.processType || (threadName === 'Content' ? 'tab' : (threadName === 'Plugin' ? 'plugin' : 'default'));
+  const processType = thread.processType || (threadName === 'Content' ? 'tab' : (threadName === 'Plugin' ? 'plugin' : 'default'));
 
   if (threadName === 'Content') {
     threadName = 'GeckoMain';


### PR DESCRIPTION
This builds on top of #120 

The `npm test` command is adapted to include a code coverage report at the end of each test run. Additionally there is a new script `npm run test-report` which generates a report that CircleCI then uploads to https://codecov.io/

Here's what the new test output looks like:

```bash
$ npm test

> cleopatra@0.0.1 test /Users/clarkbw/src/mozilla/cleopatra
> nyc mocha --compilers js:babel-core/register test/**/*.js src/**/test/*.js



  unique-string-array
    ✓ should return the right strings
    ✓ should return the correct index for existing strings
    ✓ should return a new index for a new string

  preprocess-profile
    preprocessProfile
      ✓ should have three threads
      ✓ should not have a profile-wide libs property
      ✓ should have threads that are objects of the right shape
      ✓ should sort libs by start address
      ✓ should have reasonable pdbName fields on each library
      ✓ should have reasonable breakpadId fields on each library
      ✓ should shift the content process by 1 second
      ✓ should create one function per frame
      ✓ should create one resource per used library

  profile-data
    createFuncStackTableAndFixupSamples
      ✓ should create one funcStack per stack

  symbolication
    getContainingLibrary
      ✓ should return the first library for addresses inside the first library
      ✓ should return the second library for addresses inside the second library
      ✓ should return the third library for addresses inside the third library
      ✓ should return no library when outside or in holes
    symbolicateProfile
      ✓ should assign correct symbols to frames

  summarize-profile
    ✓ has the thread names
    ✓ categorizes samples
    ✓ provides a rolling summary
    ✓ provides sane rolling summary values


  22 passing (21ms)

-------------------------|----------|----------|----------|----------|----------------|
File                     |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
-------------------------|----------|----------|----------|----------|----------------|
All files                |    43.12 |    31.35 |    51.92 |    41.99 |                |
 common                  |    77.78 |    66.04 |    85.71 |    76.81 |                |
  summarize-profile.js   |    80.29 |    67.35 |    85.29 |    79.39 |... 236,253,254 |
  time-code.js           |    28.57 |       50 |      100 |    28.57 |      4,5,6,7,8 |
 common/test             |      100 |     87.5 |      100 |      100 |                |
  summarize-profile.js   |      100 |     87.5 |      100 |      100 |                |
 content                 |    31.96 |    22.26 |    38.05 |    31.68 |                |
  preprocess-profile.js  |    38.66 |    27.13 |    67.74 |    37.58 |... 611,612,619 |
  profile-data.js        |    10.58 |     4.55 |     6.82 |    10.82 |... 525,526,529 |
  promise-worker.js      |      2.7 |        0 |     9.09 |     3.33 |... 44,45,46,48 |
  symbolication.js       |    60.71 |    45.45 |       64 |    61.83 |... 297,298,300 |
  unique-string-array.js |    86.67 |     87.5 |      100 |    84.62 |           9,25 |
-------------------------|----------|----------|----------|----------|----------------|
```