### PR TITLE
Don't leave new.cleopatra.io service workers stranded

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/content/index.js",
   "scripts": {
     "build": "npm run build:clean && NODE_ENV=development webpack --progress",
-    "build:clean": "rimraf dist && mkdirp dist && cp res/.htaccess dist/ && cp res/zee-worker.js dist/",
+    "build:clean": "rimraf dist && mkdirp dist && cp res/.htaccess dist/ && cp res/new-cleopatra-io-serviceworker.js dist/ && cp res/zee-worker.js dist/",
     "build-prod": "npm run build:clean && NODE_ENV=production webpack -p --progress",
     "build-prod-readable": "npm run build:clean && NODE_ENV=production webpack --progress",
     "eslint": "eslint index.js src",

--- a/res/.htaccess
+++ b/res/.htaccess
@@ -1,7 +1,15 @@
 RewriteEngine On
 
+# Rewrite new.cleopatra.io/sw.js to an empty service worker so that existing
+# service workers on new.cleopatra.io can update to it and we don't leave
+# people stranded on the old service worker.
+RewriteCond %{REQUEST_URI} ^/sw\.js$
+RewriteCond %{HTTP_HOST} ^new\.cleopatra\.io$ [NC]
+RewriteRule ^ /new-cleopatra-io-serviceworker.js [L]
+
 # Redirect requests from www.perf-html.io and from new.cleoptra.io to perf-html.io
 RewriteCond %{HTTP_HOST} !^perf-html\.io$ [NC]
+RewriteCond %{REQUEST_URI} !^/new-cleopatra-io-serviceworker\.js$
 RewriteRule ^(.*)$ https://perf-html.io/$1 [L,R=301]
 
 # If an existing asset or directory is requested go to it as it is

--- a/res/new-cleopatra-io-serviceworker.js
+++ b/res/new-cleopatra-io-serviceworker.js
@@ -1,0 +1,27 @@
+/**
+ * This is the service worker that the existing service worker on
+ * new.cleopatra.io will update to. The only purpose of this service worker
+ * is to clear the cached resources and pass through all network requests
+ * so that navigation requests will receive the server's "redirect" response
+ * and everybody just gets redirected to perf-html.io.
+ */
+
+self.addEventListener('activate', function (event) {
+  event.waitUntil(caches.keys().then(function (keys) {
+    // Remove all caches.
+    return Promise.all(keys.map(function (key) {
+      return caches.delete(key);
+    }));
+  }).then(function () {
+    if (self.clients && self.clients.claim) {
+      return self.clients.claim();
+    }
+  }));
+});
+
+self.addEventListener('message', function (e) {
+  var data = e.data;
+  if (data && data.action === 'skipWaiting') {
+    self.skipWaiting();
+  }
+});


### PR DESCRIPTION
We're currently responding to all requests to new.cleopatra.io with a redirect to perf-html.io, including update requests for the service worker. If a service worker update request is redirected, the service worker update is canceled. This would leave users stuck on the current service worker forever; they'd be served from the cache and never pick up the redirect to perf-html.io.

This patch will cause us to serve an empty service worker at https://new.cleopatra.io/sw.js that existing service workers can update to.

Since this new service worker will not intercept fetches, all requests will go
straight to the server, which will respond with a redirect to perf-html.io.

I've already deployed this change to the server (by manually importing this branch from my clone), and it's working.