### PR TITLE
[blocked] Call tree filtering

### DIFF
--- a/res/filter.svg
+++ b/res/filter.svg
@@ -1,0 +1,16 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="#0b0b0b">
+  <style>
+    /* Use a fill that's visible on both light and dark themes for filter inputs */
+    #filterinput:target + #icon {
+      fill: #aaa;
+    }
+  </style>
+  <g id="filterinput"/>
+  <g id="icon">
+    <path fill-opacity=".3" d="M6.6 8.4c0-.6-1.7.3-1.7-.3 0-.4-1.7-2.7-1.7-2.7H13s-1.8 2-1.8 2.7c0 .3-2.1-.1-2.1.3v6.1H7s-.4-4.1-.4-6.1z"/>
+    <path d="M2 2v2.3L4.7 9H6v5.4l2.1 1 1.8-.9V9h1.3L14 4.3V2H2zm11 2l-2.2 4H9v5.8l-.9.4-1.1-.5V8H5.2L3 4V3h10v1z"/>
+  </g>
+</svg>

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -196,3 +196,47 @@ export function popCallTreeFilters(
     firstRemovedFilterIndex,
   };
 }
+
+export function mergeFunction(
+  funcIndex: IndexIntoFuncTable,
+  threadIndex: ThreadIndex
+) {
+  return {
+    type: 'MERGE_FUNCTION',
+    funcIndex,
+    threadIndex,
+  };
+}
+
+export function unmergeFunction(
+  funcIndex: IndexIntoFuncTable,
+  threadIndex: ThreadIndex
+) {
+  return {
+    type: 'UNMERGE_FUNCTION',
+    funcIndex,
+    threadIndex,
+  };
+}
+
+export function mergeSubtree(
+  funcIndex: IndexIntoFuncTable,
+  threadIndex: ThreadIndex
+) {
+  return {
+    type: 'MERGE_SUBTREE',
+    funcIndex,
+    threadIndex,
+  };
+}
+
+export function unmergeSubtree(
+  funcIndex: IndexIntoFuncTable,
+  threadIndex: ThreadIndex
+) {
+  return {
+    type: 'UNMERGE_SUBTREE',
+    funcIndex,
+    threadIndex,
+  };
+}

--- a/src/components/app/ProfileSharing.css
+++ b/src/components/app/ProfileSharing.css
@@ -98,7 +98,7 @@
 }
 
 .profileSharingProfileDownloadPanel {
-  --offset-from-right: 25px;
+  --offset-horizontal: 25px;
   --width: 30em;
 }
 

