### PR TITLE
Add flow typing for flame chart, annotate type units

### DIFF
--- a/src/common/text-measurement.js
+++ b/src/common/text-measurement.js
@@ -1,10 +1,19 @@
+// @flow
+
 /**
  * Measure the size of text for drawing within a 2d context. This will allow text
  * to be drawn in a constrained space. This class uses a variety of heuristics and
  * caching to make this process fast.
  */
 class TextMeasurement {
-  constructor(ctx) {
+
+  _ctx: CanvasRenderingContext2D
+  _cache: {[id: string]: number}
+  _averageCharWidth: number
+  overflowChar: string
+  minWidth: number
+
+  constructor(ctx: CanvasRenderingContext2D) {
     this._ctx = ctx;
     this._cache = {};
     this._averageCharWidth = this._calcAverageCharWidth();
@@ -21,7 +30,7 @@ class TextMeasurement {
    *
    * @return {number} The average letter width.
    */
-  _calcAverageCharWidth() {
+  _calcAverageCharWidth(): number {
     const string = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.()< /:-_';
     return this.getTextWidth(string) / string.length;
   }
@@ -33,7 +42,7 @@ class TextMeasurement {
    * @param {string} text - The text to analyze.
    * @return {number} The text width.
    */
-  getTextWidth(text) {
+  getTextWidth(text: string): number {
     const cachedWidth = this._cache[text];
     if (cachedWidth) {
       return cachedWidth;
@@ -50,7 +59,7 @@ class TextMeasurement {
    * @param {string} text - The text to analyze.
    * @return {number} The approximate text width.
    */
-  getTextWidthApprox(text) {
+  getTextWidthApprox(text: string): number {
     return text.length * this._averageCharWidth;
   }
 
@@ -62,7 +71,7 @@ class TextMeasurement {
    * @param {number} maxWidth - The available width for the given text.
    * @return {string} The fitted text.
    */
-  getFittedText(text, maxWidth) {
+  getFittedText(text: string, maxWidth: number): string {
     if (this.minWidth > maxWidth) {
       return '';
     }

--- a/src/common/types/units.js
+++ b/src/common/types/units.js
@@ -1,8 +1,8 @@
 export type Milliseconds = number;
 
 /**
- * The pixels represented by a unit of CSS, e.g. the height of a div by setting the
- * div.style.height = 15. This may not be the actual size of pixels in a canvas or
+ * The pixels represented by the px unit of CSS, e.g. the height of a div by setting the
+ * div.style.height = "15px". This may not be the actual size of pixels in a canvas or
  * displayed on the screen.
  */
 export type CssPixels = number;

--- a/src/common/types/units.js
+++ b/src/common/types/units.js
@@ -1,0 +1,20 @@
+export type Milliseconds = number;
+
+/**
+ * The pixels represented by a unit of CSS, e.g. the height of a div by setting the
+ * div.style.height = 15. This may not be the actual size of pixels in a canvas or
+ * displayed on the screen.
+ */
+export type CssPixels = number;
+
+/**
+ * The size of the pixels actually present on the device, particularly used on canvas
+ * sizing.
+ */
+export type DevicePixels = number;
+
+/**
+ * Given a specific timing range in a profile, 0 is the left-most side of this range,
+ * and 1 is the right-most.
+ */
+export type UnitIntervalOfProfileRange = number;

--- a/src/content/components/FlameChartCanvas.js
+++ b/src/content/components/FlameChartCanvas.js
@@ -35,6 +35,8 @@ class FlameChartCanvas extends Component {
   _textMeasurement: null|TextMeasurement
   _ctx: null|CanvasRenderingContext2D
 
+  props: Props
+
   constructor(props: Props) {
     super(props);
     this._requestedAnimationFrame = false;

--- a/src/content/components/FlameChartCanvas.js
+++ b/src/content/components/FlameChartCanvas.js
@@ -1,7 +1,28 @@
-import React, { Component, PropTypes } from 'react';
+// @flow
+import React, { Component } from 'react';
 import shallowCompare from 'react-addons-shallow-compare';
 import { timeCode } from '../../common/time-code';
 import TextMeasurement from '../../common/text-measurement';
+
+import type { Thread } from '../../common/types/profile';
+import type { Milliseconds, CssPixels, UnitIntervalOfProfileRange, DevicePixels } from '../../common/types/units';
+import type { StackTimingByDepth } from '../stack-timing';
+
+type Props = {
+  thread: Thread,
+  interval: Milliseconds,
+  rangeStart: Milliseconds,
+  rangeEnd: Milliseconds,
+  className: string,
+  containerWidth: CssPixels,
+  containerHeight: CssPixels,
+  viewportLeft: UnitIntervalOfProfileRange,
+  viewportRight: UnitIntervalOfProfileRange,
+  viewportTop: CssPixels,
+  viewportBottom: CssPixels,
+  stackTimingByDepth: StackTimingByDepth,
+  rowHeight: CssPixels,
+};
 
 const ROW_HEIGHT = 16;
 const TEXT_OFFSET_START = 3;
@@ -9,11 +30,16 @@ const TEXT_OFFSET_TOP = 11;
 
 class FlameChartCanvas extends Component {
 
-  constructor(props) {
+  _requestedAnimationFrame: boolean
+  _devicePixelRatio: number
+  _textMeasurement: null|TextMeasurement
+  _ctx: null|CanvasRenderingContext2D
+
+  constructor(props: Props) {
     super(props);
     this._requestedAnimationFrame = false;
     this._devicePixelRatio = 1;
-    this._textWidthsCache = {};
+    this._textMeasurement = null;
   }
 
   _scheduleDraw() {
@@ -30,8 +56,8 @@ class FlameChartCanvas extends Component {
     }
   }
 
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
+  shouldComponentUpdate(nextProps: Props) {
+    return shallowCompare(this, nextProps);
   }
 
   componentDidMount() {
@@ -42,8 +68,8 @@ class FlameChartCanvas extends Component {
     const {canvas} = this.refs;
     const {containerWidth, containerHeight} = this.props;
     const {devicePixelRatio} = window;
-    const pixelWidth = containerWidth * devicePixelRatio;
-    const pixelHeight = containerHeight * devicePixelRatio;
+    const pixelWidth: DevicePixels = containerWidth * devicePixelRatio;
+    const pixelHeight: DevicePixels = containerHeight * devicePixelRatio;
     if (!this._ctx) {
       this._ctx = canvas.getContext('2d');
     }
@@ -80,12 +106,14 @@ class FlameChartCanvas extends Component {
     const ctx = this._prepCanvas();
     ctx.clearRect(0, 0, containerWidth, containerHeight);
 
-    const rangeLength = rangeEnd - rangeStart;
-    const viewportLength = viewportRight - viewportLeft;
+    const rangeLength: Milliseconds = rangeEnd - rangeStart;
+    const viewportLength: UnitIntervalOfProfileRange = viewportRight - viewportLeft;
 
-    // Only draw the stack frames that are vertically within view.
+    // Convert CssPixels to Stack Depth
     const startDepth = Math.floor(viewportTop / rowHeight);
     const endDepth = Math.ceil(viewportBottom / rowHeight);
+
+    // Only draw the stack frames that are vertically within view.
     for (let depth = startDepth; depth < endDepth; depth++) {
       // Get the timing information for a row of stack frames.
       const stackTiming = stackTimingByDepth[depth];
@@ -102,8 +130,8 @@ class FlameChartCanvas extends Component {
        */
 
       // Decide which samples to actually draw
-      const timeAtViewportLeft = rangeStart + rangeLength * viewportLeft;
-      const timeAtViewportRight = rangeStart + rangeLength * viewportRight;
+      const timeAtViewportLeft: Milliseconds = rangeStart + rangeLength * viewportLeft;
+      const timeAtViewportRight: Milliseconds = rangeStart + rangeLength * viewportRight;
 
       for (let i = 0; i < stackTiming.length; i++) {
         // Only draw samples that are in bounds.
@@ -134,13 +162,13 @@ class FlameChartCanvas extends Component {
               // Platform code
               : 'rgb(240, 240, 240)';
           }
-          const unitStartTime = (stackTiming.start[i] - rangeStart) / rangeLength;
-          const unitEndTime = (stackTiming.end[i] - rangeStart) / rangeLength;
+          const startTime: UnitIntervalOfProfileRange = (stackTiming.start[i] - rangeStart) / rangeLength;
+          const endTime: UnitIntervalOfProfileRange = (stackTiming.end[i] - rangeStart) / rangeLength;
 
-          const x = ((unitStartTime - viewportLeft) * containerWidth / viewportLength);
-          const y = depth * ROW_HEIGHT - viewportTop;
-          const w = ((unitEndTime - unitStartTime) * containerWidth / viewportLength);
-          const h = ROW_HEIGHT - 1;
+          const x: CssPixels = ((startTime - viewportLeft) * containerWidth / viewportLength);
+          const y: CssPixels = depth * ROW_HEIGHT - viewportTop;
+          const w: CssPixels = ((endTime - startTime) * containerWidth / viewportLength);
+          const h: CssPixels = ROW_HEIGHT - 1;
 
           if (w < 2) {
             // Skip sending draw calls for sufficiently small boxes.
@@ -152,10 +180,10 @@ class FlameChartCanvas extends Component {
 
           // TODO - L10N RTL.
           // Constrain the x coordinate to the leftmost area.
-          const x2 = Math.max(x, 0) + TEXT_OFFSET_START;
-          const w2 = Math.max(0, w - (x2 - x));
+          const x2: CssPixels = Math.max(x, 0) + TEXT_OFFSET_START;
+          const w2: CssPixels = Math.max(0, w - (x2 - x));
 
-          if (w2 > this._textMeasurement.minWidth) {
+          if (this._textMeasurement !== null && w2 > this._textMeasurement.minWidth) {
             const text = this._textMeasurement.getFittedText(name, w2);
             if (text) {
               ctx.fillStyle = 'rgb(0, 0, 0)';
@@ -172,23 +200,5 @@ class FlameChartCanvas extends Component {
     return <canvas className='flameChartCanvas' ref='canvas'/>;
   }
 }
-
-FlameChartCanvas.propTypes = {
-  thread: PropTypes.shape({
-    samples: PropTypes.object.isRequired,
-  }).isRequired,
-  interval: PropTypes.number.isRequired,
-  rangeStart: PropTypes.number.isRequired,
-  rangeEnd: PropTypes.number.isRequired,
-  className: PropTypes.string,
-  containerWidth: PropTypes.number,
-  containerHeight: PropTypes.number,
-  viewportLeft: PropTypes.number,
-  viewportRight: PropTypes.number,
-  stackTimingByDepth: PropTypes.array,
-  rowHeight: PropTypes.number.isRequired,
-  viewportTop: PropTypes.number.isRequired,
-  viewportBottom: PropTypes.number.isRequired,
-};
 
 export default FlameChartCanvas;

--- a/src/content/components/FlameChartViewport.js
+++ b/src/content/components/FlameChartViewport.js
@@ -6,13 +6,7 @@ import type { Milliseconds, CssPixels, UnitIntervalOfProfileRange } from '../../
 import type { StackTimingByDepth } from '../stack-timing';
 
 type Props = {
-  connectedProps: {
-    thread: Thread,
-    interval: Milliseconds,
-    timeRange: { start: Milliseconds, end: Milliseconds },
-    maxStackDepth: number,
-    stackTimingByDepth: StackTimingByDepth,
-  },
+  connectedProps: {[key: any]: any},
   maxViewportHeight: number,
   rowHeight: number,
 };
@@ -150,10 +144,10 @@ class FlameChartViewport extends Component {
               viewportTop } = this.state;
 
       // Calculate left and right in terms of the unit interval of the profile range.
-      const viewportLength:CssPixels = viewportRight - viewportLeft;
-      const unitOffsetX:UnitIntervalOfProfileRange = viewportLength * (event.clientX - dragX) / containerWidth;
-      let newViewportLeft:CssPixels = viewportLeft - unitOffsetX;
-      let newViewportRight:CssPixels = viewportRight - unitOffsetX;
+      const viewportLength: CssPixels = viewportRight - viewportLeft;
+      const unitOffsetX: UnitIntervalOfProfileRange = viewportLength * (event.clientX - dragX) / containerWidth;
+      let newViewportLeft: CssPixels = viewportLeft - unitOffsetX;
+      let newViewportRight: CssPixels = viewportRight - unitOffsetX;
       if (newViewportLeft < 0) {
         newViewportLeft = 0;
         newViewportRight = viewportLength;
@@ -164,8 +158,8 @@ class FlameChartViewport extends Component {
       }
 
       // Calculate top and bottom in terms of pixels.
-      let newViewportTop:CssPixels = viewportTop - (event.clientY - dragY);
-      let newViewportBottom:CssPixels = newViewportTop + containerHeight;
+      let newViewportTop: CssPixels = viewportTop - (event.clientY - dragY);
+      let newViewportBottom: CssPixels = newViewportTop + containerHeight;
 
       // Constrain the viewport to the bottom.
       if (newViewportBottom > maxViewportHeight) {

--- a/src/content/components/FlameChartViewport.js
+++ b/src/content/components/FlameChartViewport.js
@@ -6,7 +6,13 @@ import type { Milliseconds, CssPixels, UnitIntervalOfProfileRange } from '../../
 import type { StackTimingByDepth } from '../stack-timing';
 
 type Props = {
-  connectedProps: {[key: any]: any},
+  thread: Thread,
+  maxStackDepth: number,
+  stackTimingByDepth: StackTimingByDepth,
+  isSelected: boolean,
+  timeRange: { start: Milliseconds, end: Milliseconds },
+  threadIndex: number,
+  interval: Milliseconds,
   maxViewportHeight: number,
   rowHeight: number,
 };
@@ -210,8 +216,7 @@ class FlameChartViewport extends Component {
 
   render() {
     const {
-      connectedProps: { thread, interval, timeRange, maxStackDepth, stackTimingByDepth },
-      rowHeight,
+      thread, interval, timeRange, maxStackDepth, stackTimingByDepth, rowHeight,
     } = this.props;
 
     const { containerWidth, containerHeight, viewportLeft, viewportRight, viewportTop,

--- a/src/content/containers/FlameChartView.js
+++ b/src/content/containers/FlameChartView.js
@@ -31,13 +31,21 @@ class FlameChartView extends Component {
   render() {
     // The viewport needs to know about the height of what it's drawing, calculate
     // that here at the top level component.
-    const {maxStackDepth} = this.props;
+    const {
+      thread, maxStackDepth, stackTimingByDepth, isSelected, timeRange, threadIndex, interval,
+    } = this.props;
     const maxViewportHeight = (maxStackDepth + 1) * ROW_HEIGHT;
 
     return (
       <div className='flameChartView'>
         <ProfileCallTreeSettings />
-        <FlameChartViewport connectedProps={this.props}
+        <FlameChartViewport thread={thread}
+                            maxStackDepth={maxStackDepth}
+                            stackTimingByDepth={stackTimingByDepth}
+                            isSelected={isSelected}
+                            timeRange={timeRange}
+                            threadIndex={threadIndex}
+                            interval={interval}
                             maxViewportHeight={maxViewportHeight}
                             rowHeight={ROW_HEIGHT} />
       </div>

--- a/src/content/containers/FlameChartView.js
+++ b/src/content/containers/FlameChartView.js
@@ -1,15 +1,32 @@
-import React, { Component, PropTypes } from 'react';
+// @flow
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import FlameChartViewport from '../components/FlameChartViewport';
 import { getSelectedThreadIndex, selectedThreadSelectors, getDisplayRange, getProfileInterval } from '../selectors/';
 import * as actions from '../actions';
 import ProfileCallTreeSettings from '../components/ProfileCallTreeSettings';
 
+import type { Thread } from '../../common/types/profile';
+import type { Milliseconds } from '../../common/types/units';
+import type { StackTimingByDepth } from '../stack-timing';
+
 require('./FlameChartView.css');
 
 const ROW_HEIGHT = 16;
 
+type Props = {
+  thread: Thread,
+  maxStackDepth: number,
+  stackTimingByDepth: StackTimingByDepth,
+  isSelected: boolean,
+  timeRange: { start: Milliseconds, end: Milliseconds },
+  threadIndex: number,
+  interval: Milliseconds,
+};
+
 class FlameChartView extends Component {
+
+  props: Props
 
   render() {
     // The viewport needs to know about the height of what it's drawing, calculate
@@ -27,15 +44,6 @@ class FlameChartView extends Component {
     );
   }
 }
-
-FlameChartView.propTypes = {
-  threadIndex: PropTypes.number.isRequired,
-  thread: PropTypes.object.isRequired,
-  interval: PropTypes.number.isRequired,
-  timeRange: PropTypes.object.isRequired,
-  isSelected: PropTypes.bool.isRequired,
-  maxStackDepth: PropTypes.number.isRequired,
-};
 
 export default connect(state => {
   return {


### PR DESCRIPTION
I added Flow to all of the Flame Chart components. While not required, I explicitly annotated types for units such as `CssPixels`, `DevicePixels`, `UnitIntervalForProfileRange` to help clarify the code, and what unit's are being used. I think this helps a bit on the code clarity.

@mstange if you could double check that I have the names correct for CssPixels and DevicePixels. That space is a bit confusing, especially if you have any type of zooming.

This resolves #151