### PR TITLE
Tweak the UX for the header graphs

### DIFF
--- a/res/style.css
+++ b/res/style.css
@@ -330,6 +330,14 @@ body, #root, .profileViewer {
   height: 6px;
   position: relative;
   overflow: hidden;
+  opacity: 0.75;
+  background-color: transparent;
+  transition: background-color 500ms;
+}
+
+.profileViewerHeaderIntervalMarkerOverview.selected {
+  opacity: 1;
+  background-color: #e4eaf6;
 }
 
 .profileViewerHeaderIntervalMarkerOverviewThreadGeckoMain {
@@ -353,7 +361,7 @@ body, #root, .profileViewer {
 .profileThreadHeaderBar {
   margin: 0;
   padding: 0;
-  height: 40px;
+  height: 30px;
   display: flex;
   flex-flow: row nowrap;
   border-top: 1px solid #D6D6D6;
@@ -370,7 +378,7 @@ body, #root, .profileViewer {
   font-weight: normal;
   font: message-box;
   font-size: 100%;
-  line-height: 40px;
+  line-height: 30px;
   border-right: 1px solid #D6D6D6;
   margin: 0;
   margin-left: 14px;
@@ -384,14 +392,14 @@ body, #root, .profileViewer {
 }
 
 .threadStackGraph {
-  height: 40px;
+  height: 30px;
   width: calc(100% - 150px);
   position: relative;
 }
 
 .threadStackGraphCanvas {
   display: block;
-  height: 40px;
+  height: 30px;
   width: 100%;
 }
 

--- a/src/content/call-tree-filters.js
+++ b/src/content/call-tree-filters.js
@@ -52,7 +52,7 @@ export function stringifyCallTreeFilters(arrayValue = []) {
   }).join('~');
 }
 
