### PR TITLE
Filter call tree by implementation - Resolves #238

### DIFF
--- a/src/content/actions/profile-view.js
+++ b/src/content/actions/profile-view.js
@@ -1,5 +1,7 @@
 // @flow
-import type { Action, ThunkAction, ProfileSelection, CallTreeFilter } from './types';
+import type {
+  Action, ThunkAction, ProfileSelection, CallTreeFilter, ImplementationFilter,
+} from './types';
 import type { ThreadIndex, IndexIntoFuncTable, IndexIntoMarkersTable } from '../../common/types/profile';
 
 /**
@@ -58,10 +60,10 @@ export function changeSelectedMarker(
   };
 }
 
-export function changeJSOnly(jsOnly: boolean): Action {
+export function changeImplementationFilter(implementation: ImplementationFilter): Action {
   return {
-    type: 'CHANGE_JS_ONLY',
-    jsOnly,
+    type: 'CHANGE_IMPLEMENTATION_FILTER',
+    implementation,
   };
 }
 

--- a/src/content/actions/test/actions.js
+++ b/src/content/actions/test/actions.js
@@ -227,7 +227,7 @@ describe('actions/changeImplementationFilter', function () {
 
   it('is initially set to filter to all', function () {
     const filter = UrlStateSelectors.getImplementationFilter(store.getState());
-    assert.equal(filter, 'all');
+    assert.equal(filter, 'combined');
   });
 
   it('can be changed to cpp', function () {

--- a/src/content/actions/test/actions.js
+++ b/src/content/actions/test/actions.js
@@ -2,17 +2,20 @@ import { assert } from 'chai';
 import { blankStore, storeWithProfile } from './fixtures/stores';
 import * as ProfileViewSelectors from '../../reducers/profile-view';
 import * as TimelineSelectors from '../../reducers/timeline-view';
+import * as UrlStateSelectors from '../../reducers/url-state';
 import {
   changeCallTreeSearchString,
   changeHidePlatformDetails,
   addRangeFilter,
   changeInvertCallstack,
   updateProfileSelection,
+  changeImplementationFilter,
 } from '../profile-view';
 import {
   changeFlameChartColorStrategy,
   changeTimelineExpandedThread,
 } from '../timeline';
+
 import { receiveProfileFromAddon } from '../receive-profile';
 import { getCategoryByImplementation } from '../../color-categories';
 const { selectedThreadSelectors } = ProfileViewSelectors;
@@ -216,6 +219,21 @@ describe('actions/changeTimelineExpandedThread', function () {
 
     store.dispatch(changeTimelineExpandedThread(2, false));
     assert.deepEqual(threads.map(isExpanded), [false, false, false]);
+  });
+});
+
+describe('actions/changeImplementationFilter', function () {
+  const store = storeWithProfile();
+
+  it('is initially set to filter to all', function () {
+    const filter = UrlStateSelectors.getImplementationFilter(store.getState());
+    assert.equal(filter, 'all');
+  });
+
+  it('can be changed to cpp', function () {
+    store.dispatch(changeImplementationFilter('cpp'));
+    const filter = UrlStateSelectors.getImplementationFilter(store.getState());
+    assert.equal(filter, 'cpp');
   });
 });
 

--- a/src/content/actions/types.js
+++ b/src/content/actions/types.js
@@ -35,6 +35,7 @@ export type FunctionsUpdatePerThread = { [id: ThreadIndex]: {
 }}
 
 export type RequestedLib = { debugName: string, breakpadId: string };
+export type ImplementationFilter = 'all' | 'js' | 'cpp';
 
 type ProfileSummaryAction =
   { type: "PROFILE_SUMMARY_PROCESSED", summary: Summary } |
@@ -89,7 +90,7 @@ type URLStateAction =
   { type: 'CHANGE_CALL_TREE_SEARCH_STRING', searchString: string } |
   { type: 'ADD_CALL_TREE_FILTER', threadIndex: ThreadIndex, filter: CallTreeFilter } |
   { type: 'POP_CALL_TREE_FILTERS', threadIndex: ThreadIndex, firstRemovedFilterIndex: number } |
-  { type: 'CHANGE_JS_ONLY', jsOnly: boolean } |
+  { type: 'CHANGE_IMPLEMENTATION_FILTER', implementation: ImplementationFilter } |
   { type: 'CHANGE_INVERT_CALLSTACK', invertCallstack: boolean } |
   { type: 'CHANGE_HIDE_PLATFORM_DETAILS', hidePlatformDetails: boolean };
 

--- a/src/content/actions/types.js
+++ b/src/content/actions/types.js
@@ -35,7 +35,7 @@ export type FunctionsUpdatePerThread = { [id: ThreadIndex]: {
 }}
 
 export type RequestedLib = { debugName: string, breakpadId: string };
-export type ImplementationFilter = 'all' | 'js' | 'cpp';
+export type ImplementationFilter = 'combined' | 'js' | 'cpp';
 
 type ProfileSummaryAction =
   { type: "PROFILE_SUMMARY_PROCESSED", summary: Summary } |

--- a/src/content/components/ProfileCallTreeSettings.css
+++ b/src/content/components/ProfileCallTreeSettings.css
@@ -14,10 +14,11 @@
   list-style: none;
   margin: 0;
   padding: 0;
+  display: flex;
+  align-items: flex-start;
 }
 
 .profileCallTreeSettingsListItem {
-  display: inline-block;
   margin: 0 5px;
   padding: 0;
 }
@@ -29,6 +30,12 @@
   display: inline-flex;
   flex-flow: row nowrap;
   align-items: center;
+  height: 25px;
+}
+
+.profileCallTreeSettingsSelect {
+  margin: 0 5px;
+  font-size: 11px;
 }
 
 .profileCallTreeSettingsCheckbox {

--- a/src/content/components/ProfileCallTreeSettings.js
+++ b/src/content/components/ProfileCallTreeSettings.js
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import actions from '../actions';
-import { getJSOnly, getInvertCallstack, getSearchString } from '../reducers/url-state';
+import { getImplementationFilter, getInvertCallstack, getSearchString } from '../reducers/url-state';
 import IdleSearchField from '../components/IdleSearchField';
 
 import './ProfileCallTreeSettings.css';
@@ -15,7 +15,7 @@ class ProfileCallTreeSettings extends Component {
   }
 
   _onJSOnlyClick(e) {
-    this.props.changeJSOnly(e.target.checked);
+    this.props.changeImplementationFilter(e.target.checked ? 'js' : 'all');
   }
 
   _onInvertCallstackClick(e) {
@@ -27,7 +27,7 @@ class ProfileCallTreeSettings extends Component {
   }
 
   render() {
-    const { jsOnly, invertCallstack, searchString } = this.props;
+    const { implementationFilter, invertCallstack, searchString } = this.props;
     return (
       <div className='profileCallTreeSettings'>
         <ul className='profileCallTreeSettingsList'>
@@ -36,7 +36,7 @@ class ProfileCallTreeSettings extends Component {
               <input type='checkbox'
                      className='profileCallTreeSettingsCheckbox'
                      onChange={this._onJSOnlyClick}
-                     checked={jsOnly}/>
+                     checked={implementationFilter === 'js'}/>
               { ' JavaScript only' }
             </label>
           </li>
@@ -66,8 +66,8 @@ class ProfileCallTreeSettings extends Component {
 }
 
 ProfileCallTreeSettings.propTypes = {
-  jsOnly: PropTypes.bool.isRequired,
-  changeJSOnly: PropTypes.func.isRequired,
+  implementationFilter: PropTypes.string.isRequired,
+  changeImplementationFilter: PropTypes.func.isRequired,
   invertCallstack: PropTypes.bool.isRequired,
   changeInvertCallstack: PropTypes.func.isRequired,
   changeCallTreeSearchString: PropTypes.func.isRequired,
@@ -76,6 +76,6 @@ ProfileCallTreeSettings.propTypes = {
 
 export default connect(state => ({
   invertCallstack: getInvertCallstack(state),
-  jsOnly: getJSOnly(state),
+  implementationFilter: getImplementationFilter(state),
   searchString: getSearchString(state),
 }), actions)(ProfileCallTreeSettings);

--- a/src/content/components/ProfileCallTreeSettings.js
+++ b/src/content/components/ProfileCallTreeSettings.js
@@ -35,12 +35,12 @@ class ProfileCallTreeSettings extends Component {
             <label className='profileCallTreeSettingsLabel'>
               Filter:
               <select
-                     className='profileCallTreeSettingsCheckbox'
+                     className='profileCallTreeSettingsSelect'
                      onChange={this._onImplementationFilterChange}
                      value={implementationFilter}>
-                <option value='all'>All samples</option>
-                <option value='js'>JS Only</option>
-                <option value='cpp'>C++ Only</option>
+                <option value='combined'>Combined stacks</option>
+                <option value='js'>JS only</option>
+                <option value='cpp'>C++ only</option>
               </select>
             </label>
           </li>

--- a/src/content/components/ProfileCallTreeSettings.js
+++ b/src/content/components/ProfileCallTreeSettings.js
@@ -9,13 +9,13 @@ import './ProfileCallTreeSettings.css';
 class ProfileCallTreeSettings extends Component {
   constructor(props) {
     super(props);
-    this._onJSOnlyClick = this._onJSOnlyClick.bind(this);
+    this._onImplementationFilterChange = this._onImplementationFilterChange.bind(this);
     this._onInvertCallstackClick = this._onInvertCallstackClick.bind(this);
     this._onSearchFieldIdleAfterChange = this._onSearchFieldIdleAfterChange.bind(this);
   }
 
-  _onJSOnlyClick(e) {
-    this.props.changeImplementationFilter(e.target.checked ? 'js' : 'all');
+  _onImplementationFilterChange(e) {
+    this.props.changeImplementationFilter(e.target.value);
   }
 
   _onInvertCallstackClick(e) {
@@ -33,11 +33,15 @@ class ProfileCallTreeSettings extends Component {
         <ul className='profileCallTreeSettingsList'>
           <li className='profileCallTreeSettingsListItem'>
             <label className='profileCallTreeSettingsLabel'>
-              <input type='checkbox'
+              Filter:
+              <select
                      className='profileCallTreeSettingsCheckbox'
-                     onChange={this._onJSOnlyClick}
-                     checked={implementationFilter === 'js'}/>
-              { ' JavaScript only' }
+                     onChange={this._onImplementationFilterChange}
+                     value={implementationFilter}>
+                <option value='all'>All samples</option>
+                <option value='js'>JS Only</option>
+                <option value='cpp'>C++ Only</option>
+              </select>
             </label>
           </li>
           <li className='profileCallTreeSettingsListItem'>

--- a/src/content/components/ProfileTreeView.js
+++ b/src/content/components/ProfileTreeView.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import TreeView from './TreeView';
 import NodeIcon from './NodeIcon';
 import { getStackAsFuncArray } from '../profile-data';
-import { getInvertCallstack, getJSOnly, getSearchString, getSelectedThreadIndex } from '../reducers/url-state';
+import { getInvertCallstack, getImplementationFilter, getSearchString, getSelectedThreadIndex } from '../reducers/url-state';
 import {
   getProfile, selectedThreadSelectors, getScrollToSelectionGeneration, getProfileViewOptions,
 } from '../reducers/profile-view';
@@ -62,7 +62,11 @@ class ProfileTreeView extends Component {
   }
 
   _onAppendageButtonClick(funcStackIndex) {
-    const { funcStackInfo, threadIndex, addCallTreeFilter, jsOnly, invertCallstack } = this.props;
+    const {
+      funcStackInfo, threadIndex, addCallTreeFilter, implementationFilter,
+      invertCallstack,
+    } = this.props;
+    const jsOnly = implementationFilter === 'js';
     if (invertCallstack) {
       addCallTreeFilter(threadIndex, {
         type: 'postfix',
@@ -141,7 +145,7 @@ ProfileTreeView.propTypes = {
   searchString: PropTypes.string,
   disableOverscan: PropTypes.bool,
   addCallTreeFilter: PropTypes.func.isRequired,
-  jsOnly: PropTypes.bool.isRequired,
+  implementationFilter: PropTypes.string.isRequired,
   invertCallstack: PropTypes.bool.isRequired,
   icons: PropTypes.array.isRequired,
 };
@@ -158,6 +162,6 @@ export default connect(state => ({
   searchString: getSearchString(state),
   disableOverscan: getProfileViewOptions(state).selection.isModifying,
   invertCallstack: getInvertCallstack(state),
-  jsOnly: getJSOnly(state),
+  implementationFilter: getImplementationFilter(state),
   icons: getIconsWithClassNames(state),
 }), actions, null, { withRef: true })(ProfileTreeView);

--- a/src/content/profile-data.js
+++ b/src/content/profile-data.js
@@ -182,6 +182,11 @@ export function filterThreadToJSOnly(thread: Thread) {
   });
 }
 
+export function filterThreadToCppOnly(thread: Thread) {
+  // TODO
+  return thread;
+}
+
 /**
  * Given a thread with stacks like below, collapse together the platform stack frames into
  * a single pseudo platform stack frame. In the diagram "J" represents JavaScript stack

--- a/src/content/profile-tree.js
+++ b/src/content/profile-tree.js
@@ -149,7 +149,8 @@ class ProfileTree {
 export type ProfileTreeClass = ProfileTree;
 
 export function getCallTree(
-  thread: Thread, interval: Milliseconds, funcStackInfo: FuncStackInfo, jsOnly: boolean
+  thread: Thread, interval: Milliseconds, funcStackInfo: FuncStackInfo,
+  implementationFilter: string
 ): ProfileTree {
   return timeCode('getCallTree', () => {
     const { funcStackTable, stackIndexToFuncStackIndex } = funcStackInfo;
@@ -181,6 +182,10 @@ export function getCallTree(
       }
     }
     const funcStackTimes = { selfTime: funcStackSelfTime, totalTime: funcStackTotalTime };
-    return new ProfileTree(funcStackTable, funcStackTimes, numChildren, thread.funcTable, thread.resourceTable, thread.stringTable, rootTotalTime, numRoots, jsOnly);
+    const jsOnly = implementationFilter === 'js';
+    return new ProfileTree(
+      funcStackTable, funcStackTimes, numChildren, thread.funcTable,
+      thread.resourceTable, thread.stringTable, rootTotalTime, numRoots, jsOnly
+    );
   });
 }

--- a/src/content/reducers/profile-view.js
+++ b/src/content/reducers/profile-view.js
@@ -414,15 +414,7 @@ export const selectorsForThread = (threadIndex: ThreadIndex): SelectorsForThread
     const _getImplementationFilteredThread = createSelector(
       _getRangeAndCallTreeFilteredThread,
       URLState.getImplementationFilter,
-      (thread, implementationFilter): Thread => {
-        switch (implementationFilter) {
-          case 'js':
-            return ProfileData.filterThreadToJSOnly(thread);
-          case 'cpp':
-            return ProfileData.filterThreadToCppOnly(thread);
-        }
-        return thread;
-      }
+      ProfileData.filterThreadByImplementation
     );
     const _getImplementationAndSearchFilteredThread = createSelector(
       _getImplementationFilteredThread,

--- a/src/content/reducers/profile-view.js
+++ b/src/content/reducers/profile-view.js
@@ -411,22 +411,28 @@ export const selectorsForThread = (threadIndex: ThreadIndex): SelectorsForThread
         return result;
       }
     );
-    const _getJSOnlyFilteredThread = createSelector(
+    const _getImplementationFilteredThread = createSelector(
       _getRangeAndCallTreeFilteredThread,
-      URLState.getJSOnly,
-      (thread, jsOnly): Thread => {
-        return jsOnly ? ProfileData.filterThreadToJSOnly(thread) : thread;
+      URLState.getImplementationFilter,
+      (thread, implementationFilter): Thread => {
+        switch (implementationFilter) {
+          case 'js':
+            return ProfileData.filterThreadToJSOnly(thread);
+          case 'cpp':
+            return ProfileData.filterThreadToCppOnly(thread);
+        }
+        return thread;
       }
     );
-    const _getJSOnlyAndSearchFilteredThread = createSelector(
-      _getJSOnlyFilteredThread,
+    const _getImplementationAndSearchFilteredThread = createSelector(
+      _getImplementationFilteredThread,
       URLState.getSearchString,
       (thread, searchString): Thread => {
         return ProfileData.filterThreadToSearchString(thread, searchString);
       }
     );
     const getFilteredThread = createSelector(
-      _getJSOnlyAndSearchFilteredThread,
+      _getImplementationAndSearchFilteredThread,
       URLState.getInvertCallstack,
       (thread, shouldInvertCallstack): Thread => {
         return shouldInvertCallstack ? ProfileData.invertCallstack(thread) : thread;
@@ -475,7 +481,7 @@ export const selectorsForThread = (threadIndex: ThreadIndex): SelectorsForThread
       getRangeSelectionFilteredThread,
       getProfileInterval,
       getFuncStackInfo,
-      URLState.getJSOnly,
+      URLState.getImplementationFilter,
       ProfileTree.getCallTree
     );
 

--- a/src/content/reducers/types.js
+++ b/src/content/reducers/types.js
@@ -1,7 +1,10 @@
 // @flow
 
 import type { Summary } from '../../common/summarize-profile';
-import type { Action, ExpandedSet, CallTreeFiltersPerThread, DataSource, ProfileSelection } from '../actions/types';
+import type {
+  Action, ExpandedSet, CallTreeFiltersPerThread, DataSource, ProfileSelection,
+  ImplementationFilter,
+} from '../actions/types';
 import type { Milliseconds, StartEndRange } from '../../common/types/units';
 import type { IndexIntoMarkersTable, IndexIntoFuncTable, Profile, ThreadIndex } from '../../common/types/profile';
 
@@ -52,7 +55,7 @@ export type URLState = {
   selectedThread: ThreadIndex,
   callTreeSearchString: string,
   callTreeFilters: CallTreeFiltersPerThread,
-  jsOnly: boolean,
+  implementation: ImplementationFilter,
   invertCallstack: boolean,
   hidePlatformDetails: boolean,
 };

--- a/src/content/reducers/url-state.js
+++ b/src/content/reducers/url-state.js
@@ -108,7 +108,7 @@ function callTreeFilters(state: CallTreeFiltersPerThread = {}, action: Action) {
  * Represents the current filter applied to the stack frames, where it will show
  * frames only by implementation.
  */
