### PR TITLE
Add missing 'format' key in the bit.ly API request.

### DIFF
--- a/src/content/shorten-url.js
+++ b/src/content/shorten-url.js
@@ -17,6 +17,7 @@ export default function shortenURL(urlToShorten) {
     queryString.stringify({
       'longUrl': longURL,
       'domain': 'perfht.ml',
+      'format': 'json',
       'access_token': 'b177b00a130faf3ecda6960e8b59fde73e902422',
     });
   return fetchJsonP(bitlyQueryURL).then(response => response.json()).then(json => json.data.url);


### PR DESCRIPTION
Bit.ly have recently made a change on their side to ignore the jsonp callback argument
if format=json was not specified, and that made our requests fail.