### PR TITLE
Upload error propagation

### DIFF
--- a/src/content/containers/ProfileSharing.js
+++ b/src/content/containers/ProfileSharing.js
@@ -146,6 +146,7 @@ class ProfileSharingCompositeButton extends Component {
           this._permalinkButton.openPanel();
         }
       });
+      return Promise.all([uploadPromise, shortenURLPromise]);
     }).catch(error => {
       this.setState({
         state: 'error',

--- a/src/content/profile-store.js
+++ b/src/content/profile-store.js
@@ -8,12 +8,12 @@ export function uploadBinaryProfileData(data, progressChangeCallback = undefined
       if (xhr.status === 200) {
         resolve(xhr.responseText);
       } else {
-        reject(xhr.status);
+        reject(`xhr onload with status != 200, xhr.statusText: ${xhr.statusText}`);
       }
     };
 
     xhr.onerror = () => {
-      reject(xhr.status);
+      reject(`xhr onerror was called, xhr.statusText: ${xhr.statusText}`);
     };
 
     xhr.upload.onprogress = e => {


### PR DESCRIPTION
A few minutes ago the profile store server was broken, but we weren't showing the upload error panel because Promise.race won't reject if one of the promises succeeds first.