--- a/src/components/calltree/CallTreeFilters.css
+++ b/src/components/calltree/CallTreeFilters.css
@@ -1,0 +1,214 @@
+.callTreeFilters {
+  z-index: 1;
+}
+
+.callTreeFiltersPanelarrowPanelAnchor {
+  top: 16px;
+}
+
+.callTreeFiltersButton {
+  background: none 0 0 no-repeat transparent;
+  flex-shrink: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  width: 16px;
+  height: 16px;
+  overflow: hidden;
+  vertical-align: top;
+  color: transparent;
+  opacity: 0.9;
+}
+
+.callTreeFiltersButton,
+.callTreeFiltersButton:hover,
+.callTreeFiltersButton:hover:active,
+.buttonWithPanel.open > * > .callTreeFiltersButton {
+  background-image: url(../../../res/filter.svg);
+}
+
+.callTreeFiltersButton:hover,
+.callTreeFiltersButton:hover:active {
+  opacity: 1;
+}
+
+.callTreeFiltersScroller {
+  max-height: 250px;
+  overflow: scroll;
+}
+
+.callTreeFiltersTable {
+  min-width: 300px;
+  min-width: 300px;
+  background-color: #fff;
+  border: 1px solid #d6d6d6;
+  margin-bottom: 10px;
+  border-collapse: collapse;
+}
+
+.callTreeFiltersRow {
+  padding: 4px 0px;
+  color: #000;
+}
+
+.callTreeFiltersEmpty {
+  padding: 10px 20px;
+}
+.callTreeFiltersEmptyP {
+  min-width: 300px;
+}
+
+.callTreeFiltersCell,
+.callTreeFiltersCellHeader {
+  padding: 5px 9px;
+  white-space: nowrap;
+}
+
+.callTreeFiltersCellHeader {
+  border: 1px solid #eaeaea;
+}
+
+.callTreeFiltersListItemName {
+  max-width: 300px;
+  padding: 0 7px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  -webkit-user-select: text;
+  -moz-user-select: text;
+  -ms-user-select: text;
+  user-select: text;
+}
+
+.callTreeFiltersType {
+  position: relative;
+  padding-right: 25px;
+  color: #486cc9;
+  text-decoration: underline;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.callTreeFiltersType::before,
+.callTreeFiltersType::after
+{
+  content: "";
+  width: 0;
+  height: 0;
+  border-style: solid;
+  position: absolute;
+  right: 5px;
+  pointer-events: none;
+}
+
+.callTreeFiltersType::before {
+  border-width: 0 4px 3px 4px;
+  border-color: transparent transparent #000 transparent;
+  top: 8px;
+}
+
+.callTreeFiltersType::after {
+  border-width: 3px 4px 0 4px;
+  border-color: #000 transparent transparent transparent;
+  top: 14px;
+}
+
+.callTreeFiltersSelect {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  border: 0;
+  background: none;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.callTreeFiltersCheckbox {
+  margin: 0 0 0 5px;
+}
+
+.callTreeFiltersTransitionGroup {
+  position: absolute;
+  top: 29px;
+  left: -10px;
+}
+
+.callTreeFiltersHintContainer {
+  transform-origin: 30px 13px;
+}
+
+.callTreeFiltersHint {
+    padding: 6px 9px;
+    border-radius: 3px;
+    line-height: 13px;
+    background-color: #798fc8;
+    color: #fff;
+    box-shadow: 0 2px 2px rgba(0, 0, 0, 0.3);
+    pointer-events: none;
+    max-width: 150px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+}
+
+.callTreeFiltersHint::before {
+  content: "";
+  display: block;
+  position: absolute;
+  top: -7px;
+  width: 10px;
+  height: 10px;
+  background: #798fc8;
+  transform: rotate(45deg);
+  transform-origin: top left;
+  z-index: -1;
+  left: 18px;
+}
+
+.callTreeFiltersTransition-enter {
+  animation: callTreeFiltersEnter 150ms;
+}
+
+.callTreeFiltersTransition-leave {
+  animation: callTreeFiltersLeave 200ms;
+}
+
+@keyframes callTreeFiltersEnter {
+  0% {
+    opacity: 0;
+    animation-timing-function: cubic-bezier(0.0, 0.2, 0.2, 0);
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes callTreeFiltersLeave {
+  0% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-10px,-22px) scale(0.1);
+    animation-timing-function: ease-out;
+  }
+}
+
+.callTreeFiltersFlash > .buttonWithPanelButtonWrapper {
+  animation: callTreeFiltersButtonFlash 0.5s;
+}
+
+@keyframes callTreeFiltersButtonFlash {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.5);
+  }
+  100% {
+    transform: scale(1);
+  }
+}

