### PR TITLE
add some simple tests for worker reducers

### DIFF
--- a/src/worker/reducers/index.js
+++ b/src/worker/reducers/index.js
@@ -1,6 +1,6 @@
 import {combineReducers} from 'redux';
-import profile from './profile'
-import summary from './summary'
+import profile from './profile';
+import summary from './summary';
 
 export default combineReducers({
   profile,

--- a/src/worker/reducers/index.js
+++ b/src/worker/reducers/index.js
@@ -1,22 +1,6 @@
 import {combineReducers} from 'redux';
-
-function profile(state = null, action) {
-  switch (action.type) {
-    case 'PROFILE_PROCESSED':
-      return action.profile;
-    default:
-      return state;
-  }
-}
-
-function summary(state = null, action) {
-  switch (action.type) {
-    case 'PROFILE_SUMMARY_PROCESSED':
-      return action.summary;
-    default:
-      return state;
-  }
-}
+import profile from './profile'
+import summary from './summary'
 
 export default combineReducers({
   profile,

--- a/src/worker/reducers/profile.js
+++ b/src/worker/reducers/profile.js
@@ -1,0 +1,8 @@
+export default function profile(state = null, action) {
+  switch (action.type) {
+    case 'PROFILE_PROCESSED':
+      return action.profile;
+    default:
+      return state;
+  }
+}

--- a/src/worker/reducers/summary.js
+++ b/src/worker/reducers/summary.js
@@ -1,0 +1,8 @@
+export default function summary(state = null, action) {
+  switch (action.type) {
+    case 'PROFILE_SUMMARY_PROCESSED':
+      return action.summary;
+    default:
+      return state;
+  }
+}

--- a/src/worker/test/reducers.js
+++ b/src/worker/test/reducers.js
@@ -1,0 +1,61 @@
+import 'babel-polyfill';
+import { describe, it } from 'mocha';
+import { assert } from 'chai';
+
+import profile from '../reducers/profile';
+import summary from '../reducers/summary';
+
+describe('worker/reducers', function () {
+
+  describe('reducers/profile', function () {
+
+    it('returns the profile', function () {
+      const data = "____DATA____";
+      let state = profile(null, {
+        type: 'PROFILE_PROCESSED',
+        profile: data
+      });
+      assert.strictEqual(data, state);
+    });
+
+    it('defaults to returning the state', function () {
+      let state = profile(undefined, {
+        type: null
+      });
+      assert.equal(null, state);
+
+      const data = {};
+      state = profile(data, {
+        type: null
+      });
+      assert.strictEqual(data, state);
+    });
+
+  });
+
+  describe('reducers/summary', function () {
+
+    it('returns the summary', function () {
+      const data = "____DATA____";
+      let state = summary(null, {
+        type: 'PROFILE_SUMMARY_PROCESSED',
+        summary: data
+      });
+      assert.strictEqual(data, state);
+    });
+
+    it('defaults to returning the state', function () {
+      let state = summary(undefined, {
+        type: null
+      });
+      assert.equal(null, state);
+
+      const data = {};
+      state = summary(data, {
+        type: null
+      });
+      assert.strictEqual(data, state);
+    });
+
+  });
+});

--- a/src/worker/test/reducers.js
+++ b/src/worker/test/reducers.js
@@ -10,23 +10,23 @@ describe('worker/reducers', function () {
   describe('reducers/profile', function () {
 
     it('returns the profile', function () {
-      const data = "____DATA____";
-      let state = profile(null, {
+      const data = '____DATA____';
+      const state = profile(null, {
         type: 'PROFILE_PROCESSED',
-        profile: data
+        profile: data,
       });
       assert.strictEqual(data, state);
     });
 
     it('defaults to returning the state', function () {
       let state = profile(undefined, {
-        type: null
+        type: null,
       });
       assert.equal(null, state);
 
       const data = {};
       state = profile(data, {
-        type: null
+        type: null,
       });
       assert.strictEqual(data, state);
     });
@@ -36,23 +36,23 @@ describe('worker/reducers', function () {
   describe('reducers/summary', function () {
 
     it('returns the summary', function () {
-      const data = "____DATA____";
-      let state = summary(null, {
+      const data = '____DATA____';
+      const state = summary(null, {
         type: 'PROFILE_SUMMARY_PROCESSED',
-        summary: data
+        summary: data,
       });
       assert.strictEqual(data, state);
     });
 
     it('defaults to returning the state', function () {
       let state = summary(undefined, {
-        type: null
+        type: null,
       });
       assert.equal(null, state);
 
       const data = {};
       state = summary(data, {
-        type: null
+        type: null,
       });
       assert.strictEqual(data, state);
     });


### PR DESCRIPTION
Writing tests require that I can access the reducers as functions and the `combineReducers` function makes that impossible so I had to split them out.  I believe this is the common format for redux anyway.

The tests themselves aren't particularly clever, but neither are these reducers so they should at least act as a good sanity check.  Also they should bump our code coverage and it would be good to prototype that process more.