### PR TITLE
Move index.js to src/content/index.js to speed up webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "perf.html",
   "version": "0.0.1",
   "description": "perf.html, the gecko profiler UI",
-  "main": "index.js",
+  "main": "src/content/index.js",
   "scripts": {
     "test": "npm run build && npm run test-all",
     "test-all": "NODE_ENV=test nyc mocha --compilers js:babel-core/register 'test/**/*.js' 'src/**/test/*.js'",
@@ -18,8 +18,8 @@
     "build-prod": "npm run build:clean && NODE_ENV=production webpack -p --progress",
     "build:clean": "rimraf dist && mkdirp dist && cp res/.htaccess dist/ && cp res/zee-worker.js dist/",
     "publish": "rimraf public_html && cp -r dist public_html",
-    "eslint": "eslint index.js src",
-    "eslint-fix": "eslint --fix index.js src",
+    "eslint": "eslint src",
+    "eslint-fix": "eslint --fix src",
     "documentation": "documentation"
   },
   "author": "Markus Stange <mstange@themasta.com>",

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import Perf from 'react-addons-perf';
 import { render } from 'react-dom';
-import Root from './src/content/containers/Root';
-import createStore from './src/content/create-store';
-import './res/style.css';
+import Root from './containers/Root';
+import createStore from './create-store';
+import '../../res/style.css';
 
 if (process.env.NODE_ENV === 'production') {
   const runtime = require('offline-plugin/runtime');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,10 @@ const path = require('path');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const OfflinePlugin = require('offline-plugin');
-
+const includes = [
+  path.join(__dirname, 'src'),
+  path.join(__dirname, 'res'),
+];
 const baseConfig = {
   plugins: [
     new webpack.DefinePlugin({
@@ -36,15 +39,15 @@ const baseConfig = {
     rules: [{
       test: /\.js$/,
       loaders: ['babel-loader'],
-      include: __dirname,
+      include: includes,
     }, {
       test: /\.json$/,
       loaders: ['json-loader'],
-      include: __dirname,
+      include: includes,
     }, {
       test: /\.css?$/,
       loaders: ['style-loader', 'css-loader?minimize'],
-      include: __dirname,
+      include: includes,
     }, {
       test: /\.jpg$/,
       loader: 'file-loader',
@@ -85,7 +88,7 @@ if (process.env.NODE_ENV === 'production') {
 module.exports = [
   {
     entry: [
-      './index',
+      './src/content/index',
     ],
     output: {
       path: path.join(__dirname, 'dist'),


### PR DESCRIPTION
Webpack was doing its thing on everything including the `node_modules` directory. This PR takes down the initial load time on my machine from ~20 seconds to ~7 seconds. It should also help cut down on source map size.