### PR TITLE
Restore how 'JS only' works in the call tree

### DIFF
--- a/src/content/actions/index.js
+++ b/src/content/actions/index.js
@@ -405,6 +405,13 @@ export function changeInvertCallstack(invertCallstack) {
   };
 }
 
+export function changeHidePlatformDetails(hidePlatformDetails) {
+  return {
+    type: 'CHANGE_HIDE_PLATFORM_DETAILS',
+    hidePlatformDetails,
+  };
+}
+
 export function updateProfileSelection(selection) {
   return {
     type: 'UPDATE_PROFILE_SELECTION',

--- a/src/content/actions/test/actions.js
+++ b/src/content/actions/test/actions.js
@@ -3,7 +3,7 @@ import { describe, it } from 'mocha';
 import { assert } from 'chai';
 import { blankStore, storeWithProfile } from './fixtures/stores';
 import * as selectors from '../../reducers/profile-view';
-import { changeCallTreeSearchString, receiveProfileFromAddon, changeJSOnly, addRangeFilter, changeInvertCallstack } from '../';
+import { changeCallTreeSearchString, receiveProfileFromAddon, changeHidePlatformDetails, addRangeFilter, changeInvertCallstack } from '../';
 const { selectedThreadSelectors } = selectors;
 
 const profile = require('../../../common/test/fixtures/profile-2d-canvas.json');
@@ -18,7 +18,7 @@ describe('actions/profile', function () {
   });
 });
 
