### PR TITLE
Add worker.js to the externals

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -97,7 +97,7 @@ if (process.env.NODE_ENV === 'production') {
         scope: '/',
         events: true,
       },
-      externals: ['/zee-worker.js'],
+      externals: ['/zee-worker.js', '/worker.js'],
       cacheMaps: [
         {
           requestTypes: null,


### PR DESCRIPTION
... so that the service worker doesn't try to return index.html for the URL `/worker.js`.

This wouldn't happen if we were using worker-loader, because webpack would know about the file and would add it to the appropriate list in the service worker. We should try to find out how we can use webpack in our testing infrastructure so that we can use the loaders again.