-function implementation(state: ImplementationFilter = 'all', action: Action) {
+function implementation(state: ImplementationFilter = 'combined', action: Action) {
   switch (action.type) {
     case 'CHANGE_IMPLEMENTATION_FILTER':
       return action.implementation;

--- a/src/content/reducers/url-state.js
+++ b/src/content/reducers/url-state.js
@@ -7,7 +7,9 @@ import * as RangeFilters from '../range-filters';
 
 import type { ThreadIndex } from '../../common/types/profile';
 import type { StartEndRange } from '../../common/types/units';
-import type { Action, CallTreeFiltersPerThread, CallTreeFilter, DataSource } from '../actions/types';
+import type {
+  Action, CallTreeFiltersPerThread, CallTreeFilter, DataSource, ImplementationFilter,
+} from '../actions/types';
 import type { State, URLState, Reducer } from './types';
 
 function dataSource(state: DataSource = 'none', action: Action) {
@@ -102,10 +104,14 @@ function callTreeFilters(state: CallTreeFiltersPerThread = {}, action: Action) {
   }
 }
 
-function jsOnly(state: boolean = false, action: Action) {
+/**
+ * Represents the current filter applied to the stack frames, where it will show
+ * frames only by implementation.
+ */
+function implementation(state: ImplementationFilter = 'all', action: Action) {
   switch (action.type) {
-    case 'CHANGE_JS_ONLY':
-      return action.jsOnly;
+    case 'CHANGE_IMPLEMENTATION_FILTER':
+      return action.implementation;
     default:
       return state;
   }
@@ -138,7 +144,7 @@ const urlStateReducer: Reducer<URLState> = (regularUrlStateReducer => (state: UR
   }
 })(combineReducers({
   dataSource, hash, selectedTab, rangeFilters, selectedThread,
-  callTreeSearchString, callTreeFilters, jsOnly, invertCallstack,
+  callTreeSearchString, callTreeFilters, implementation, invertCallstack,
   hidePlatformDetails,
 }));
 export default urlStateReducer;
@@ -148,7 +154,7 @@ const getURLState = (state: State): URLState => state.urlState;
 export const getDataSource = (state: State) => getURLState(state).dataSource;
 export const getHash = (state: State) => getURLState(state).hash;
 export const getRangeFilters = (state: State) => getURLState(state).rangeFilters;
-export const getJSOnly = (state: State) => getURLState(state).jsOnly;
+export const getImplementationFilter = (state: State) => getURLState(state).implementation;
 export const getHidePlatformDetails = (state: State) => getURLState(state).hidePlatformDetails;
 export const getInvertCallstack = (state: State) => getURLState(state).invertCallstack;
 export const getSearchString = (state: State) => getURLState(state).callTreeSearchString;

--- a/src/content/url-handling.js
+++ b/src/content/url-handling.js
@@ -56,7 +56,7 @@ export function urlFromState(urlState: URLState) {
     case 'calltree':
       query.search = urlState.callTreeSearchString || undefined;
       query.invertCallstack = urlState.invertCallstack ? null : undefined;
-      query.implementation = urlState.implementation === 'all'
+      query.implementation = urlState.implementation === 'combined'
         ? undefined
         : urlState.implementation;
       query.callTreeFilters = stringifyCallTreeFilters(urlState.callTreeFilters[urlState.selectedThread]) || undefined;
@@ -101,7 +101,7 @@ export function stateFromCurrentLocation(): URLState {
         selectedThread: 0,
         callTreeSearchString: '',
         callTreeFilters: {},
-        implementation: 'all',
+        implementation: 'combined',
         invertCallstack: false,
         hidePlatformDetails: false,
       };
@@ -116,7 +116,7 @@ export function stateFromCurrentLocation(): URLState {
   const needHash = ['local', 'public'].includes(dataSource);
   const selectedThread = query.thread !== undefined ? +query.thread : 0;
 
-  let implementation = 'all';
+  let implementation = 'combined';
   if (query.implementation === 'js' || query.implementation === 'cpp') {
     implementation = query.implementation;
   } else if (query.jsOnly !== undefined) {

--- a/src/content/url-handling.js
+++ b/src/content/url-handling.js
@@ -1,6 +1,8 @@
+// @flow
 import queryString from 'query-string';
 import { stringifyRangeFilters, parseRangeFilters } from './range-filters';
 import { stringifyCallTreeFilters, parseCallTreeFilters } from './call-tree-filters';
+import type { URLState } from './reducers/types';
 
 // {
 //   // general:
@@ -9,7 +11,7 @@ import { stringifyCallTreeFilters, parseCallTreeFilters } from './call-tree-filt
 //   selectedTab: 'summary' or 'calltree' or ...,
 //   rangeFilters: [] or [{ start, end }, ...],
 //   selectedThread: 0 or 1 or ...,
-//   
+//
 //   // only when selectedTab === 'calltree':
 //   callTreeSearchString: '' or '::RunScript' or ...,
 //   callTreeFilters: [[], [{type:'prefix', matchJSOnly:true, prefixFuncs:[1,3,7]}, {}, ...], ...], // one per thread
@@ -17,7 +19,7 @@ import { stringifyCallTreeFilters, parseCallTreeFilters } from './call-tree-filt
 //   invertCallstack: false or true,
 // }
 
-function dataSourceDirs(urlState) {
+function dataSourceDirs(urlState: URLState) {
   const { dataSource } = urlState;
   switch (dataSource) {
     case 'from-addon':
@@ -33,7 +35,7 @@ function dataSourceDirs(urlState) {
   }
 }
 
-export function urlFromState(urlState) {
+export function urlFromState(urlState: URLState) {
   const { dataSource } = urlState;
   if (dataSource === 'none') {
     return '/';
@@ -44,7 +46,7 @@ export function urlFromState(urlState) {
   ].join('/') + '/';
 
   // Start with the query parameters that are shown regardless of the active tab.
-  const query = {
+  const query: Object = {
     range: stringifyRangeFilters(urlState.rangeFilters) || undefined,
     thread: `${urlState.selectedThread}`,
   };
@@ -54,7 +56,9 @@ export function urlFromState(urlState) {
     case 'calltree':
       query.search = urlState.callTreeSearchString || undefined;
       query.invertCallstack = urlState.invertCallstack ? null : undefined;
-      query.jsOnly = urlState.jsOnly ? null : undefined;
+      query.implementation = urlState.implementation === 'all'
+        ? undefined
+        : urlState.implementation;
       query.callTreeFilters = stringifyCallTreeFilters(urlState.callTreeFilters[urlState.selectedThread]) || undefined;
       break;
     case 'timeline':
@@ -64,10 +68,14 @@ export function urlFromState(urlState) {
       break;
   }
   const qString = queryString.stringify(query);
+  console.log(
+    '!!! query',
+    { urlState, query, qString}
+  );
   return pathname + (qString ? '?' + qString : '');
 }
 
-export function stateFromCurrentLocation() {
+export function stateFromCurrentLocation(): URLState {
   const pathname = window.location.pathname;
   const qString = window.location.search.substr(1);
   const hash = window.location.hash;
@@ -97,8 +105,9 @@ export function stateFromCurrentLocation() {
         selectedThread: 0,
         callTreeSearchString: '',
         callTreeFilters: {},
-        jsOnly: false,
+        implementation: 'all',
         invertCallstack: false,
+        hidePlatformDetails: false,
       };
     }
   }
@@ -110,6 +119,15 @@ export function stateFromCurrentLocation() {
   }
   const needHash = ['local', 'public'].includes(dataSource);
   const selectedThread = query.thread !== undefined ? +query.thread : 0;
+
+  let implementation = 'all';
+  if (query.implementation === 'js' || query.implementation === 'cpp') {
+    implementation = query.implementation;
+  } else if (query.jsOnly !== undefined) {
+    // Support the old URL structure that had a jsOnly flag.
+    implementation = 'js';
+  }
+
   return {
     dataSource,
     hash: needHash ? dirs[1] : '',
@@ -120,7 +138,7 @@ export function stateFromCurrentLocation() {
     callTreeFilters: {
       [selectedThread]: query.callTreeFilters ? parseCallTreeFilters(query.callTreeFilters) : [],
     },
-    jsOnly: query.jsOnly !== undefined,
+    implementation,
     invertCallstack: query.invertCallstack !== undefined,
     hidePlatformDetails: query.hidePlatformDetails !== undefined,
   };

--- a/src/content/url-handling.js
+++ b/src/content/url-handling.js
@@ -68,10 +68,6 @@ export function urlFromState(urlState: URLState) {
       break;
   }
   const qString = queryString.stringify(query);
-  console.log(
-    '!!! query',
-    { urlState, query, qString}
-  );
   return pathname + (qString ? '?' + qString : '');
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -419,7 +419,7 @@ describe('filter-by-implementation', function () {
   }
 
   it('will return the same thread if filtering to "all"', function () {
-    assert.equal(filterThreadByImplementation(thread, 'all'), thread);
+    assert.equal(filterThreadByImplementation(thread, 'combined'), thread);
   });
 
   it('will return only JS samples if filtering to "js"', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -2,8 +2,9 @@ import 'babel-polyfill';
 import { assert, config } from 'chai';
 import { getContainingLibrary, symbolicateProfile, applyFunctionMerging, setFuncNames } from '../src/content/symbolication';
 import { preprocessProfile, unserializeProfileOfArbitraryFormat, serializeProfile } from '../src/content/preprocess-profile';
-import { resourceTypes, getFuncStackInfo, getTracingMarkers } from '../src/content/profile-data';
+import { resourceTypes, getFuncStackInfo, getTracingMarkers, filterThreadByImplementation } from '../src/content/profile-data';
 import exampleProfile from './example-profile';
+import profileWithJS from './timings-with-js';
 import { UniqueStringArray } from '../src/content/unique-string-array';
 import { FakeSymbolStore } from './fake-symbol-store';
 import { sortDataTable } from '../src/content/data-table-utils';
@@ -404,5 +405,42 @@ describe('color-categories', function () {
       'The JS Baseline frame is labeled as as JS Baseline.');
     assert.equal(categories[6].color, implementationCategoryMap['JS Baseline'],
       'The platform frames are colored according to the color definition');
+  });
+});
+
+describe('filter-by-implementation', function () {
+  const profile = preprocessProfile(profileWithJS);
+  const thread = profile.threads[0];
+
+  function stackIsJS(filteredThread, stackIndex) {
+    const frameIndex = filteredThread.stackTable.frame[stackIndex];
+    const funcIndex = filteredThread.frameTable.func[frameIndex];
+    return filteredThread.funcTable.isJS[funcIndex];
+  }
+
+  it('will return the same thread if filtering to "all"', function () {
+    assert.equal(filterThreadByImplementation(thread, 'all'), thread);
+  });
+
+  it('will return only JS samples if filtering to "js"', function () {
+    const jsOnlyThread = filterThreadByImplementation(thread, 'js');
+    const nonNullSampleStacks = jsOnlyThread.samples.stack.filter(stack => stack !== null);
+    const samplesAreAllJS = nonNullSampleStacks
+      .map(stack => stackIsJS(jsOnlyThread, stack))
+      .reduce((a, b) => a && b);
+
+    assert.isTrue(samplesAreAllJS, 'samples are all js');
+    assert.lengthOf(nonNullSampleStacks, 4);
+  });
+
+  it('will return only C++ samples if filtering to "cpp"', function () {
+    const cppOnlyThread = filterThreadByImplementation(thread, 'cpp');
+    const nonNullSampleStacks = cppOnlyThread.samples.stack.filter(stack => stack !== null);
+    const samplesAreAllJS = nonNullSampleStacks
+      .map(stack => !stackIsJS(cppOnlyThread, stack))
+      .reduce((a, b) => a && b);
+
+    assert.isTrue(samplesAreAllJS, 'samples are all cpp');
+    assert.lengthOf(nonNullSampleStacks, 10);
   });
 });


### PR DESCRIPTION
Resolves #238 by changing the "jsOnly" filter to a implementation filter.

<img width="607" alt="image" src="https://cloud.githubusercontent.com/assets/1588648/25189792/dac9988e-24ef-11e7-9b97-8135b00cf833.png">

<img width="603" alt="image" src="https://cloud.githubusercontent.com/assets/1588648/25189797/e3003634-24ef-11e7-9a78-939ca57f09c5.png">