--- a/src/components/calltree/CallTreeFilters.js
+++ b/src/components/calltree/CallTreeFilters.js
@@ -1,0 +1,299 @@
+// @flow
+import React, { PureComponent } from 'react';
+import { CSSTransitionGroup } from 'react-transition-group';
+
+import ButtonWithPanel from '../shared/ButtonWithPanel';
+import ArrowPanel from '../shared/ArrowPanel';
+import {
+  selectedThreadSelectors,
+  getLastAddedFilter,
+} from '../../reducers/profile-view';
+import {
+  getMergeFunctionsList,
+  getMergeSubtreeList,
+  getSelectedThreadIndex,
+} from '../../reducers/url-state';
+import { connect } from 'react-redux';
+import classNames from 'classnames';
+import {
+  mergeFunction,
+  unmergeFunction,
+  mergeSubtree,
+  unmergeSubtree,
+} from '../../actions/profile-view';
+
+import type { State, LastAddedFilter } from '../../types/reducers';
+import type {
+  Thread,
+  ThreadIndex,
+  IndexIntoFuncTable,
+} from '../../types/profile';
+
+import './CallTreeFilters.css';
+
+const MERGE_FUNCTION_LABEL = 'merge function';
+const MERGE_SUBTREE_LABEL = 'merge subtree';
+const REMOVE_FILTER_LABEL = 'remove this filter';
+const HINT_ENTER_TIMEOUT = 250;
+const HINT_LEAVE_TIMEOUT = 200;
+const HINT_ON_DECK_TIMEOUT = 1200;
+
+type Props = {
+  mergeFunction: typeof mergeFunction,
+  unmergeFunction: typeof unmergeFunction,
+  mergeSubtree: typeof mergeSubtree,
+  unmergeSubtree: typeof unmergeSubtree,
+  mergeFunctionsList: IndexIntoFuncTable[],
+  mergeSubtreeList: IndexIntoFuncTable[],
+  thread: Thread,
+  threadIndex: ThreadIndex,
+  lastAddedFilter: LastAddedFilter,
+};
+
+class CallTreeFilters extends PureComponent {
+  props: Props;
+
+  state: {
+    hasAddedFuncAtLeastOnce: boolean,
+    lastAddedFunc: string | null,
+  };
+
+  _timeoutID: number;
+  _scroller: ?HTMLElement;
+
+  constructor(props: Props) {
+    super(props);
+    (this: any)._renderItem = this._renderItem.bind(this);
+    (this: any)._setScrollerElement = this._setScrollerElement.bind(this);
+    (this: any)._setScrollerMaxHeight = this._setScrollerMaxHeight.bind(this);
+    this._timeoutID = 0;
+
+    this.state = {
+      hasAddedFuncAtLeastOnce: false,
+      lastAddedFunc: null,
+    };
+  }
+
+  componentDidMount() {
+    window.addEventListener('resize', this._setScrollerMaxHeight, false);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this._setScrollerMaxHeight, false);
+  }
+
+  _setScrollerElement(scroller: HTMLElement) {
+    this._scroller = scroller;
+    this._setScrollerMaxHeight();
+  }
+
+  _setScrollerMaxHeight() {
+    if (this._scroller) {
+      // This number is fairly arbitrary, but leave some room at the bottom of the scroller.
+      const BOTTOM_MARGIN = 20;
+      const { top } = this._scroller.getBoundingClientRect();
+      const height = window.innerHeight - top - BOTTOM_MARGIN;
+      // Satisfy flow's null checks.
+      if (this._scroller) {
+        this._scroller.style.maxHeight = `${height}px`;
+      }
+    }
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    const { threadIndex, lastAddedFilter } = nextProps;
+    if (this.props.lastAddedFilter !== nextProps.lastAddedFilter) {
+      if (lastAddedFilter && threadIndex === lastAddedFilter.threadIndex) {
+        this.setState({
+          hasAddedFuncAtLeastOnce: true,
+          lastAddedFunc: this._funcIndexToName(lastAddedFilter.funcIndex),
+        });
+        this._timeoutID++;
+        const timeoutID = this._timeoutID;
+        setTimeout(() => {
+          if (timeoutID === this._timeoutID) {
+            this.setState({ lastAddedFunc: null });
+          }
+        }, HINT_ON_DECK_TIMEOUT);
+      }
+    }
+  }
+
+  _renderItem({ id, name, type }) {
+    return (
+      <tr className="callTreeFiltersRow" key={type + id}>
+        <td className="callTreeFiltersCell callTreeFiltersType">
+          {type}
+          <select
+            className="callTreeFiltersSelect"
+            value={type}
+            onChange={(event: SyntheticInputEvent) =>
+              this._changeFilterType(id, type, event.target.value)}
+          >
+            <option>
+              {MERGE_FUNCTION_LABEL}
+            </option>
+            <option>
+              {MERGE_SUBTREE_LABEL}
+            </option>
+            <option>
+              {REMOVE_FILTER_LABEL}
+            </option>
+          </select>
+        </td>
+        <td className="callTreeFiltersCell callTreeFiltersAppliedWhere">
+          Entire Thread
+        </td>
+        <td
+          className="callTreeFiltersCell callTreeFiltersListItemName"
+          title={name}
+        >
+          {name}
+        </td>
+      </tr>
+    );
+  }
+
+  _changeFilterType(
+    funcIndex: IndexIntoFuncTable,
+    oldType: string,
+    newType: string
+  ) {
+    const {
+      unmergeFunction,
+      mergeSubtree,
+      unmergeSubtree,
+      threadIndex,
+    } = this.props;
+    switch (oldType) {
+      case MERGE_FUNCTION_LABEL:
+        unmergeFunction(funcIndex, threadIndex);
+        break;
+      case MERGE_SUBTREE_LABEL:
+        unmergeSubtree(funcIndex, threadIndex);
+        break;
+    }
+
+    switch (newType) {
+      case MERGE_FUNCTION_LABEL:
+        mergeFunction(funcIndex, threadIndex);
+        this.props.mergeFunction(funcIndex, threadIndex);
+        break;
+      case MERGE_SUBTREE_LABEL:
+        mergeSubtree(funcIndex, threadIndex);
+        break;
+    }
+  }
+
+  _funcIndexToName(funcIndex: IndexIntoFuncTable) {
+    const { thread } = this.props;
+    return thread.stringTable.getString(thread.funcTable.name[funcIndex]);
+  }
+
+  _parseFilters() {
+    const { mergeFunctionsList, mergeSubtreeList } = this.props;
+
+    return [
+      ...mergeFunctionsList.map(id => ({
+        id,
+        name: this._funcIndexToName(id),
+        type: MERGE_FUNCTION_LABEL,
+      })),
+      ...mergeSubtreeList.map(id => ({
+        id,
+        name: this._funcIndexToName(id),
+        type: MERGE_SUBTREE_LABEL,
+      })),
+    ].sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  render() {
+    const filters = this._parseFilters();
+    const { lastAddedFunc, hasAddedFuncAtLeastOnce } = this.state;
+    const panelClass = classNames({
+      callTreeFiltersFlash: hasAddedFuncAtLeastOnce && !lastAddedFunc,
+      callTreeFilters: true,
+    });
+
+    return (
+      <div>
+        <CSSTransitionGroup
+          transitionName="callTreeFiltersTransition"
+          transitionEnterTimeout={HINT_ENTER_TIMEOUT}
+          transitionLeaveTimeout={HINT_LEAVE_TIMEOUT}
+          component="div"
+          className="callTreeFiltersTransitionGroup"
+        >
+          {lastAddedFunc
+            ? <div className="callTreeFiltersHintContainer" key={lastAddedFunc}>
+                <div className="callTreeFiltersHint">
+                  {lastAddedFunc}
+                </div>
+              </div>
+            : null}
+        </CSSTransitionGroup>
+        <ButtonWithPanel
+          className={panelClass}
+          label="Filter"
+          panel={
+            <ArrowPanel
+              className="callTreeFiltersPanel"
+              title="Merged functions and subtrees"
+              offsetDirection="left"
+            >
+              <div
+                className="callTreeFiltersScroller"
+                ref={this._setScrollerElement}
+              >
+                <table className="callTreeFiltersTable">
+                  <thead>
+                    <tr>
+                      <th className="callTreeFiltersCellHeader">Filter</th>
+                      <th className="callTreeFiltersCellHeader">Where</th>
+                      <th className="callTreeFiltersCellHeader">Function</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {filters.length > 0
+                      ? filters.map(this._renderItem)
+                      : <tr>
+                          <td colSpan={3} className="callTreeFiltersEmpty">
+                            <p className="callTreeFiltersEmptyP">
+                              No filters are currently active. Right click on
+                              the call tree, and merge individual functions or
+                              entire subtrees into their callers in the call
+                              tree. These filters help to hide away noisy
+                              functions that get in the way of performance
+                              analysis.
+                            </p>
+                          </td>
+                        </tr>}
+                  </tbody>
+                </table>
+              </div>
+            </ArrowPanel>
+          }
+        />
+      </div>
+    );
+  }
+}
+
+export default connect(
+  (state: State) => {
+    const threadIndex = getSelectedThreadIndex(state);
+    return {
+      thread: selectedThreadSelectors.getThread(state),
+      threadIndex,
+      lastAddedFilter: getLastAddedFilter(state),
+      mergeFunctionsList: getMergeFunctionsList(state, threadIndex),
+      mergeSubtreeList: getMergeSubtreeList(state, threadIndex),
+    };
+  },
+  {
+    mergeFunction,
+    unmergeFunction,
+    mergeSubtree,
+    unmergeSubtree,
+  }
+)(CallTreeFilters);

