### PR TITLE
Properly handle the search string when moving through the browser his…

### DIFF
--- a/src/content/actions/types.js
+++ b/src/content/actions/types.js
@@ -76,7 +76,8 @@ type TimelineAction =
    { type: 'CHANGE_TIMELINE_EXPANDED_THREAD', threadIndex: ThreadIndex, isExpanded: boolean };
 
 type URLEnhancerAction =
-  { type: "@@urlenhancer/urlSetupDone" };
+  { type: "@@urlenhancer/urlSetupDone" } |
+  { type: '@@urlenhancer/updateURLState', urlState: any };
 
 type URLStateAction =
   { type: 'WAITING_FOR_PROFILE_FROM_FILE' } |

--- a/src/content/components/IdleSearchField.js
+++ b/src/content/components/IdleSearchField.js
@@ -20,6 +20,8 @@ class IdleSearchField extends Component {
   _timeout: number;
   _previouslyNotifiedValue: string;
 
+  props: Props;
+
   state: {
     value: string,
   };

--- a/src/content/components/IdleSearchField.js
+++ b/src/content/components/IdleSearchField.js
@@ -1,10 +1,30 @@
+// @flow
 import React, { Component, PropTypes } from 'react';
 import classNames from 'classnames';
 
 import './IdleSearchField.css';
 
+type Props = {
+  onIdleAfterChange: (string) => void,
+  idlePeriod: number,
+  defaultValue: ?string,
+  className: ?string,
+  title: ?string,
+};
+
 class IdleSearchField extends Component {
-  constructor(props) {
+  _onSearchFieldChange: Event => void;
+  _onSearchFieldFocus: Event => void;
+  _onClearButtonClick: Event => void;
+  _onTimeout: void => void;
+  _timeout: number;
+  _previouslyNotifiedValue: string;
+
+  state: {
+    value: string,
+  };
+
+  constructor(props: Props) {
     super(props);
     this._onSearchFieldChange = this._onSearchFieldChange.bind(this);
     this._onSearchFieldFocus = this._onSearchFieldFocus.bind(this);
@@ -17,13 +37,13 @@ class IdleSearchField extends Component {
     this._previouslyNotifiedValue = this.state.value;
   }
 
-  _onSearchFieldFocus(e) {
-    e.target.select();
+  _onSearchFieldFocus(e: Event & { currentTarget: HTMLInputElement }) {
+    e.currentTarget.select();
   }
 
-  _onSearchFieldChange(e) {
+  _onSearchFieldChange(e: Event & { currentTarget: HTMLInputElement }) {
     this.setState({
-      value: e.target.value,
+      value: e.currentTarget.value,
     });
 
     if (this._timeout) {
@@ -37,7 +57,7 @@ class IdleSearchField extends Component {
     this._notifyIfChanged(this.state.value);
   }
 
-  _notifyIfChanged(value) {
+  _notifyIfChanged(value: string) {
     if (value !== this._previouslyNotifiedValue) {
       this._previouslyNotifiedValue = value;
       this.props.onIdleAfterChange(value);
@@ -49,16 +69,16 @@ class IdleSearchField extends Component {
     this._notifyIfChanged('');
   }
 
-  _onClearButtonFocus(e) {
+  _onClearButtonFocus(e: Event & { relatedTarget: HTMLElement; currentTarget: HTMLElement }) {
     // prevent the focus on the clear button
     if (e.relatedTarget) {
       e.relatedTarget.focus();
     } else {
-      e.target.blur();
+      e.currentTarget.blur();
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentWillReceiveProps(nextProps: Props) {
     if (nextProps.defaultValue !== this.props.defaultValue) {
       this._notifyIfChanged(nextProps.defaultValue || '');
       this.setState({
@@ -78,7 +98,7 @@ class IdleSearchField extends Component {
                value={this.state.value}
                onChange={this._onSearchFieldChange}
                onFocus={this._onSearchFieldFocus}/>
-        <input type='button'
+        <input type='reset'
                className='idleSearchFieldButton'
                onClick={this._onClearButtonClick}
                onFocus={this._onClearButtonFocus}/>

--- a/src/content/containers/URLManager.js
+++ b/src/content/containers/URLManager.js
@@ -1,8 +1,25 @@
+// @flow
+
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { getIsURLSetupDone } from '../reducers/app';
 
+import type { Dispatch } from '../actions/types.js';
+
+type Props = {
+  stateFromCurrentLocation: void => any,
+  urlFromState: any => string,
+  children: any,
+  urlState: any,
+  isURLSetupDone: boolean,
+  updateURLState: string => void,
+  urlSetupDone: void => void,
+  show404: string => void,
+};
+
 class URLManager extends Component {
+  props: Props;
+
   _updateState() {
     const { updateURLState, stateFromCurrentLocation, show404 } = this.props;
     if (window.history.state) {
@@ -25,7 +42,7 @@ class URLManager extends Component {
     urlSetupDone();
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentWillReceiveProps(nextProps: Props) {
     const { urlFromState, isURLSetupDone } = this.props;
     const newURL = urlFromState(nextProps.urlState);
     if (newURL !== window.location.pathname + window.location.search) {
@@ -57,7 +74,7 @@ URLManager.propTypes = {
 export default connect(state => ({
   urlState: state.urlState,
   isURLSetupDone: getIsURLSetupDone(state),
-}), dispatch => ({
+}), (dispatch: Dispatch) => ({
   updateURLState: urlState => dispatch({ type: '@@urlenhancer/updateURLState', urlState }),
   urlSetupDone: () => dispatch({ type: '@@urlenhancer/urlSetupDone' }),
   show404: url => dispatch({ type: 'FILE_NOT_FOUND', url }),

--- a/src/content/containers/URLManager.js
+++ b/src/content/containers/URLManager.js
@@ -3,8 +3,8 @@ import { connect } from 'react-redux';
 import { getIsURLSetupDone } from '../reducers/app';
 
 class URLManager extends Component {
-  componentDidMount() {
-    const { updateURLState, urlSetupDone, stateFromCurrentLocation, show404 } = this.props;
+  _updateState() {
+    const { updateURLState, stateFromCurrentLocation, show404 } = this.props;
     if (window.history.state) {
       updateURLState(window.history.state);
     } else {
@@ -16,9 +16,12 @@ class URLManager extends Component {
         show404(window.location.pathname + window.location.search);
       }
     }
-    window.onpopstate = e => {
-      updateURLState(e.state);
-    };
+  }
+  componentDidMount() {
+    const { urlSetupDone } = this.props;
+
+    this._updateState();
+    window.onpopstate = () => this._updateState();
     urlSetupDone();
   }
 

--- a/src/content/url-handling.js
+++ b/src/content/url-handling.js
@@ -57,7 +57,8 @@ export function urlFromState(urlState) {
       query.jsOnly = urlState.jsOnly ? null : undefined;
       query.callTreeFilters = stringifyCallTreeFilters(urlState.callTreeFilters[urlState.selectedThread]) || undefined;
       break;
-    case 'flameChart':
+    case 'timeline':
+      query.search = urlState.callTreeSearchString || undefined;
       query.invertCallstack = urlState.invertCallstack ? null : undefined;
       query.hidePlatformDetails = urlState.hidePlatformDetails ? null : undefined;
       break;


### PR DESCRIPTION
…tory (Fixes #236)

* Rewrote part of the IdleSearchField component, making the <input>
a React-controlled component.
* Fix the URL handling for the flame chart

Behavior changes:
* We select the search input on Focus event instead of Click event, so
that when clicking on a focused search input the user can put the cursor
at a specific position.
* Clicking the "clear" button will only focus the search input if it was
previously focused.