### PR TITLE
Make components pure

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "react": "^15.4.1",
     "react-addons-css-transition-group": "^15.4.2",
     "react-addons-perf": "^15.4.1",
-    "react-addons-shallow-compare": "^15.4.1",
     "react-contextmenu": "^2.3.1",
     "react-dom": "^15.4.1",
     "react-redux": "^4.4.2",

--- a/src/content/components/Draggable.js
+++ b/src/content/components/Draggable.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PureComponent, PropTypes } from 'react';
 
 /**
  * A component that reports mouse dragging (left mouse button only) in its
@@ -8,7 +8,7 @@ import React, { Component, PropTypes } from 'react';
  * x and y deltas compared to the mouse position at mousedown.
  * During the drag, the additional className 'dragging' is set on the element.
  */
-export default class Draggable extends Component {
+export default class Draggable extends PureComponent {
 
   constructor(props) {
     super(props);

--- a/src/content/components/FlameChartCanvas.js
+++ b/src/content/components/FlameChartCanvas.js
@@ -1,6 +1,5 @@
 // @flow
-import React, { Component } from 'react';
-import shallowCompare from 'react-addons-shallow-compare';
+import React, { PureComponent } from 'react';
 import { timeCode } from '../../common/time-code';
 import TextMeasurement from '../../common/text-measurement';
 import withTimelineViewport from './TimelineViewport';
@@ -34,7 +33,7 @@ const ROW_HEIGHT = 16;
 const TEXT_OFFSET_START = 3;
 const TEXT_OFFSET_TOP = 11;
 
-class FlameChartCanvas extends Component {
+class FlameChartCanvas extends PureComponent {
 
   _requestedAnimationFrame: boolean
   _devicePixelRatio: number
@@ -62,10 +61,6 @@ class FlameChartCanvas extends Component {
         }
       });
     }
-  }
-
-  shouldComponentUpdate(nextProps: Props) {
-    return shallowCompare(this, nextProps);
   }
 
   componentDidMount() {

--- a/src/content/components/FlameChartSettings.js
+++ b/src/content/components/FlameChartSettings.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PureComponent, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import actions from '../actions';
 import { getHidePlatformDetails, getInvertCallstack, getSearchString } from '../reducers/url-state';
@@ -6,7 +6,7 @@ import IdleSearchField from '../components/IdleSearchField';
 
 import './FlameChartSettings.css';
 
-class FlameChartSettings extends Component {
+class FlameChartSettings extends PureComponent {
   constructor(props) {
     super(props);
     this._onHidePlatformDetailsClick = this._onHidePlatformDetailsClick.bind(this);

--- a/src/content/components/IdleSearchField.js
+++ b/src/content/components/IdleSearchField.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { Component, PropTypes } from 'react';
+import React, { PureComponent, PropTypes } from 'react';
 import classNames from 'classnames';
 
 import './IdleSearchField.css';
@@ -12,7 +12,7 @@ type Props = {
   title: ?string,
 };
 
-class IdleSearchField extends Component {
+class IdleSearchField extends PureComponent {
   _onSearchFieldChange: Event => void;
   _onSearchFieldFocus: Event => void;
   _onClearButtonClick: Event => void;

--- a/src/content/components/Initializing.js
+++ b/src/content/components/Initializing.js
@@ -1,8 +1,8 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PureComponent, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import actions from '../actions';
 
-class Initializing extends Component {
+class Initializing extends PureComponent {
   render() {
     const {
       className, profilerUrl,

--- a/src/content/components/IntervalMarkerOverview.js
+++ b/src/content/components/IntervalMarkerOverview.js
@@ -1,6 +1,5 @@
 // @flow
 import React, { PureComponent } from 'react';
-import shallowCompare from 'react-addons-shallow-compare';
 import classNames from 'classnames';
 import { timeCode } from '../../common/time-code';
 import { withSize } from '../with-size';
@@ -135,10 +134,6 @@ class IntervalMarkerOverview extends PureComponent {
     this.setState({
       hoveredItem: null,
     });
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   render() {

--- a/src/content/components/OverflowEdgeIndicator.js
+++ b/src/content/components/OverflowEdgeIndicator.js
@@ -1,9 +1,9 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PureComponent, PropTypes } from 'react';
 import classNames from 'classnames';
 
 import './OverflowEdgeIndicator.css';
 
-class OverflowEdgeIndicator extends Component {
+class OverflowEdgeIndicator extends PureComponent {
   constructor(props) {
     super(props);
     this.state = {

--- a/src/content/components/ProfileCallTreeSettings.js
+++ b/src/content/components/ProfileCallTreeSettings.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PureComponent, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import actions from '../actions';
 import { getImplementationFilter, getInvertCallstack, getSearchString } from '../reducers/url-state';
@@ -6,7 +6,7 @@ import IdleSearchField from '../components/IdleSearchField';
 
 import './ProfileCallTreeSettings.css';
 
-class ProfileCallTreeSettings extends Component {
+class ProfileCallTreeSettings extends PureComponent {
   constructor(props) {
     super(props);
     this._onImplementationFilterChange = this._onImplementationFilterChange.bind(this);

--- a/src/content/components/ProfileThreadHeaderBar.js
+++ b/src/content/components/ProfileThreadHeaderBar.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PureComponent, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import ThreadStackGraph from './ThreadStackGraph';
 import { selectorsForThread } from '../reducers/profile-view';
@@ -7,7 +7,7 @@ import { getSampleIndexClosestToTime, getStackAsFuncArray } from '../profile-dat
 import actions from '../actions';
 import { ContextMenuTrigger } from 'react-contextmenu';
 
-class ProfileThreadHeaderBar extends Component {
+class ProfileThreadHeaderBar extends PureComponent {
 
   constructor(props) {
     super(props);

--- a/src/content/components/ProfileTreeView.js
+++ b/src/content/components/ProfileTreeView.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PureComponent, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import TreeView from './TreeView';
 import NodeIcon from './NodeIcon';
@@ -11,7 +11,7 @@ import { getIconsWithClassNames } from '../reducers/icons';
 
 import actions from '../actions';
 
-class ProfileTreeView extends Component {
+class ProfileTreeView extends PureComponent {
   constructor(props) {
     super(props);
     this._fixedColumns = [

--- a/src/content/components/ProfileViewer.js
+++ b/src/content/components/ProfileViewer.js
@@ -58,9 +58,9 @@ class ProfileViewer extends PureComponent {
 
   render() {
     const {
-      className, viewOptions, timeRange, changeTabOrder, selectedTab,
+      className, tabOrder, timeRange, changeTabOrder, selectedTab,
     } = this.props;
-    const { tabOrder } = viewOptions;
+
     return (
       <div className={className}>
         <div className={`${className}TopBar`}>
@@ -91,7 +91,7 @@ class ProfileViewer extends PureComponent {
 
 ProfileViewer.propTypes = {
   className: PropTypes.string.isRequired,
-  viewOptions: PropTypes.object.isRequired,
+  tabOrder: PropTypes.arrayOf(PropTypes.number).isRequired,
   timeRange: PropTypes.object.isRequired,
   selectedTab: PropTypes.string.isRequired,
   changeSelectedTab: PropTypes.func.isRequired,
@@ -99,7 +99,7 @@ ProfileViewer.propTypes = {
 };
 
 export default connect(state => ({
-  viewOptions: getProfileViewOptions(state),
+  tabOrder: getProfileViewOptions(state).tabOrder,
   selectedTab: getSelectedTab(state),
   className: 'profileViewer',
   timeRange: getDisplayRange(state),

--- a/src/content/components/SelectionScrubberOverlay.js
+++ b/src/content/components/SelectionScrubberOverlay.js
@@ -1,9 +1,9 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PureComponent, PropTypes } from 'react';
 import classNames from 'classnames';
 import clamp from 'clamp';
 import Draggable from './Draggable';
 
-export default class SelectionScubberOverlay extends Component {
+export default class SelectionScubberOverlay extends PureComponent {
   constructor(props) {
     super(props);
 

--- a/src/content/components/SummarizeLineGraph.js
+++ b/src/content/components/SummarizeLineGraph.js
@@ -1,10 +1,10 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PureComponent, PropTypes } from 'react';
 
 const HEIGHT = 30;
 const STROKE = 3;
 const HALF_STROKE = STROKE / 2;
 
-class SummarizeLineGraph extends Component {
+class SummarizeLineGraph extends PureComponent {
   componentDidMount() {
     const resize = () => this.updateWidth();
     window.addEventListener('resize', resize);

--- a/src/content/components/SummarizeProfileExpand.js
+++ b/src/content/components/SummarizeProfileExpand.js
@@ -1,7 +1,7 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PureComponent, PropTypes } from 'react';
 import SummarizeLineGraph from './SummarizeLineGraph';
 
-class SummarizeProfileExpand extends Component {
+class SummarizeProfileExpand extends PureComponent {
   render() {
     const {summary, threadIndex, isExpanded, expand, collapse, expandLength} = this.props;
     // Only show the expand/collapse button when it is warranted.

--- a/src/content/components/SummarizeProfileHeader.js
+++ b/src/content/components/SummarizeProfileHeader.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PureComponent, PropTypes } from 'react';
 
 const LINE_GRAPH_TITLE = 'The line graph represents the number of samples that were in ' +
   'a given category over time. In order to present a high-level summary, the samples ' +
@@ -11,7 +11,7 @@ const PERCENT_TIME_TITLE = 'The percentage of time represents the percentage of 
   'many samples of a given category were observed over the entire course of the ' +
   'recording.';
 
-class SummarizeProfileHeader extends Component {
+class SummarizeProfileHeader extends PureComponent {
   render() {
     const { threadName, processType } = this.props;
     return (

--- a/src/content/components/SummarizeProfileThread.js
+++ b/src/content/components/SummarizeProfileThread.js
@@ -1,7 +1,7 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PureComponent, PropTypes } from 'react';
 import SummarizeLineGraph from './SummarizeLineGraph';
 
-class SummarizeProfileThread extends Component {
+class SummarizeProfileThread extends PureComponent {
   render() {
     const {summaryTable, rollingSummary, isExpanded, index, expandLength} = this.props;
     if (index > expandLength && !isExpanded) {

--- a/src/content/components/ThreadMarkerOverlay.js
+++ b/src/content/components/ThreadMarkerOverlay.js
@@ -1,9 +1,8 @@
-import React, { Component, PropTypes } from 'react';
-import shallowCompare from 'react-addons-shallow-compare';
+import React, { PureComponent, PropTypes } from 'react';
 
 import './ThreadMarkerOverlay.css';
 
-class ThreadMarkerOverlay extends Component {
+class ThreadMarkerOverlay extends PureComponent {
 
   constructor(props) {
     super(props);
@@ -15,10 +14,6 @@ class ThreadMarkerOverlay extends Component {
       return;
     }
     this.props.onSelectMarker(+e.target.dataset.index);
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   render() {

--- a/src/content/components/ThreadStackGraph.js
+++ b/src/content/components/ThreadStackGraph.js
@@ -1,10 +1,9 @@
-import React, { Component, PropTypes } from 'react';
-import shallowCompare from 'react-addons-shallow-compare';
+import React, { PureComponent, PropTypes } from 'react';
 import classNames from 'classnames';
 import { timeCode } from '../../common/time-code';
 import { getSampleFuncStacks } from '../profile-data';
 
-class ThreadStackGraph extends Component {
+class ThreadStackGraph extends PureComponent {
 
   constructor(props) {
     super(props);
@@ -26,10 +25,6 @@ class ThreadStackGraph extends Component {
         }
       });
     }
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   componentDidMount() {

--- a/src/content/components/TimeRuler.js
+++ b/src/content/components/TimeRuler.js
@@ -1,6 +1,6 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PureComponent, PropTypes } from 'react';
 
-class TimeRuler extends Component {
+class TimeRuler extends PureComponent {
 
   _findNiceNumberGreaterOrEqualTo(uglyNumber) {
     // Write uglyNumber as a * 10^b, with 1 <= a < 10.

--- a/src/content/components/TreeView.js
+++ b/src/content/components/TreeView.js
@@ -1,5 +1,4 @@
-import React, { Component, PropTypes } from 'react';
-import shallowCompare from 'react-addons-shallow-compare';
+import React, { PureComponent, PropTypes } from 'react';
 import classNames from 'classnames';
 import VirtualList from './VirtualList';
 import { BackgroundImageStyleDef } from './StyleDef';
@@ -51,15 +50,11 @@ function reactStringWithHighlightedSubstrings(string, substring, className) {
   return result;
 }
 
-class TreeViewRowFixedColumns extends Component {
+class TreeViewRowFixedColumns extends PureComponent {
 
   constructor(props) {
     super(props);
     this._onClick = this._onClick.bind(this);
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   _onClick(event) {
@@ -105,15 +100,11 @@ TreeViewRowFixedColumns.propTypes = {
   highlightString: PropTypes.string,
 };
 
-class TreeViewRowScrolledColumns extends Component {
+class TreeViewRowScrolledColumns extends PureComponent {
 
   constructor(props) {
     super(props);
     this._onClick = this._onClick.bind(this);
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   _onClick(event) {
@@ -185,7 +176,7 @@ TreeViewRowScrolledColumns.propTypes = {
   highlightString: PropTypes.string,
 };
 
-class TreeView extends Component {
+class TreeView extends PureComponent {
 
   constructor(props) {
     super(props);
@@ -206,10 +197,6 @@ class TreeView extends Component {
       this.refs.list.scrollItemIntoView(rowIndex, depth * 10);
     }
 
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/content/components/VirtualList.js
+++ b/src/content/components/VirtualList.js
@@ -1,12 +1,8 @@
-import React, { Component, PropTypes } from 'react';
-import shallowCompare from 'react-addons-shallow-compare';
+import React, { PureComponent, PropTypes } from 'react';
 import classNames from 'classnames';
 import range from 'array-range';
 
-class VirtualListRow extends Component {
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
-  }
+class VirtualListRow extends PureComponent {
 
   render() {
     const { renderItem, item, index, columnIndex } = this.props;
@@ -22,11 +18,7 @@ VirtualListRow.propTypes = {
   isSpecial: PropTypes.bool,
 };
 
-class VirtualListInnerChunk extends Component {
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
-  }
-
+class VirtualListInnerChunk extends PureComponent {
   render() {
     const { className, renderItem, items, specialItems, visibleRangeStart, visibleRangeEnd, columnIndex } = this.props;
 
@@ -61,14 +53,10 @@ VirtualListInnerChunk.propTypes = {
   columnIndex: PropTypes.number.isRequired,
 };
 
-class VirtualListInner extends Component {
+class VirtualListInner extends PureComponent {
   constructor(props) {
     super(props);
     this._containerCreated = e => { this._container = e; };
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   getBoundingClientRect() {
@@ -126,7 +114,7 @@ VirtualListInner.propTypes = {
   columnIndex: PropTypes.number.isRequired,
 };
 
-class VirtualList extends Component {
+class VirtualList extends PureComponent {
 
   constructor(props) {
     super(props);
@@ -146,10 +134,6 @@ class VirtualList extends Component {
   componentWillUnmount() {
     document.removeEventListener('copy', this._onCopy, false);
     this._container.removeEventListener('scroll', this._onScroll);
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   _onScroll() {

--- a/src/content/containers/ProfileLogView.js
+++ b/src/content/containers/ProfileLogView.js
@@ -1,9 +1,9 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PureComponent, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { selectedThreadSelectors } from '../reducers/profile-view';
 import actions from '../actions';
 
-class ProfileLogView extends Component {
+class ProfileLogView extends PureComponent {
   render() {
     const { thread } = this.props;
     const { markers, stringTable } = thread;

--- a/src/content/containers/ProfileMarkersView.js
+++ b/src/content/containers/ProfileMarkersView.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PureComponent, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import TreeView from '../components/TreeView';
 import { getZeroAt, selectedThreadSelectors } from '../reducers/profile-view';
@@ -79,7 +79,7 @@ class MarkerTree {
   }
 }
 
-class ProfileMarkersView extends Component {
+class ProfileMarkersView extends PureComponent {
   constructor(props) {
     super(props);
     this._fixedColumns = [

--- a/src/content/containers/ProfileSharing.js
+++ b/src/content/containers/ProfileSharing.js
@@ -1,7 +1,7 @@
 import React, { PureComponent, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { getProfile, getProfileViewOptions } from '../reducers/profile-view';
+import { getProfile, getProfileRootRange } from '../reducers/profile-view';
 import { getDataSource, getHash, getURLPredictor } from '../reducers/url-state';
 import actions from '../actions';
 import { compress } from '../gz';
@@ -240,8 +240,8 @@ class ProfileDownloadButton extends PureComponent {
   }
 
   _onPanelOpen() {
-    const { profile, viewOptions } = this.props;
-    const profileDate = new Date(profile.meta.startTime + viewOptions.rootRange.start);
+    const { profile, rootRange } = this.props;
+    const profileDate = new Date(profile.meta.startTime + rootRange.start);
     const serializedProfile = serializeProfile(profile);
     const blob = new Blob([serializedProfile], { type: 'application/octet-binary' });
     const blobURL = URL.createObjectURL(blob);
@@ -300,23 +300,23 @@ class ProfileDownloadButton extends PureComponent {
 
 ProfileDownloadButton.propTypes = {
   profile: PropTypes.object,
-  viewOptions: PropTypes.object,
+  rootRange: PropTypes.object,
 };
 
-const ProfileSharing = ({ profile, viewOptions, dataSource, hash, profilePublished, predictURL }) => (
+const ProfileSharing = ({ profile, rootRange, dataSource, hash, profilePublished, predictURL }) => (
   <div className='profileSharing'>
     <ProfileSharingCompositeButton profile={profile}
                                    dataSource={dataSource}
                                    hash={hash}
                                    onProfilePublished={profilePublished}
                                    predictURL={predictURL}/>
-    <ProfileDownloadButton profile={profile} viewOptions={viewOptions}/>
+    <ProfileDownloadButton profile={profile} rootRange={rootRange}/>
   </div>
 );
 
 ProfileSharing.propTypes = {
   profile: PropTypes.object,
-  viewOptions: PropTypes.object,
+  rootRange: PropTypes.object,
   dataSource: PropTypes.string.isRequired,
   hash: PropTypes.string,
   profilePublished: PropTypes.func.isRequired,
@@ -325,7 +325,7 @@ ProfileSharing.propTypes = {
 
 export default connect(state => ({
   profile: getProfile(state),
-  viewOptions: getProfileViewOptions(state),
+  rootRange: getProfileRootRange(state),
   dataSource: getDataSource(state),
   hash: getHash(state),
   predictURL: getURLPredictor(state),

--- a/src/content/containers/ProfileSummaryView.js
+++ b/src/content/containers/ProfileSummaryView.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PureComponent, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { getProfile } from '../reducers/profile-view';
 import { getProfileSummaries, getProfileExpandedSummaries } from '../reducers/summary-view';
@@ -12,7 +12,7 @@ require('./ProfileSummaryView.css');
 
 const EXPAND_LENGTH = 5;
 
-class ProfileSummaryView extends Component {
+class ProfileSummaryView extends PureComponent {
   render() {
     const {
       summaries, expanded, threads,

--- a/src/content/containers/ProfileTaskTracerView.js
+++ b/src/content/containers/ProfileTaskTracerView.js
@@ -1,10 +1,10 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PureComponent, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import actions from '../actions';
 import { getTasksByThread, getProfileTaskTracerData } from '../reducers/profile-view';
 import { withSize } from '../with-size';
 
-class ThreadTaskTracerTracksImpl extends Component {
+class ThreadTaskTracerTracksImpl extends PureComponent {
   render() {
     const { tasks, tasktracer, rangeStart, rangeEnd, width } = this.props;
     const { taskTable, stringTable, addressTable } = tasktracer;
@@ -82,7 +82,7 @@ ThreadTaskTracerTracksImpl.propTypes = {
 
 const ThreadTaskTracerTracks = withSize(ThreadTaskTracerTracksImpl);
 
-class ThreadTaskTracerView extends Component {
+class ThreadTaskTracerView extends PureComponent {
   render() {
     const { name, tasks, tasktracer, rangeStart, rangeEnd } = this.props;
     if (tasks.length === 0) {
@@ -105,7 +105,7 @@ ThreadTaskTracerView.propTypes = {
   rangeEnd: PropTypes.number.isRequired,
 };
 
-class ProfileTaskTracerView extends Component {
+class ProfileTaskTracerView extends PureComponent {
   render() {
     const { tasktracer, tasksByThread, rangeStart, rangeEnd } = this.props;
     const { threadTable, stringTable } = tasktracer;

--- a/src/content/containers/ProfileUploadField.js
+++ b/src/content/containers/ProfileUploadField.js
@@ -1,8 +1,8 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PureComponent, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import actions from '../actions';
 
-class ProfileUploadField extends Component {
+class ProfileUploadField extends PureComponent {
   constructor(props) {
     super(props);
     this._onInputChange = this._onInputChange.bind(this);

--- a/src/content/containers/Root.js
+++ b/src/content/containers/Root.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PureComponent, PropTypes } from 'react';
 import { connect, Provider } from 'react-redux';
 import actions from '../actions';
 import ProfileViewer from '../components/ProfileViewer';
@@ -35,7 +35,7 @@ type ProfileViewProps = {
   retrieveProfileFromWeb: string => void,
 };
 
-class ProfileViewWhenReadyImpl extends Component {
+class ProfileViewWhenReadyImpl extends PureComponent {
   props: ProfileViewProps;
 
   componentDidMount() {
@@ -110,7 +110,7 @@ type RootProps = {
   store: Store<State, Action>,
 };
 
-export default class Root extends Component {
+export default class Root extends PureComponent {
   props: RootProps;
 
   render() {

--- a/src/content/containers/TimelineFlameChart.js
+++ b/src/content/containers/TimelineFlameChart.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import FlameChartCanvas from '../components/FlameChartCanvas';
 import { selectorsForThread, getDisplayRange, getProfileInterval, getProfileViewOptions } from '../reducers/profile-view';
@@ -43,7 +43,7 @@ type Props = {
   processDetails: string,
 };
 
-class TimelineFlameChart extends Component {
+class TimelineFlameChart extends PureComponent {
 
   props: Props
 

--- a/src/content/containers/TimelineView.js
+++ b/src/content/containers/TimelineView.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { getThreads, getThreadOrder } from '../reducers/profile-view';
 import actions from '../actions';
@@ -19,7 +19,7 @@ type Props = {
   changeThreadOrder: any => any,
 };
 
-class TimlineViewTimelinesImpl extends Component {
+class TimlineViewTimelinesImpl extends PureComponent {
 
   props: Props
 
@@ -63,7 +63,7 @@ class TimlineViewTimelinesImpl extends Component {
 
 const TimelineViewTimelines = withSize(TimlineViewTimelinesImpl);
 
-class TimelineView extends Component {
+class TimelineView extends PureComponent {
 
   props: {
     threads: Thread[],

--- a/src/content/containers/URLManager.js
+++ b/src/content/containers/URLManager.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { Component, PropTypes } from 'react';
+import React, { PureComponent, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { getIsURLSetupDone } from '../reducers/app';
 
@@ -17,7 +17,7 @@ type Props = {
   show404: string => void,
 };
 
-class URLManager extends Component {
+class URLManager extends PureComponent {
   props: Props;
 
   _updateState() {

--- a/src/content/reducers/profile-view.js
+++ b/src/content/reducers/profile-view.js
@@ -300,6 +300,7 @@ export const getProfileView = (state: State): ProfileViewState => state.profileV
  * Profile View Options
  */
 export const getProfileViewOptions = (state: State) => getProfileView(state).viewOptions;
+export const getProfileRootRange = (state: State) => getProfileViewOptions(state).rootRange;
 
 export const getScrollToSelectionGeneration = createSelector(
   getProfileViewOptions,


### PR DESCRIPTION
I removed all instance of Component and moved to PureComponent to help with minimizing component updates.

The second commit makes viewOptions not trigger unwanted updates when a value inside of it changes, in order to wrk with PureComponents.