### PR TITLE
Filter out jitcode from C++ only call tree; Resolves #285

### DIFF
--- a/src/content/profile-data.js
+++ b/src/content/profile-data.js
@@ -142,11 +142,14 @@ export function filterThreadByImplementation(thread: Thread, implementation: str
         if (funcTable.isJS[funcIndex]) {
           return false;
         }
-        // Try to filter out jitcode frames, they are named like 0xNNNNNNN where N is some
-        // number, and they don't have any resource associated with them.
+        // Regular C++ functions are associated with a resource that describes the
+        // shared library that these C++ functions were loaded from. Jitcode is not
+        // loaded from shared libraries but instead generated at runtime, so Jitcode
+        // frames are not associated with a shared library and thus have no resource
         const locationString = stringTable.getString(funcTable.name[funcIndex]);
-        const isJitcode = funcTable.resource[funcIndex] === -1 && locationString.startsWith('0x');
-        return !isJitcode;
+        const isProbablyJitCode =
+          funcTable.resource[funcIndex] === -1 && locationString.startsWith('0x');
+        return !isProbablyJitCode;
       });
     case 'js':
       return _filterThreadByFunc(thread, funcIndex => funcTable.isJS[funcIndex]);


### PR DESCRIPTION
Combined stacks (jitcode present):
<img width="1313" alt="image" src="https://cloud.githubusercontent.com/assets/1588648/25585161/e9146c7a-2e5e-11e7-9bf0-16acaf9f21ed.png">

C++ Only (no jitcode):
<img width="1313" alt="image" src="https://cloud.githubusercontent.com/assets/1588648/25585189/0549667a-2e5f-11e7-97c1-570856038d6d.png">