--- a/src/components/calltree/ProfileCallTreeContextMenu.css
+++ b/src/components/calltree/ProfileCallTreeContextMenu.css
@@ -1,0 +1,10 @@
+.profileCallTreeContextMenuLabel {
+  display: inline-block;
+  border: 1px solid #ccc;
+  border-radius: .2em;
+  margin: 0 .2em;
+  padding: 0 .5em;
+  background-color: #f6f6f6;
+  font-size: 10px;
+  color: #000;
+}

--- a/src/components/calltree/ProfileCallTreeSettings.css
+++ b/src/components/calltree/ProfileCallTreeSettings.css
@@ -10,6 +10,7 @@
   background: #F9F9F9;
   display: flex;
   flex-flow: row nowrap;
+  z-index: 1;
 }
 
 .profileCallTreeSettingsList {
@@ -35,6 +36,7 @@
   flex-flow: row nowrap;
   align-items: center;
   height: 25px;
+  position: relative;
 }
 
 .profileCallTreeSettingsSelect {

--- a/src/components/calltree/ProfileCallTreeSettings.js
+++ b/src/components/calltree/ProfileCallTreeSettings.js
@@ -13,6 +13,7 @@ import {
   getSearchString,
 } from '../../reducers/url-state';
 import IdleSearchField from '../shared/IdleSearchField';
+import CallTreeFilters from './CallTreeFilters';
 
 import './ProfileCallTreeSettings.css';
 
@@ -81,6 +82,11 @@ class ProfileCallTreeSettings extends PureComponent {
                 checked={invertCallstack}
               />
               {' Invert call stack'}
+            </label>
+          </li>
+          <li className="profileCallTreeSettingsListItem">
+            <label className="profileCallTreeSettingsLabel">
+              <CallTreeFilters />
             </label>
           </li>
         </ul>

--- a/src/components/shared/ArrowPanel.css
+++ b/src/components/shared/ArrowPanel.css
@@ -10,7 +10,7 @@
 }
 
 .arrowPanel {
-  --internal-offset-from-right: var(--offset-from-right, 60px);
+  --internal-offset-horizontal: var(--offset-horizontal, 60px);
   --internal-offset-from-top: 15px;
   --internal-width: var(--width, auto);
   --internal-button-height: 30px;
@@ -18,7 +18,6 @@
   --internal-ok-button-color: var(--ok-button-color, white);
   position: absolute;
   top: var(--internal-offset-from-top);
-  right: calc(0px - var(--internal-offset-from-right));
   min-width: var(--internal-width);
   filter: drop-shadow(0 0 0.5px rgba(0,0,0,0.4)) drop-shadow(0 4px 5px rgba(0,0,0,0.4));
   filter: url(../../../res/shadowfilter.svg#menushadow);
@@ -27,7 +26,16 @@
   line-height: 1.3;
   background: hsla(0, 0%, 97%, 0.95);
   border-radius: 5px;
-  transform-origin: calc(100% - var(--internal-offset-from-right))
+}
+.arrowPanel.right {
+  right: calc(0px - var(--internal-offset-horizontal));
+  transform-origin: calc(100% - var(--internal-offset-horizontal))
+                    calc(0px - var(--internal-offset-from-top));
+}
+
+.arrowPanel.left {
+  left: calc(0px - var(--internal-offset-horizontal));
+  transform-origin: var(--internal-offset-horizontal)
                     calc(0px - var(--internal-offset-from-top));
 }
 
@@ -77,13 +85,20 @@
   display: block;
   position: absolute;
   top: 0;
-  left: calc(100% - var(--internal-offset-from-right));
   width: calc(1.42 * var(--internal-offset-from-top));
   height: calc(1.42 * var(--internal-offset-from-top));
   background: hsla(0, 0%, 97%, 0.95);
   transform: rotate(45deg);
   transform-origin: top left;
   z-index: -1;
+}
+
+.arrowPanelArrow.right::before {
+  left: calc(100% - var(--internal-offset-horizontal));
+}
+
+.arrowPanelArrow.left::before {
+  left: var(--internal-offset-horizontal);
 }
 
 .arrowPanelTitle {

--- a/src/components/shared/ArrowPanel.js
+++ b/src/components/shared/ArrowPanel.js
@@ -12,6 +12,7 @@ class ArrowPanel extends PureComponent {
     super(props);
     this.state = { open: false };
     this._windowMouseDownListener = this._windowMouseDownListener.bind(this);
+    this._escapeListener = this._escapeListener.bind(this);
     this._panelElementCreated = elem => {
       this._panelElement = elem;
     };
@@ -29,6 +30,7 @@ class ArrowPanel extends PureComponent {
       this.props.onOpen();
     }
     window.addEventListener('mousedown', this._windowMouseDownListener, true);
+    window.addEventListener('keypress', this._escapeListener, false);
   }
 
   close() {
@@ -45,6 +47,7 @@ class ArrowPanel extends PureComponent {
       this._windowMouseDownListener,
       true
     );
+    window.removeEventListener('keypress', this._escapeListener, false);
   }
 
   componentWillUnmount() {
@@ -53,14 +56,21 @@ class ArrowPanel extends PureComponent {
       this._windowMouseDownListener,
       true
     );
+    window.removeEventListener('keypress', this._escapeListener, false);
   }
 
-  _windowMouseDownListener(e) {
+  _windowMouseDownListener(event) {
     if (
       this.state.open &&
       this._panelElement &&
-      !this._panelElement.contains(e.target)
+      !this._panelElement.contains(event.target)
     ) {
+      this.close();
+    }
+  }
+
+  _escapeListener(event) {
+    if (event.key === 'Escape' && this.state.open && this._panelElement) {
       this.close();
     }
   }
@@ -86,21 +96,28 @@ class ArrowPanel extends PureComponent {
       title,
       okButtonText,
       cancelButtonText,
+      offsetDirection,
     } = this.props;
     const hasTitle = title !== undefined;
     const hasButtons = okButtonText || cancelButtonText;
     const { open } = this.state;
     return (
-      <div className="arrowPanelAnchor">
+      <div
+        className={classNames(
+          'arrowPanelAnchor',
+          className + 'arrowPanelAnchor'
+        )}
+      >
         <div
           className={classNames(
             'arrowPanel',
             { open, hasTitle, hasButtons },
+            offsetDirection,
             className
           )}
           ref={this._panelElementCreated}
         >
-          <div className="arrowPanelArrow" />
+          <div className={classNames('arrowPanelArrow', offsetDirection)} />
           {hasTitle
             ? <h1 className="arrowPanelTitle">
                 {title}
@@ -141,6 +158,7 @@ ArrowPanel.propTypes = {
   title: PropTypes.string,
   okButtonText: PropTypes.string,
   cancelButtonText: PropTypes.string,
+  offsetDirection: PropTypes.string,
 };
 
 export default ArrowPanel;

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -170,41 +170,105 @@ export function defaultThreadOrder(threads: Thread[]): ThreadIndex[] {
   return threadOrder;
 }
 
-export function filterThreadByImplementation(
+/**
+ * There are two filtering strategies for functions. Either an individual stack frame
+ * is hidden, in which case its timing is charged to its caller. The other case
+ * is that the entire subtree needs to be removed. _applyFuncFilters handles both of
+ * these cases, and arbitrarily performs these actions based on what is passed in.
+ * From a higher level, filterThreadByFunc wires together those specific strategies
+ * without caring about the implementation details of how those strategies are
+ * specifically applied to create a new filtered thread.
+ */
+export function filterThreadByFunc(
   thread: Thread,
-  implementation: string
+  implementation: string,
+  chargeToCallerList: IndexIntoFuncTable[],
+  mergeSubtreeList: IndexIntoFuncTable[]
 ): Thread {
+  // Return the existing thread if no filters need to be applied.
+  if (
+    implementation === 'combined' &&
+    chargeToCallerList.length === 0 &&
+    mergeSubtreeList.length === 0
+  ) {
+    return thread;
+  }
+
+  // Prepare the filtering functions.
+  const filterFuncByImplementation = _getFuncImplementationFilter(
+    thread,
+    implementation
+  );
+  const filterOutFrameByFunc = funcIndex =>
+    filterFuncByImplementation(funcIndex) ||
+    chargeToCallerList.includes(funcIndex);
+  const filterOutSubtreeByFunc = funcIndex =>
+    mergeSubtreeList.includes(funcIndex);
+
+  // Apply all the filters to the thread.
+  return _applyFuncFilters(
+    thread,
+    filterOutFrameByFunc,
+    filterOutSubtreeByFunc
+  );
+}
+
+function _getFuncImplementationFilter(
+  thread,
+  implementation: string
+): IndexIntoFuncTable => boolean {
   const { funcTable, stringTable } = thread;
 
   switch (implementation) {
     case 'cpp':
-      return _filterThreadByFunc(thread, funcIndex => {
-        // Return quickly if this is a JS frame.
+      return funcIndex => {
+        // Discard quickly if this is a JS frame.
         if (funcTable.isJS[funcIndex]) {
-          return false;
+          return true;
         }
         // Regular C++ functions are associated with a resource that describes the
         // shared library that these C++ functions were loaded from. Jitcode is not
         // loaded from shared libraries but instead generated at runtime, so Jitcode
-        // frames are not associated with a shared library and thus have no resource
+        // frames are not associated with a shared library and thus have no resource.
+        // These stack frames should be discarded when looking at C++ only.
         const locationString = stringTable.getString(funcTable.name[funcIndex]);
         const isProbablyJitCode =
           funcTable.resource[funcIndex] === -1 &&
           locationString.startsWith('0x');
-        return !isProbablyJitCode;
-      });
+        return isProbablyJitCode;
+      };
     case 'js':
-      return _filterThreadByFunc(
-        thread,
-        funcIndex => funcTable.isJS[funcIndex]
-      );
+      // Discard if not JS.
+      return funcIndex => !funcTable.isJS[funcIndex];
   }
-  return thread;
+  return () => false;
 }
 
-function _filterThreadByFunc(
+/**
+ * Take two arbitrary functions. The first filters out individual stack frames based
+ * on the function. The second merges the entire subtree based on the function.
+ *
+ * filterOutFrameByFunc:
+ *
+ *          0                    0
+ *        /  \      Func 1     / | \
+ *      1     2      ->       3  4  2
+ *     /\     /\                   / \
+ *    3 4    5  6                 5  6
+ *
+ * filterOutSubtreeByFunc:
+ *
+ *          0                    0
+ *        /  \      Func 1       |
+ *      1     2      ->          2
+ *     /\     /\                / \
+ *    3 4    5  6              5  6
+ *
+ */
+function _applyFuncFilters(
   thread: Thread,
-  filter: IndexIntoFuncTable => boolean
+  filterOutFrameByFunc: IndexIntoFuncTable => boolean,
+  filterOutSubtreeByFunc: IndexIntoFuncTable => boolean
 ): Thread {
   return timeCode('filterThread', () => {
     const { stackTable, frameTable, samples } = thread;
@@ -219,6 +283,9 @@ function _filterThreadByFunc(
     const frameCount = frameTable.length;
     const prefixStackAndFrameToStack = new Map(); // prefixNewStack * frameCount + frame => newStackIndex
 
+    /**
+     * Create a new StackTable by applying filterOutFrameByFunc.
+     */
     function convertStack(stackIndex) {
       if (stackIndex === null) {
         return null;
@@ -228,7 +295,11 @@ function _filterThreadByFunc(
         const prefixNewStack = convertStack(stackTable.prefix[stackIndex]);
         const frameIndex = stackTable.frame[stackIndex];
         const funcIndex = frameTable.func[frameIndex];
-        if (filter(funcIndex)) {
+        if (filterOutFrameByFunc(funcIndex)) {
+          // Discard this stack frame, and use the prefix.
+          newStack = prefixNewStack;
+        } else {
+          // Keep this stack frame, and remember the new stack index.
           const prefixStackAndFrameIndex =
             (prefixNewStack === null ? -1 : prefixNewStack) * frameCount +
             frameIndex;
@@ -240,15 +311,32 @@ function _filterThreadByFunc(
           }
           oldStackToNewStack.set(stackIndex, newStack);
           prefixStackAndFrameToStack.set(prefixStackAndFrameIndex, newStack);
-        } else {
-          newStack = prefixNewStack;
         }
       }
       return newStack;
     }
 
+    /**
+     * Find the correct leaf stack by merging subtrees that match filterOutSubtreeByFunc.
+     */
+    function mergeStack(stackIn: IndexIntoStackTable | null) {
+      let leafStack = stackIn;
+      let stackIndex = stackIn;
+      // Walk up the stack, and find the leaf-most stack.
+      while (stackIndex !== null) {
+        const prefix = newStackTable.prefix[stackIndex];
+        const frameIndex = newStackTable.frame[stackIndex];
+        const funcIndex = frameTable.func[frameIndex];
+        if (filterOutSubtreeByFunc(funcIndex)) {
+          leafStack = prefix;
+        }
+        stackIndex = prefix;
+      }
+      return leafStack;
+    }
+
     const newSamples = Object.assign({}, samples, {
-      stack: samples.stack.map(oldStack => convertStack(oldStack)),
+      stack: samples.stack.map(oldStack => mergeStack(convertStack(oldStack))),
     });
 
     return Object.assign({}, thread, {

--- a/src/test/utils/analyze-profile.js
+++ b/src/test/utils/analyze-profile.js
@@ -1,0 +1,54 @@
+// @flow
+import type {
+  Thread,
+  IndexIntoFuncTable,
+  IndexIntoStackTable,
+} from '../../types/profile';
+
+/**
+ * Maps a thread's sample into the height of the stack.
+ */
+export function mapSamplesToStackHeight({
+  samples,
+  stackTable,
+}: Thread): number[] {
+  return samples.stack.map(stackIndexIn => {
+    let stackIndex = stackIndexIn;
+    let i = 0;
+    while (stackIndex !== null) {
+      i++;
+      stackIndex = stackTable.prefix[stackIndex];
+    }
+    return i;
+  });
+}
+
+/**
+ * Maps a thread's samples to whether a given funcIndex is in its stack.
+ */
+export function mapSamplesToHasFunc(
+  { samples, stackTable, frameTable }: Thread,
+  funcIndex: IndexIntoFuncTable
+): boolean[] {
+  return samples.stack.map(stackIndexIn => {
+    let stackIndex = stackIndexIn;
+    while (stackIndex !== null) {
+      const frameIndex = stackTable.frame[stackIndex];
+      if (frameTable.func[frameIndex] === funcIndex) {
+        return true;
+      }
+      stackIndex = stackTable.prefix[stackIndex];
+    }
+    return false;
+  });
+}
+
+export function getFuncIndexByName(thread: Thread, name: string) {
+  return thread.funcTable.name.indexOf(thread.stringTable.indexForString(name));
+}
+
+export function stackIsJS(thread: Thread, stackIndex: IndexIntoStackTable) {
+  const frameIndex = thread.stackTable.frame[stackIndex];
+  const funcIndex = thread.frameTable.func[frameIndex];
+  return thread.funcTable.isJS[funcIndex];
+}

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -27,6 +27,7 @@ export type PostfixCallTreeFilter = {
 };
 export type CallTreeFilter = PrefixCallTreeFilter | PostfixCallTreeFilter;
 export type CallTreeFiltersPerThread = { [id: ThreadIndex]: CallTreeFilter[] };
+export type FuncsPerThread = { [id: ThreadIndex]: IndexIntoFuncTable[] };
 export type DataSource =
   | 'none'
   | 'from-file'
@@ -168,7 +169,28 @@ type URLStateAction =
       implementation: ImplementationFilter,
     }
   | { type: 'CHANGE_INVERT_CALLSTACK', invertCallstack: boolean }
-  | { type: 'CHANGE_HIDE_PLATFORM_DETAILS', hidePlatformDetails: boolean };
+  | { type: 'CHANGE_HIDE_PLATFORM_DETAILS', hidePlatformDetails: boolean }
+  | { type: 'CHANGE_HIDE_PLATFORM_DETAILS', hidePlatformDetails: boolean }
+  | {
+      type: 'MERGE_FUNCTION',
+      funcIndex: IndexIntoFuncTable,
+      threadIndex: ThreadIndex,
+    }
+  | {
+      type: 'UNMERGE_FUNCTION',
+      funcIndex: IndexIntoFuncTable,
+      threadIndex: ThreadIndex,
+    }
+  | {
+      type: 'MERGE_SUBTREE',
+      funcIndex: IndexIntoFuncTable,
+      threadIndex: ThreadIndex,
+    }
+  | {
+      type: 'UNMERGE_SUBTREE',
+      funcIndex: IndexIntoFuncTable,
+      threadIndex: ThreadIndex,
+    };
 
 type IconsAction =
   | { type: 'ICON_HAS_LOADED', icon: string }

--- a/src/types/reducers.js
+++ b/src/types/reducers.js
@@ -9,6 +9,7 @@ import type {
   Action,
   ExpandedSet,
   CallTreeFiltersPerThread,
+  FuncsPerThread,
   DataSource,
   ProfileSelection,
   ImplementationFilter,
@@ -26,6 +27,10 @@ import type { GetCategory } from '../profile-logic/color-categories';
 
 export type Reducer<T> = (T, Action) => T;
 
+export type LastAddedFilter = null | {
+  threadIndex: ThreadIndex,
+  funcIndex: IndexIntoFuncTable,
+};
 export type RequestedLib = { debugName: string, breakpadId: string };
 export type SymbolicationStatus = 'DONE' | 'SYMBOLICATING';
 export type ThreadViewOptions = {
@@ -45,6 +50,7 @@ export type ProfileViewState = {
     tabOrder: number[],
   },
   profile: Profile,
+  lastAddedFilter: LastAddedFilter | null,
 };
 
 export type AppViewState =
@@ -84,6 +90,8 @@ export type URLState = {
   hidePlatformDetails: boolean,
   threadOrder: ThreadIndex[],
   hiddenThreads: ThreadIndex[],
+  mergeFunctions: FuncsPerThread,
+  mergeSubtree: FuncsPerThread,
 };
 
 export type IconState = Set<string>;


### PR DESCRIPTION
This is a UI prototype for filtering. This will provide UI for issues #244 and issue #242.

<img width="653" alt="image" src="https://cloud.githubusercontent.com/assets/1588648/25595871/18856ca2-2e8c-11e7-8777-45afdcd61638.png">

<img width="508" alt="image" src="https://cloud.githubusercontent.com/assets/1588648/25595896/33388160-2e8c-11e7-8c7a-716245646e8d.png">

I'd like to place this UI in a button that opens up, with possibly a text label that goes with it. The placement is arbitrary at this point and probably needs to be adjusted a bit. The button is the same filtering button used throughout all of devtools.

I also tried to find less technical words to describe what was going on, while not sacrificing on the technical accuracy of the filtering operation. The filter panel and the context menu can grow and change with any additional features we wish to add.

I would appreciate any feedback before I started working on the filtering logic part of this.
@bzbarsky @mstange @julienw @ehsan