-describe('selectors/getStackTimingByDepth', function () {
+describe('selectors/getStackTimingByDepthForFlameChart', function () {
   /**
    * This table shows off how a flame chart gets filtered to JS only, where the number is
    * the stack index, and P is platform code, and J javascript.
@@ -37,7 +37,7 @@ describe('selectors/getStackTimingByDepth', function () {
 
   it('computes unfiltered stack timing by depth', function () {
     const store = storeWithProfile();
-    const stackTimingByDepth = selectedThreadSelectors.getStackTimingByDepth(store.getState());
+    const stackTimingByDepth = selectedThreadSelectors.getStackTimingByDepthForFlameChart(store.getState());
     assert.deepEqual(stackTimingByDepth, [
       { start: [0], end: [91], stack: [0], length: 1 },
       { start: [0, 50], end: [40, 91], stack: [1, 1], length: 2 },
@@ -49,10 +49,10 @@ describe('selectors/getStackTimingByDepth', function () {
     ]);
   });
 
-  it('computes JS only stack timing by depth', function () {
+  it('computes "Hide platform details" stack timing by depth', function () {
     const store = storeWithProfile();
-    store.dispatch(changeJSOnly(true));
-    const stackTimingByDepth = selectedThreadSelectors.getStackTimingByDepth(store.getState());
+    store.dispatch(changeHidePlatformDetails(true));
+    const stackTimingByDepth = selectedThreadSelectors.getStackTimingByDepthForFlameChart(store.getState());
 
     assert.deepEqual(stackTimingByDepth, [
       { start: [0], end: [91], stack: [0], length: 1 },
@@ -66,7 +66,7 @@ describe('selectors/getStackTimingByDepth', function () {
   it('uses search strings', function () {
     const store = storeWithProfile();
     store.dispatch(changeCallTreeSearchString('javascript'));
-    const stackTimingByDepth = selectedThreadSelectors.getStackTimingByDepth(store.getState());
+    const stackTimingByDepth = selectedThreadSelectors.getStackTimingByDepthForFlameChart(store.getState());
     assert.deepEqual(stackTimingByDepth, [
       { start: [60], end: [91], stack: [0], length: 1 },
       { start: [60], end: [91], stack: [1], length: 1 },
@@ -97,7 +97,7 @@ describe('selectors/getStackTimingByDepth', function () {
   it('can handle inverted stacks', function () {
     const store = storeWithProfile();
     store.dispatch(changeInvertCallstack(true));
-    const stackTimingByDepth = selectedThreadSelectors.getStackTimingByDepth(store.getState());
+    const stackTimingByDepth = selectedThreadSelectors.getStackTimingByDepthForFlameChart(store.getState());
     assert.deepEqual(stackTimingByDepth, [
       {
         start: [0, 10, 30, 40, 50, 60, 70, 80, 90],
@@ -130,23 +130,23 @@ describe('selectors/getStackTimingByDepth', function () {
   });
 });
 
-describe('selectors/getFuncStackMaxDepth', function () {
-  it('calculates the max func depth and observes of JS filters', function () {
+describe('selectors/getFuncStackMaxDepthForFlameChart', function () {
+  it('calculates the max func depth and observes of platform detail filters', function () {
     const store = storeWithProfile();
-    const allSamplesMaxDepth = selectedThreadSelectors.getFuncStackMaxDepth(store.getState());
+    const allSamplesMaxDepth = selectedThreadSelectors.getFuncStackMaxDepthForFlameChart(store.getState());
     assert.equal(allSamplesMaxDepth, 6);
-    store.dispatch(changeJSOnly(true));
-    const jsOnlySamplesMaxDepth = selectedThreadSelectors.getFuncStackMaxDepth(store.getState());
+    store.dispatch(changeHidePlatformDetails(true));
+    const jsOnlySamplesMaxDepth = selectedThreadSelectors.getFuncStackMaxDepthForFlameChart(store.getState());
     assert.equal(jsOnlySamplesMaxDepth, 4);
   });
 
   it('acts upon the current range', function () {
     const store = storeWithProfile();
     store.dispatch(addRangeFilter(0, 20));
-    const allSamplesMaxDepth = selectedThreadSelectors.getFuncStackMaxDepth(store.getState());
+    const allSamplesMaxDepth = selectedThreadSelectors.getFuncStackMaxDepthForFlameChart(store.getState());
     assert.equal(allSamplesMaxDepth, 2);
-    store.dispatch(changeJSOnly(true));
-    const jsOnlySamplesMaxDepth = selectedThreadSelectors.getFuncStackMaxDepth(store.getState());
+    store.dispatch(changeHidePlatformDetails(true));
+    const jsOnlySamplesMaxDepth = selectedThreadSelectors.getFuncStackMaxDepthForFlameChart(store.getState());
     assert.equal(jsOnlySamplesMaxDepth, 0);
   });
 });

--- a/src/content/components/FlameChartSettings.css
+++ b/src/content/components/FlameChartSettings.css
@@ -1,0 +1,44 @@
+.flameChartSettings {
+  height: 25px;
+  padding: 0;
+  line-height: 25px;
+  border-top: 1px solid #D6D6D6;
+  background: #F9F9F9;
+  display: flex;
+  flex-flow: row nowrap;
+}
+
+.flameChartSettingsList {
+  display: block;
+  flex: 1;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.flameChartSettingsListItem {
+  display: inline-block;
+  margin: 0 5px;
+  padding: 0;
+}
+
+.flameChartSettingsLabel {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
+  display: inline-flex;
+  flex-flow: row nowrap;
+  align-items: center;
+}
+
+.flameChartSettingsCheckbox {
+  margin: 0 5px;
+}
+
+.flameChartSettingsSearchbar {
+  padding: 0 10px;
+}
+
+.flameChartSettingsSearchField {
+  width: 250px;
+}

--- a/src/content/components/FlameChartSettings.js
+++ b/src/content/components/FlameChartSettings.js
@@ -1,0 +1,81 @@
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import * as actions from '../actions';
+import { getHidePlatformDetails, getInvertCallstack, getSearchString } from '../reducers/url-state';
+import IdleSearchField from '../components/IdleSearchField';
+
+import './FlameChartSettings.css';
+
+class FlameChartSettings extends Component {
+  constructor(props) {
+    super(props);
+    this._onHidePlatformDetailsClick = this._onHidePlatformDetailsClick.bind(this);
+    this._onInvertCallstackClick = this._onInvertCallstackClick.bind(this);
+    this._onSearchFieldIdleAfterChange = this._onSearchFieldIdleAfterChange.bind(this);
+  }
+
+  _onHidePlatformDetailsClick(e) {
+    this.props.changeHidePlatformDetails(e.target.checked);
+  }
+
+  _onInvertCallstackClick(e) {
+    this.props.changeInvertCallstack(e.target.checked);
+  }
+
+  _onSearchFieldIdleAfterChange(value) {
+    this.props.changeCallTreeSearchString(value);
+  }
+
+  render() {
+    const { hidePlatformDetails, invertCallstack, searchString } = this.props;
+    return (
+      <div className='flameChartSettings'>
+        <ul className='flameChartSettingsList'>
+          <li className='flameChartSettingsListItem'>
+            <label className='flameChartSettingsLabel'>
+              <input type='checkbox'
+                     className='flameChartSettingsCheckbox'
+                     onChange={this._onHidePlatformDetailsClick}
+                     checked={hidePlatformDetails}/>
+              { ' Hide platform details' }
+            </label>
+          </li>
+          <li className='flameChartSettingsListItem'>
+            <label className='flameChartSettingsLabel'>
+              <input type='checkbox'
+                     className='flameChartSettingsCheckbox'
+                     onChange={this._onInvertCallstackClick}
+                     checked={invertCallstack}/>
+              { ' Invert call stack' }
+            </label>
+          </li>
+        </ul>
+        <div className='flameChartSettingsSearchbar'>
+          <label className='flameChartSettingsSearchbarLabel'>
+            {'Filter stacks: '}
+            <IdleSearchField className='flameChartSettingsSearchField'
+                             title='Only display stacks which contain a function whose name matches this substring'
+                             idlePeriod={200}
+                             defaultValue={searchString}
+                             onIdleAfterChange={this._onSearchFieldIdleAfterChange}/>
+          </label>
+        </div>
+      </div>
+    );
+  }
+}
+
+FlameChartSettings.propTypes = {
+  hidePlatformDetails: PropTypes.bool.isRequired,
+  changeHidePlatformDetails: PropTypes.func.isRequired,
+  invertCallstack: PropTypes.bool.isRequired,
+  changeInvertCallstack: PropTypes.func.isRequired,
+  changeCallTreeSearchString: PropTypes.func.isRequired,
+  searchString: PropTypes.string.isRequired,
+};
+
+export default connect(state => ({
+  invertCallstack: getInvertCallstack(state),
+  hidePlatformDetails: getHidePlatformDetails(state),
+  searchString: getSearchString(state),
+}), actions)(FlameChartSettings);

--- a/src/content/containers/FlameChartView.js
+++ b/src/content/containers/FlameChartView.js
@@ -5,7 +5,7 @@ import FlameChartViewport from '../components/FlameChartViewport';
 import { selectedThreadSelectors, getDisplayRange, getProfileInterval } from '../reducers/profile-view';
 import { getSelectedThreadIndex } from '../reducers/url-state';
 import * as actions from '../actions';
-import ProfileCallTreeSettings from '../components/ProfileCallTreeSettings';
+import FlameChartSettings from '../components/FlameChartSettings';
 
 import type { Thread } from '../../common/types/profile';
 import type { Milliseconds } from '../../common/types/units';
@@ -39,7 +39,7 @@ class FlameChartView extends Component {
 
     return (
       <div className='flameChartView'>
-        <ProfileCallTreeSettings />
+        <FlameChartSettings />
         <FlameChartViewport thread={thread}
                             maxStackDepth={maxStackDepth}
                             stackTimingByDepth={stackTimingByDepth}
@@ -56,9 +56,9 @@ class FlameChartView extends Component {
 
 export default connect(state => {
   return {
-    thread: selectedThreadSelectors.getFilteredThread(state),
-    maxStackDepth: selectedThreadSelectors.getFuncStackMaxDepth(state),
-    stackTimingByDepth: selectedThreadSelectors.getStackTimingByDepth(state),
+    thread: selectedThreadSelectors.getFilteredThreadForFlameChart(state),
+    maxStackDepth: selectedThreadSelectors.getFuncStackMaxDepthForFlameChart(state),
+    stackTimingByDepth: selectedThreadSelectors.getStackTimingByDepthForFlameChart(state),
     isSelected: true,
     timeRange: getDisplayRange(state),
     threadIndex: getSelectedThreadIndex(state),

--- a/src/content/reducers/url-state.js
+++ b/src/content/reducers/url-state.js
@@ -113,6 +113,15 @@ function invertCallstack(state = false, action) {
   }
 }
 
+function hidePlatformDetails(state = false, action) {
+  switch (action.type) {
+    case 'CHANGE_HIDE_PLATFORM_DETAILS':
+      return action.hidePlatformDetails;
+    default:
+      return state;
+  }
+}
+
 const urlState = (regularUrlStateReducer => (state, action) => {
   switch (action.type) {
     case '@@urlenhancer/updateURLState':
@@ -123,6 +132,7 @@ const urlState = (regularUrlStateReducer => (state, action) => {
 })(combineReducers({
   dataSource, hash, selectedTab, rangeFilters, selectedThread,
   callTreeSearchString, callTreeFilters, jsOnly, invertCallstack,
+  hidePlatformDetails,
 }));
 
 export default urlState;
@@ -133,6 +143,7 @@ export const getDataSource = state => getURLState(state).dataSource;
 export const getHash = state => getURLState(state).hash;
 export const getRangeFilters = state => getURLState(state).rangeFilters;
 export const getJSOnly = state => getURLState(state).jsOnly;
+export const getHidePlatformDetails = state => getURLState(state).hidePlatformDetails;
 export const getInvertCallstack = state => getURLState(state).invertCallstack;
 export const getSearchString = state => getURLState(state).callTreeSearchString;
 export const getSelectedTab = state => getURLState(state).selectedTab;

--- a/src/content/url-handling.js
+++ b/src/content/url-handling.js
@@ -42,15 +42,26 @@ export function urlFromState(urlState) {
     ...dataSourceDirs(urlState),
     urlState.selectedTab,
   ].join('/') + '/';
-  const query = Object.assign({
+
+  // Start with the query parameters that are shown regardless of the active tab.
+  const query = {
     range: stringifyRangeFilters(urlState.rangeFilters) || undefined,
     thread: `${urlState.selectedThread}`,
-  }, urlState.selectedTab === 'calltree' ? {
-    search: urlState.callTreeSearchString || undefined,
-    invertCallstack: urlState.invertCallstack ? null : undefined,
-    jsOnly: urlState.jsOnly ? null : undefined,
-    callTreeFilters: stringifyCallTreeFilters(urlState.callTreeFilters[urlState.selectedThread]) || undefined,
-  } : {});
+  };
+
+  // Depending on which tab is active, also show tab-specific query parameters.
+  switch (urlState.selectedTab) {
+    case 'calltree':
+      query.search = urlState.callTreeSearchString || undefined;
+      query.invertCallstack = urlState.invertCallstack ? null : undefined;
+      query.jsOnly = urlState.jsOnly ? null : undefined;
+      query.callTreeFilters = stringifyCallTreeFilters(urlState.callTreeFilters[urlState.selectedThread]) || undefined;
+      break;
+    case 'flameChart':
+      query.invertCallstack = urlState.invertCallstack ? null : undefined;
+      query.hidePlatformDetails = urlState.hidePlatformDetails ? null : undefined;
+      break;
+  }
   const qString = queryString.stringify(query);
   return pathname + (qString ? '?' + qString : '');
 }
@@ -110,5 +121,6 @@ export function stateFromCurrentLocation() {
     },
     jsOnly: query.jsOnly !== undefined,
     invertCallstack: query.invertCallstack !== undefined,
+    hidePlatformDetails: query.hidePlatformDetails !== undefined,
   };
 }


### PR DESCRIPTION
, and make the flame chart use a separate selector chain that respects a 'hide platform details' setting.

There's a fair bit of code duplication here, but hopefully it's only temporary.