### PR TITLE
Tweak filter navigator bar UI and labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "query-string": "^4.2.3",
     "raw-loader": "^0.5.1",
     "react": "^15.4.1",
+    "react-addons-css-transition-group": "^15.4.2",
     "react-addons-perf": "^15.4.1",
     "react-addons-shallow-compare": "^15.4.1",
     "react-dom": "^15.4.1",

--- a/src/content/components/FilterNavigatorBar.css
+++ b/src/content/components/FilterNavigatorBar.css
@@ -103,3 +103,32 @@
 .filterNavigatorBarItem:not(.filterNavigatorBarSelectedItem):not(.filterNavigatorBarLeafItem):active:hover::after {
   border-color: rgba(0, 0, 0, 0.2);
 }
+
+.filterNavigatorBarLeafItem::after {
+  border-left-color: #7990c8;
+}
+
+/* Animation */
+
+.filterNavigatorBarTransition-enter {
+  opacity: 0.1;
+  transform: translateX(-100%);
+  z-index:0;
+}
+
+.filterNavigatorBarTransition-enter.filterNavigatorBarTransition-enter-active {
+  opacity: 1;
+  transform: translateX(0);
+  transition: opacity 300ms ease-out, transform 300ms ease-out;
+}
+
+.filterNavigatorBarTransition-leave {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.filterNavigatorBarTransition-leave.filterNavigatorBarTransition-leave-active {
+  opacity: 0.01;
+  transform: translateX(100%);
+  transition: opacity 300ms, transform 300ms;
+}

--- a/src/content/components/FilterNavigatorBar.js
+++ b/src/content/components/FilterNavigatorBar.js
@@ -1,6 +1,6 @@
 import React, { PureComponent, PropTypes } from 'react';
 import classNames from 'classnames';
-
+import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import './FilterNavigatorBar.css';
 
 class FilterNavigatorBar extends PureComponent {
@@ -17,7 +17,11 @@ class FilterNavigatorBar extends PureComponent {
   render() {
     const { className, items, selectedItem } = this.props;
     return (
-      <ol className={classNames('filterNavigatorBar', className)}>
+      <ReactCSSTransitionGroup transitionName='filterNavigatorBarTransition'
+                               transitionEnterTimeout={300}
+                               transitionLeaveTimeout={300}
+                               component='ol'
+                               className={classNames('filterNavigatorBar', className)}>
         {
           items.map((item, i) => (
             <li key={i}
@@ -34,7 +38,7 @@ class FilterNavigatorBar extends PureComponent {
             </li>
           ))
         }
-      </ol>
+      </ReactCSSTransitionGroup>
     );
   }
 }

--- a/src/content/range-filters.js
+++ b/src/content/range-filters.js
@@ -20,10 +20,18 @@ export function stringifyRangeFilters(arrayValue = []) {
   }).join('~');
 }
 
+export function getFormattedTimeLength(length: number) {
+  if (length >= 10000) {
+    return `${(length / 1000).toFixed(0)} sec`;
+  }
+  if (length >= 1000) {
+    return `${(length / 1000).toFixed(1)} sec`;
+  }
+  return `${(length).toFixed(0)} ms`;
+}
+
 export function getRangeFilterLabels(rangeFilters) {
-  const labels = rangeFilters.map(range => {
-    return `Range: ${(range.start / 1000).toFixed(2)}s–${(range.end / 1000).toFixed(2)}s`;
-  });
-  labels.unshift('Complete Profile');
+  const labels = rangeFilters.map(range => getFormattedTimeLength(range.end - range.start));
+  labels.unshift('Full Range');
   return labels;
 }


### PR DESCRIPTION
From issue #201, I tweaked what we have in the UI to simplify it, and add an animation hint to what is going on with the component. I moved from time ranges to time length. I tried it out first just to reduce the amount of text, but find that I actually prefer having the length over start and end range. I think it would be a nice tweak to add the full time range length, but I need to fix the connect memoization issue first, as that piece of info is not in our `rangeFilters`.

Let me know how this feels @jasonLaster @mstange.

<img width="1194" alt="image" src="https://cloud.githubusercontent.com/assets/1588648/24074070/2b9fa584-0c02-11e7-9557-c3112126a0f1.png">