-export function getCallTreeFilterLabels(thread, callTreeFilters) {
+export function getCallTreeFilterLabels(thread, threadName, callTreeFilters) {
   const { funcTable, stringTable } = thread;
   const labels = callTreeFilters.map(filter => {
     function lastFuncString(funcArray) {
@@ -69,6 +69,6 @@ export function getCallTreeFilterLabels(thread, callTreeFilters) {
         throw new Error('Unexpected filter type');
     }
   });
-  labels.unshift('Complete Thread');
+  labels.unshift(`Complete "${threadName}"`);
   return labels;
 }

--- a/src/content/components/IntervalMarkerOverview.js
+++ b/src/content/components/IntervalMarkerOverview.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { Component, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
 import shallowCompare from 'react-addons-shallow-compare';
 import classNames from 'classnames';
 import { timeCode } from '../../common/time-code';
@@ -19,13 +19,14 @@ type Props = {
   threadName: string,
   onSelect: any,
   styles: any,
+  isSelected: boolean,
   overlayFills: {
     HOVERED: string,
     PRESSED: string,
   },
 };
 
-class IntervalMarkerOverview extends Component {
+class IntervalMarkerOverview extends PureComponent {
 
   props: Props
 
@@ -142,12 +143,14 @@ class IntervalMarkerOverview extends Component {
 
   render() {
     this._scheduleDraw();
-    const { className } = this.props;
+    const { className, isSelected } = this.props;
     const { mouseDownItem, hoveredItem } = this.state;
     const title = !mouseDownItem && hoveredItem ? hoveredItem.title : null;
+    const canvasClassName = className.split(' ').map(name => `${name}Canvas`).join(' ');
+
     return (
-      <div className={className}>
-        <canvas className={classNames(`${className}Canvas`, 'intervalMarkerTimelineCanvas')}
+      <div className={classNames(className, isSelected ? 'selected' : null)}>
+        <canvas className={classNames(canvasClassName, 'intervalMarkerTimelineCanvas')}
                 ref={this._takeCanvasRef}
                 onMouseDown={this._onMouseDown}
                 onMouseMove={this._onMouseMove}
@@ -236,26 +239,5 @@ class IntervalMarkerOverview extends Component {
   }
 
 }
-
-IntervalMarkerOverview.propTypes = {
-  className: PropTypes.string.isRequired,
-  rangeStart: PropTypes.number.isRequired,
-  rangeEnd: PropTypes.number.isRequired,
-  intervalMarkers: PropTypes.arrayOf(PropTypes.shape({
-    start: PropTypes.number.isRequired,
-    dur: PropTypes.number.isRequired,
-    title: PropTypes.string.isRequired,
-    name: PropTypes.string,
-  })).isRequired,
-  width: PropTypes.number.isRequired, // provided by withSize
-  threadIndex: PropTypes.number.isRequired,
-  threadName: PropTypes.string.isRequired,
-  onSelect: PropTypes.func.isRequired,
-  styles: PropTypes.object.isRequired,
-  overlayFills: PropTypes.shape({
-    HOVERED: PropTypes.string.isRequired,
-    PRESSED: PropTypes.string.isRequired,
-  }).isRequired,
-};
 
 export default withSize(IntervalMarkerOverview);

--- a/src/content/components/ProfileThreadHeaderBar.js
+++ b/src/content/components/ProfileThreadHeaderBar.js
@@ -39,30 +39,16 @@ class ProfileThreadHeaderBar extends Component {
   _onMarkerSelect(/* markerIndex */) {
   }
 
-  getThreadTooltip(): string {
-    // The tid and pid weren't always included, so they are optional for displaying.
-    const { thread } = this.props;
-    let tooltip = '';
-    if (thread.pid !== undefined) {
-      tooltip = `pid: ${thread.pid}`;
-    }
-    if (thread.tid !== undefined) {
-      if (thread.pid !== undefined) {
-        tooltip += ', ';
-      }
-      tooltip += `tid: ${thread.tid}`;
-    }
-    return tooltip;
-  }
-
   render() {
-    const { thread, interval, rangeStart, rangeEnd, funcStackInfo, selectedFuncStack, isSelected, style } = this.props;
-    const label = thread.processType ? `${thread.name} [${thread.processType}]` : thread.name;
+    const {
+      thread, interval, rangeStart, rangeEnd, funcStackInfo, selectedFuncStack,
+      isSelected, style, threadName, processDetails,
+    } = this.props;
 
     return (
       <li className={'profileThreadHeaderBar' + (isSelected ? ' selected' : '')} style={style}>
-        <h1 onMouseDown={this._onLabelMouseDown} className='grippy' title={this.getThreadTooltip()}>
-          {label}
+        <h1 onMouseDown={this._onLabelMouseDown} className='grippy' title={processDetails}>
+          {threadName}
         </h1>
         <ThreadStackGraph interval={interval}
                           thread={thread}
@@ -91,6 +77,8 @@ ProfileThreadHeaderBar.propTypes = {
   selectedFuncStack: PropTypes.number.isRequired,
   isSelected: PropTypes.bool.isRequired,
   style: PropTypes.object,
+  threadName: PropTypes.string,
+  processDetails: PropTypes.string,
 };
 
 export default connect((state, props) => {
@@ -99,6 +87,8 @@ export default connect((state, props) => {
   const selectedThread = getSelectedThreadIndex(state);
   return {
     thread: selectors.getFilteredThread(state),
+    threadName: selectors.getFriendlyThreadName(state),
+    processDetails: selectors.getThreadProcessDetails(state),
     funcStackInfo: selectors.getFuncStackInfo(state),
     selectedFuncStack: threadIndex === selectedThread ? selectors.getSelectedFuncStack(state) : -1,
     isSelected: threadIndex === selectedThread,

--- a/src/content/containers/ProfileThreadJankOverview.js
+++ b/src/content/containers/ProfileThreadJankOverview.js
@@ -2,13 +2,16 @@ import { connect } from 'react-redux';
 import IntervalMarkerOverview from '../components/IntervalMarkerOverview';
 import { selectorsForThread } from '../reducers/profile-view';
 import { styles, overlayFills } from '../interval-marker-styles';
+import { getSelectedThreadIndex } from '../reducers/url-state';
 
 export default connect((state, props) => {
   const { threadIndex } = props;
   const selectors = selectorsForThread(threadIndex);
   const threadName = selectors.getThread(state).name;
+  const selectedThread = getSelectedThreadIndex(state);
   return {
     intervalMarkers: selectors.getJankInstances(state),
+    isSelected: threadIndex === selectedThread,
     threadName,
     styles,
     overlayFills,

--- a/src/content/containers/ProfileThreadTracingMarkerOverview.js
+++ b/src/content/containers/ProfileThreadTracingMarkerOverview.js
@@ -2,13 +2,16 @@ import { connect } from 'react-redux';
 import IntervalMarkerOverview from '../components/IntervalMarkerOverview';
 import { selectorsForThread } from '../reducers/profile-view';
 import { styles, overlayFills } from '../interval-marker-styles';
+import { getSelectedThreadIndex } from '../reducers/url-state';
 
 export default connect((state, props) => {
   const { threadIndex } = props;
   const selectors = selectorsForThread(threadIndex);
+  const selectedThread = getSelectedThreadIndex(state);
   return {
     intervalMarkers: selectors.getRangeSelectionFilteredTracingMarkers(state),
     threadName: selectors.getThread(state).name,
+    isSelected: threadIndex === selectedThread,
     styles,
     overlayFills,
   };

--- a/src/content/containers/TimelineFlameChart.js
+++ b/src/content/containers/TimelineFlameChart.js
@@ -38,6 +38,8 @@ type Props = {
   horizontalViewport: HorizontalViewport,
   viewHeight: CssPixels,
   selection: ProfileSelection,
+  threadName: string,
+  processDetails: string,
 };
 
 class TimelineFlameChart extends Component {
@@ -86,13 +88,12 @@ class TimelineFlameChart extends Component {
     const {
       thread, isThreadExpanded, maxStackDepth, stackTimingByDepth, isSelected, timeRange,
       threadIndex, interval, getCategory, getLabel, horizontalViewport,
-      updateProfileSelection, selection,
+      updateProfileSelection, selection, threadName, processDetails,
     } = this.props;
 
     // The viewport needs to know about the height of what it's drawing, calculate
     // that here at the top level component.
     const maxViewportHeight = maxStackDepth * STACK_FRAME_HEIGHT;
-    const title = thread.processType ? `${thread.name} [${thread.processType}]` : thread.name;
     const height = this.getViewHeight(maxViewportHeight);
     const buttonClass = classNames('timelineFlameChartCollapseButton', {
       expanded: isThreadExpanded,
@@ -101,8 +102,8 @@ class TimelineFlameChart extends Component {
 
     return (
       <div className='timelineFlameChart' style={{ height }}>
-        <div className='timelineFlameChartLabels grippy'>
-          <span>{title}</span>
+        <div className='timelineFlameChartLabels grippy' title={processDetails}>
+          <span>{threadName}</span>
           <button className={buttonClass} onClick={this.toggleThreadCollapse} />
         </div>
         <FlameChartViewport key={threadIndex}
@@ -147,5 +148,7 @@ export default connect((state, ownProps) => {
     getLabel: isThreadExpanded ? getLabelingStrategy(state) : getImplementationName,
     threadIndex,
     selection: getProfileViewOptions(state).selection,
+    threadName: threadSelectors.getFriendlyThreadName(state),
+    processDetails: threadSelectors.getThreadProcessDetails(state),
   };
 }, (actions: Object))(TimelineFlameChart);

--- a/src/content/profile-data.js
+++ b/src/content/profile-data.js
@@ -744,3 +744,52 @@ export function filterTracingMarkersToRange(tracingMarkers: TracingMarker[],
                                             rangeEnd: number): TracingMarker[] {
   return tracingMarkers.filter(tm => tm.start < rangeEnd && tm.start + tm.dur >= rangeStart);
 }
+
+export function getFriendlyThreadName(threads: Thread[], thread: Thread): string {
+  let label;
+  switch (thread.name) {
+    case 'GeckoMain':
+      switch (thread.processType) {
+        case 'default':
+          label = 'Main Thread';
+          break;
+        case 'tab': {
+          const contentThreads = threads.filter(thread => {
+            return thread.name === 'GeckoMain' && thread.processType === 'tab';
+          });
+          if (contentThreads.length > 1) {
+            const index = 1 + contentThreads.indexOf(thread);
+            label = `Content (${index} of ${contentThreads.length})`;
+          } else {
+            label = 'Content';
+          }
+          break;
+        }
+        case 'plugin':
+          label = 'Plugin';
+          break;
+      }
+      break;
+  }
+
+  if (!label) {
+    label = thread.name;
+  }
+  return label;
+}
+
+export function getThreadProcessDetails(thread: Thread): string {
+  let label = `thread: "${thread.name}"`;
+  if (thread.tid !== undefined) {
+    label += ` (${thread.tid})`;
+  }
+
+  if (thread.processType) {
+    label += `\nprocess: "${thread.processType}"`;
+    if (thread.pid !== undefined) {
+      label += ` (${thread.pid})`;
+    }
+  }
+
+  return label;
+}

--- a/src/content/reducers/profile-view.js
+++ b/src/content/reducers/profile-view.js
@@ -321,6 +321,8 @@ export const getProfileTaskTracerData = (state: State): TaskTracer => getProfile
 
 export type SelectorsForThread = {
   getThread: State => Thread,
+  getFriendlyThreadName: State => string,
+  getThreadProcessDetails: State => string,
   getViewOptions: State => ThreadViewOptions,
   getCallTreeFilters: State => CallTreeFilter[],
   getCallTreeFilterLabels: State => string[],
@@ -348,8 +350,18 @@ export const selectorsForThread = (threadIndex: ThreadIndex): SelectorsForThread
     const getThread = (state: State): Thread => getProfile(state).threads[threadIndex];
     const getViewOptions = (state: State): ThreadViewOptions => getProfileViewOptions(state).perThread[threadIndex];
     const getCallTreeFilters = (state: State): CallTreeFilter[] => URLState.getCallTreeFilters(state, threadIndex);
+    const getFriendlyThreadName = createSelector(
+      getThreads,
+      getThread,
+      ProfileData.getFriendlyThreadName
+    );
+    const getThreadProcessDetails = createSelector(
+      getThread,
+      ProfileData.getThreadProcessDetails
+    );
     const getCallTreeFilterLabels: (state: State) => string[] = createSelector(
       getThread,
+      getFriendlyThreadName,
       getCallTreeFilters,
       CallTreeFilters.getCallTreeFilterLabels
     );
@@ -542,6 +554,8 @@ export const selectorsForThread = (threadIndex: ThreadIndex): SelectorsForThread
       getFuncStackMaxDepthForFlameChart,
       getStackTimingByDepthForFlameChart,
       getLeafCategoryStackTimingForFlameChart,
+      getFriendlyThreadName,
+      getThreadProcessDetails,
     };
   }
   return selectorsForThreads[threadIndex];


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1588648/24976139/e63d6c3e-1f8d-11e7-9110-3b38b528ddfc.png)

I was chatting with @hotsphink about markers, and he was relating some UX challenges when using perf.html. This patch addresses those issues, along with a few things that were bugging me.

 * Come up with plain text phrases for the thread names, since `GeckoMain` and `default`, `tab`, and `plugin` for thread names is not very user-friendly.
 * Remove process from the thread name.
 * Add all relevant process and thread information to a tooltip.
 * Highlight the selected thread in the marker overview area.
 * Put the name of the thread in the call tree selection.

![image](https://cloud.githubusercontent.com/assets/1588648/24976273/6bacff24-1f8e-11e7-8c3b-47ea50722779.png)
