### PR TITLE
Show the favicons in the call tree when possible. Fixes #18

### DIFF
--- a/res/default-favicon.svg
+++ b/res/default-favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <text style="font: italic 13px sans-serif" x="8" y="12.5" text-anchor="middle">h</text>
+  <circle cx="8" cy="8" r="7" stroke="black" fill="none"/>
+</svg>

--- a/res/style.css
+++ b/res/style.css
@@ -78,6 +78,13 @@ body, #root, .profileViewer {
   justify-content: flex-start;
 }
 
+.treeRowIcon {
+  display: block;
+  width: 12px;
+  height: 12px;
+  margin: auto 2px;
+}
+
 .treeViewHeaderColumn {
   position: absolute;
   box-sizing: border-box;

--- a/src/common/types/profile.js
+++ b/src/common/types/profile.js
@@ -86,7 +86,7 @@ export type ResourceTable = {
   length: number,
   lib: IndexIntoLibs[],
   name: IndexIntoStringTable[],
-  type: resourceTypeEnum,
+  type: resourceTypeEnum[],
 }
 
 export type Thread = {

--- a/src/content/components/NodeIcon.js
+++ b/src/content/components/NodeIcon.js
@@ -1,0 +1,54 @@
+import React, { PureComponent, PropTypes } from 'react';
+import DefaultFavicon from '../../../res/default-favicon.svg';
+
+const failedIcons = new Set();
+
+class NodeIcon extends PureComponent {
+  constructor(props) {
+    super(props);
+
+    this._onIconError = this._onIconError.bind(this);
+
+    this.state = {
+      icon: this._getIconForNode(props.node),
+    };
+  }
+
+  _updateState(props) {
+    this.setState({
+      icon: this._getIconForNode(props.node),
+    });
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.node !== this.props.node) {
+      this._updateState(nextProps);
+    }
+  }
+
+  _onIconError(failedUrl) {
+    failedIcons.add(failedUrl);
+    this._updateState(this.props);
+  }
+
+  _getIconForNode(node) {
+    if (!node.icon) {
+      return null;
+    }
+    return failedIcons.has(node.icon) ? DefaultFavicon : node.icon;
+  }
+
+  render() {
+    return this.state.icon && <img
+           src={this.state.icon}
+           referrerPolicy='no-referrer'
+           className='treeRowIcon'
+           onError={ e => this._onIconError(e.target.src) } />;
+  }
+}
+
+NodeIcon.propTypes = {
+  node: PropTypes.object.isRequired,
+};
+
+export default NodeIcon;

--- a/src/content/components/TreeView.js
+++ b/src/content/components/TreeView.js
@@ -3,6 +3,7 @@ import shallowCompare from 'react-addons-shallow-compare';
 import classNames from 'classnames';
 import VirtualList from './VirtualList';
 import { ContextMenuTrigger } from 'react-contextmenu';
+import NodeIcon from './NodeIcon';
 
 const TreeViewHeader = ({ fixedColumns, mainColumn }) => (
   <div className='treeViewHeader'>
@@ -131,6 +132,7 @@ class TreeViewRowScrolledColumns extends Component {
       <div className={`treeViewRow treeViewRowScrolledColumns ${evenOddClassName} ${selected ? 'selected' : ''} ${node.dim ? 'dim' : ''}`} style={{height: '16px'}} onMouseDown={this._onClick}>
         <span className='treeRowIndentSpacer' style={{ width: `${depth * 10}px` }}/>
         <span className={`treeRowToggleButton ${isExpanded ? 'expanded' : 'collapsed'} ${canBeExpanded ? 'canBeExpanded' : 'leaf'}`} />
+        <NodeIcon node={ node } />
         <span className={`treeViewRowColumn treeViewMainColumn ${mainColumn.propName}`}>
           {reactStringWithHighlightedSubstrings(node[mainColumn.propName], highlightString, 'treeViewHighlighting')}
         </span>

--- a/src/content/profile-tree.js
+++ b/src/content/profile-tree.js
@@ -19,10 +19,6 @@ type FuncStackChildren = IndexIntoFuncStackTable[];
 type FuncStackTimes = { selfTime: Milliseconds, totalTime: Milliseconds };
 
 function extractFaviconFromLibname(libname: string): string | null {
-  if (!libname.startsWith('http://') && !libname.startsWith('https://')) {
-    return null;
-  }
-
   const url = new URL('/favicon.ico', libname);
   return url.href;
 }
@@ -133,8 +129,7 @@ class ProfileTree {
         lib: libName,
         // Dim platform pseudo-stacks.
         dim: !isJS && this._jsOnly,
-        // http(s) resources should have "webhost" type but currently all URLs are of type "url". Let's be future proof.
-        icon: [resourceTypes.url, resourceTypes.webhost].includes(resourceType) ? extractFaviconFromLibname(libName) : null,
+        icon: resourceType === resourceTypes.webhost ? extractFaviconFromLibname(libName) : null,
       };
       this._nodes.set(funcStackIndex, node);
     }

--- a/src/content/profile-tree.js
+++ b/src/content/profile-tree.js
@@ -1,6 +1,6 @@
 // @flow
 import { timeCode } from '../common/time-code';
-import { getSampleFuncStacks } from './profile-data';
+import { getSampleFuncStacks, resourceTypes } from './profile-data';
 import type { Thread, FuncTable, ResourceTable, StringTable, IndexIntoFuncTable } from '../common/types/profile';
 import type { FuncStackTable, IndexIntoFuncStackTable, FuncStackInfo } from '../common/types/profile-derived';
 import type { Milliseconds } from '../common/types/units';
@@ -12,10 +12,21 @@ type Node = {
   name: string,
   lib: string,
   dim: boolean,
+  icon: string | null,
 };
 
 type FuncStackChildren = IndexIntoFuncStackTable[];
 type FuncStackTimes = { selfTime: Milliseconds, totalTime: Milliseconds };
+
+function extractFaviconFromLibname(libname: string): string | null {
+  if (!libname.startsWith('http://') && !libname.startsWith('https://')) {
+    return null;
+  }
+
+  const url = new URL('/favicon.ico', libname);
+  return url.href;
+}
+
 
 class ProfileTree {
 
@@ -109,16 +120,21 @@ class ProfileTree {
     if (node === undefined) {
       const funcIndex = this._funcStackTable.func[funcStackIndex];
       const funcName = this._stringTable.getString(this._funcTable.name[funcIndex]);
+      const resourceIndex = this._funcTable.resource[funcIndex];
+      const resourceType = this._resourceTable.type[resourceIndex];
       const isJS = this._funcTable.isJS[funcIndex];
+      const libName = this._getOriginAnnotation(funcIndex);
 
       node = {
         totalTime: `${this._funcStackTimes.totalTime[funcStackIndex].toFixed(1)}ms`,
         totalTimePercent: `${(100 * this._funcStackTimes.totalTime[funcStackIndex] / this._rootTotalTime).toFixed(1)}%`,
         selfTime: `${this._funcStackTimes.selfTime[funcStackIndex].toFixed(1)}ms`,
         name: funcName,
-        lib: this._getOriginAnnotation(funcIndex),
+        lib: libName,
         // Dim platform pseudo-stacks.
         dim: !isJS && this._jsOnly,
+        // http(s) resources should have "webhost" type but currently all URLs are of type "url". Let's be future proof.
+        icon: [resourceTypes.url, resourceTypes.webhost].includes(resourceType) ? extractFaviconFromLibname(libName) : null,
       };
       this._nodes.set(funcStackIndex, node);
     }


### PR DESCRIPTION
This is done by appending /favicon.ico to the library's hostname. So
it's not always accurate.