### PR TITLE
Added license headers to all source files

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ Say hello on [slack] in the #perf channel.
 
 [MPL v2](./LICENSE)
 
+### Optional Notices
+
+Some permissive software licenses request but do not require an acknowledgement of the use of their software. We are very grateful to the following people and projects for their contributions to this product:
+
+* The [zlib] compression library (Jean-loup Gailly, Mark Adler and team)
+
 [slack-badge]: https://devtools-html-slack.herokuapp.com/badge.svg
 [slack]: https://devtools-html-slack.herokuapp.com/
 
@@ -60,3 +66,4 @@ Say hello on [slack] in the #perf channel.
 [Firefox]:https://www.mozilla.org/firefox/
 [Cleopatra]: https://github.com/mozilla/cleopatra
 [Gecko Profiler]: https://github.com/devtools-html/Gecko-Profiler-Addon
+[zlib]: http://www.zlib.net/

--- a/flow-typed/overrides/Image.js
+++ b/flow-typed/overrides/Image.js
@@ -1,4 +1,8 @@
- declare class Image extends HTMLImageElement {
-   constructor(width?: number, height?: number): void;
-   referrerPolicy: ReferrerPolicyType;
- }
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+declare class Image extends HTMLImageElement {
+  constructor(width?: number, height?: number): void;
+  referrerPolicy: ReferrerPolicyType;
+}

--- a/flow-typed/overrides/WheelEvent.js
+++ b/flow-typed/overrides/WheelEvent.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 declare class WheelEvent extends MouseEvent {
   deltaX: number; // readonly
   deltaY: number; // readonly

--- a/res/.htaccess
+++ b/res/.htaccess
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 RewriteEngine On
 
 # Redirect requests from www.perf-html.io to perf-html.io

--- a/res/circlearrow.svg
+++ b/res/circlearrow.svg
@@ -1,3 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <svg  xmlns="http://www.w3.org/2000/svg"
       xmlns:xlink="http://www.w3.org/1999/xlink"
       width="64" height="16" viewBox="0 0 64 16">

--- a/res/index.html
+++ b/res/index.html
@@ -1,3 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/res/scope-bar-separator.svg
+++ b/res/scope-bar-separator.svg
@@ -1,3 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <svg  xmlns="http://www.w3.org/2000/svg"
       xmlns:xlink="http://www.w3.org/1999/xlink"
       width="48" height="48" viewBox="0 0 24 24">

--- a/res/shadowfilter.svg
+++ b/res/shadowfilter.svg
@@ -1,3 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <svg xmlns="http://www.w3.org/2000/svg">
   <defs>
     <filter id="menushadow" color-interpolation-filters="sRGB" x="-10" y="-10" width="30" height="30">

--- a/res/style.css
+++ b/res/style.css
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 html, body {
   margin: 0;
   padding: 0;

--- a/res/treetwisty.svg
+++ b/res/treetwisty.svg
@@ -1,3 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <svg  xmlns="http://www.w3.org/2000/svg"
       xmlns:xlink="http://www.w3.org/1999/xlink"
       width="64" height="32" viewBox="0 0 64 32">

--- a/res/zee-worker.js
+++ b/res/zee-worker.js
@@ -1,4 +1,3 @@
-
 // zee.js: zlib compiled to js
 
 var Zee = (function() {

--- a/res/zoom-icon.svg
+++ b/res/zoom-icon.svg
@@ -1,3 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <svg  xmlns="http://www.w3.org/2000/svg"
       xmlns:xlink="http://www.w3.org/1999/xlink"
       width="20" height="20" viewBox="0 0 80 80">

--- a/src/common/message-handler.js
+++ b/src/common/message-handler.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 export default function createMessageHandler(thread, store, handlers) {
   function call(fn, ...args) {
     store.dispatch(fn(...args));

--- a/src/common/summarize-profile.js
+++ b/src/common/summarize-profile.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import { timeCode } from './time-code';
 import type { Profile, Thread, IndexIntoStackTable } from './types/profile';

--- a/src/common/text-measurement.js
+++ b/src/common/text-measurement.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 
 /**

--- a/src/common/thread-middleware.js
+++ b/src/common/thread-middleware.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /**
  * Create a middleware that allows for dispatching actions between threads. This
  * inspects each action, hijacks it if it has a certain key, and then uses postMessage

--- a/src/common/time-code.js
+++ b/src/common/time-code.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 
 export function timeCode(label: string, codeAsACallback: any => any): any {

--- a/src/common/types/profile-derived.js
+++ b/src/common/types/profile-derived.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import type { Milliseconds } from './units';
 import type { MarkerPayload } from './profile';

--- a/src/common/types/profile.js
+++ b/src/common/types/profile.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 
 import type { Milliseconds } from './units';

--- a/src/common/types/units.js
+++ b/src/common/types/units.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 export type Milliseconds = number;
 
 /**

--- a/src/content/actions/app.js
+++ b/src/content/actions/app.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import type { Action } from './types';
 

--- a/src/content/actions/icons.js
+++ b/src/content/actions/icons.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import type { Action, ThunkAction } from './types';
 

--- a/src/content/actions/index.js
+++ b/src/content/actions/index.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import * as app from './app';
 import * as icons from './icons';

--- a/src/content/actions/profile-summary.js
+++ b/src/content/actions/profile-summary.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import type { Action } from './types';
 import type { Summary } from '../../common/summarize-profile';

--- a/src/content/actions/profile-view.js
+++ b/src/content/actions/profile-view.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import type {
   Action, ThunkAction, ProfileSelection, CallTreeFilter, ImplementationFilter,

--- a/src/content/actions/receive-profile.js
+++ b/src/content/actions/receive-profile.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import { oneLine } from 'common-tags';
 import { getProfile } from '../reducers/profile-view';

--- a/src/content/actions/timeline.js
+++ b/src/content/actions/timeline.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import type { Action } from './types';
 import type { GetLabel } from '../labeling-strategies';

--- a/src/content/actions/types.js
+++ b/src/content/actions/types.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import type { Summary } from '../../common/summarize-profile';
 import type { Profile, Thread, ThreadIndex, IndexIntoMarkersTable, IndexIntoFuncTable } from '../../common/types/profile';

--- a/src/content/async-storage.js
+++ b/src/content/async-storage.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /**
  *
  * Adapted from https://hg.mozilla.org/mozilla-central/file/a77b73c7723e1060993045fb31eb2f0a30473486/devtools/shared/async-storage.js

--- a/src/content/call-tree-filters.js
+++ b/src/content/call-tree-filters.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { uintArrayToString, stringToUintArray } from './uintarray-encoding';
 
 export function parseCallTreeFilters(stringValue = '') {

--- a/src/content/color-categories.js
+++ b/src/content/color-categories.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import type { Thread, IndexIntoFrameTable, IndexIntoStackTable } from '../common/types/profile';
 

--- a/src/content/components/ArrowPanel.css
+++ b/src/content/components/ArrowPanel.css
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 .arrowPanelAnchor {
   position: absolute;
   z-index: 10;

--- a/src/content/components/ArrowPanel.js
+++ b/src/content/components/ArrowPanel.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 import classNames from 'classnames';
 

--- a/src/content/components/ButtonWithPanel.css
+++ b/src/content/components/ButtonWithPanel.css
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 .buttonWithPanel {
   display: flex;
   flex-flow: column nowrap;

--- a/src/content/components/ButtonWithPanel.js
+++ b/src/content/components/ButtonWithPanel.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 import classNames from 'classnames';
 

--- a/src/content/components/Draggable.js
+++ b/src/content/components/Draggable.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 
 /**

--- a/src/content/components/FilterNavigatorBar.css
+++ b/src/content/components/FilterNavigatorBar.css
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 .filterNavigatorBar {
   --internal-selected-color: var(--selected-color, #7990c8);
   height: 24px;

--- a/src/content/components/FilterNavigatorBar.js
+++ b/src/content/components/FilterNavigatorBar.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 import classNames from 'classnames';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';

--- a/src/content/components/FlameChartCanvas.css
+++ b/src/content/components/FlameChartCanvas.css
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 .flameChartCanvas {
   position: absolute;
   top: 0;

--- a/src/content/components/FlameChartCanvas.js
+++ b/src/content/components/FlameChartCanvas.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import React, { PureComponent } from 'react';
 import TextMeasurement from '../../common/text-measurement';

--- a/src/content/components/FlameChartSettings.css
+++ b/src/content/components/FlameChartSettings.css
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 .flameChartSettings {
   height: 25px;
   padding: 0;

--- a/src/content/components/FlameChartSettings.js
+++ b/src/content/components/FlameChartSettings.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import actions from '../actions';

--- a/src/content/components/IdleSearchField.css
+++ b/src/content/components/IdleSearchField.css
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 .idleSearchField {
   display: inline-flex;
   flex-flow: row nowrap;

--- a/src/content/components/IdleSearchField.js
+++ b/src/content/components/IdleSearchField.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import React, { PureComponent, PropTypes } from 'react';
 import classNames from 'classnames';

--- a/src/content/components/Initializing.js
+++ b/src/content/components/Initializing.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import actions from '../actions';

--- a/src/content/components/IntervalMarkerOverview.js
+++ b/src/content/components/IntervalMarkerOverview.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import React, { PureComponent } from 'react';
 import classNames from 'classnames';

--- a/src/content/components/NodeIcon.js
+++ b/src/content/components/NodeIcon.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 import { connect } from 'react-redux';
 

--- a/src/content/components/OverflowEdgeIndicator.css
+++ b/src/content/components/OverflowEdgeIndicator.css
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 .overflowEdgeIndicator {
   position: relative;
 }

--- a/src/content/components/OverflowEdgeIndicator.js
+++ b/src/content/components/OverflowEdgeIndicator.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 import classNames from 'classnames';
 

--- a/src/content/components/ProfileCallTreeSettings.css
+++ b/src/content/components/ProfileCallTreeSettings.css
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 .profileCallTreeSettings {
   height: 25px;
   padding: 0;

--- a/src/content/components/ProfileCallTreeSettings.js
+++ b/src/content/components/ProfileCallTreeSettings.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import actions from '../actions';

--- a/src/content/components/ProfileThreadHeaderBar.js
+++ b/src/content/components/ProfileThreadHeaderBar.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import ThreadStackGraph from './ThreadStackGraph';

--- a/src/content/components/ProfileTreeView.js
+++ b/src/content/components/ProfileTreeView.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import TreeView from './TreeView';

--- a/src/content/components/ProfileViewer.js
+++ b/src/content/components/ProfileViewer.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import TabBar from '../components/TabBar';

--- a/src/content/components/Reorderable.js
+++ b/src/content/components/Reorderable.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 import bisection from 'bisection';
 import clamp from 'clamp';

--- a/src/content/components/SelectionScrubberOverlay.js
+++ b/src/content/components/SelectionScrubberOverlay.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 import classNames from 'classnames';
 import clamp from 'clamp';

--- a/src/content/components/StyleDef.js
+++ b/src/content/components/StyleDef.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // inspired from https://gist.github.com/jviereck/9a71734afcfe848ddbe2 -- simplified
 //
 // Because JSX isn't nice with CSS content because of the braces, we use a

--- a/src/content/components/SummarizeLineGraph.js
+++ b/src/content/components/SummarizeLineGraph.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 
 const HEIGHT = 30;

--- a/src/content/components/SummarizeProfileExpand.js
+++ b/src/content/components/SummarizeProfileExpand.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 import SummarizeLineGraph from './SummarizeLineGraph';
 

--- a/src/content/components/SummarizeProfileHeader.js
+++ b/src/content/components/SummarizeProfileHeader.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 
 const LINE_GRAPH_TITLE = 'The line graph represents the number of samples that were in ' +

--- a/src/content/components/SummarizeProfileThread.js
+++ b/src/content/components/SummarizeProfileThread.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 import SummarizeLineGraph from './SummarizeLineGraph';
 

--- a/src/content/components/TabBar.js
+++ b/src/content/components/TabBar.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 import classNames from 'classnames';
 import Reorderable from './Reorderable';

--- a/src/content/components/ThreadMarkerOverlay.css
+++ b/src/content/components/ThreadMarkerOverlay.css
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 .threadMarkerOverlay {
   position: absolute;
   top: 0;

--- a/src/content/components/ThreadMarkerOverlay.js
+++ b/src/content/components/ThreadMarkerOverlay.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 
 import './ThreadMarkerOverlay.css';

--- a/src/content/components/ThreadStackGraph.js
+++ b/src/content/components/ThreadStackGraph.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 import classNames from 'classnames';
 import { timeCode } from '../../common/time-code';

--- a/src/content/components/TimeRuler.js
+++ b/src/content/components/TimeRuler.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 
 class TimeRuler extends PureComponent {

--- a/src/content/components/TimeSelectionScrubber.js
+++ b/src/content/components/TimeSelectionScrubber.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 import TimeRuler from './TimeRuler';
 import SelectionScrubberOverlay from './SelectionScrubberOverlay';

--- a/src/content/components/TimelineViewport.css
+++ b/src/content/components/TimelineViewport.css
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 .timelineViewport {
   flex: 1;
   position: relative;

--- a/src/content/components/TimelineViewport.js
+++ b/src/content/components/TimelineViewport.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import React, { PureComponent } from 'react';
 import classNames from 'classnames';

--- a/src/content/components/TreeView.js
+++ b/src/content/components/TreeView.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 import classNames from 'classnames';
 import VirtualList from './VirtualList';

--- a/src/content/components/VirtualList.js
+++ b/src/content/components/VirtualList.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 import classNames from 'classnames';
 import range from 'array-range';

--- a/src/content/containers/Home.css
+++ b/src/content/containers/Home.css
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 .home {
   min-height: 100vh;
   display: flex;

--- a/src/content/containers/Home.js
+++ b/src/content/containers/Home.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import ProfileUploadField from './ProfileUploadField';

--- a/src/content/containers/ProfileCallTreeContextMenu.js
+++ b/src/content/containers/ProfileCallTreeContextMenu.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import React, { PureComponent } from 'react';
 import { ContextMenu, MenuItem, SubMenu } from 'react-contextmenu';

--- a/src/content/containers/ProfileCallTreeFilterNavigator.css
+++ b/src/content/containers/ProfileCallTreeFilterNavigator.css
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 .profileCallTreeFilterNavigator {
   border-top: 1px solid #D6D6D6;
   background: #EEE;

--- a/src/content/containers/ProfileCallTreeFilterNavigator.js
+++ b/src/content/containers/ProfileCallTreeFilterNavigator.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { connect } from 'react-redux';
 import actions from '../actions';
 import { selectedThreadSelectors } from '../reducers/profile-view';

--- a/src/content/containers/ProfileCallTreeView.js
+++ b/src/content/containers/ProfileCallTreeView.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React from 'react';
 import ProfileTreeView from '../components/ProfileTreeView';
 import ProfileCallTreeSettings from '../components/ProfileCallTreeSettings';

--- a/src/content/containers/ProfileFilterNavigator.js
+++ b/src/content/containers/ProfileFilterNavigator.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { connect } from 'react-redux';
 import actions from '../actions';
 import { getRangeFilterLabels } from '../reducers/url-state';

--- a/src/content/containers/ProfileLogView.js
+++ b/src/content/containers/ProfileLogView.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { selectedThreadSelectors } from '../reducers/profile-view';

--- a/src/content/containers/ProfileMarkersView.js
+++ b/src/content/containers/ProfileMarkersView.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import TreeView from '../components/TreeView';

--- a/src/content/containers/ProfileSharing.css
+++ b/src/content/containers/ProfileSharing.css
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 .profileSharing {
   --internal-share-button-background-color: var(--share-button-background-color, hsl(137,81%,44%));
   --internal-uploading-button-background-color: var(--uploading-button-background-color, #38445f);
@@ -55,7 +59,7 @@
 
 .profileSharingUploadingButtonProgress::-moz-progress-bar {
   background: var(--internal-uploading-progress-fill-color);
-} 
+}
 
 .profileSharingShareButtonButton {
   background-color: var(--internal-share-button-background-color);

--- a/src/content/containers/ProfileSharing.js
+++ b/src/content/containers/ProfileSharing.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';

--- a/src/content/containers/ProfileSummaryView.css
+++ b/src/content/containers/ProfileSummaryView.css
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 .summarize-profile {
   flex: 1;
   border-top: 1px solid #D6D6D6;

--- a/src/content/containers/ProfileSummaryView.js
+++ b/src/content/containers/ProfileSummaryView.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { getProfile } from '../reducers/profile-view';

--- a/src/content/containers/ProfileTaskTracerView.js
+++ b/src/content/containers/ProfileTaskTracerView.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import actions from '../actions';

--- a/src/content/containers/ProfileThreadHeaderContextMenu.js
+++ b/src/content/containers/ProfileThreadHeaderContextMenu.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import React, { PureComponent } from 'react';
 import { ContextMenu, MenuItem } from 'react-contextmenu';

--- a/src/content/containers/ProfileThreadJankOverview.js
+++ b/src/content/containers/ProfileThreadJankOverview.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { connect } from 'react-redux';
 import IntervalMarkerOverview from '../components/IntervalMarkerOverview';
 import { selectorsForThread } from '../reducers/profile-view';

--- a/src/content/containers/ProfileThreadTracingMarkerOverview.js
+++ b/src/content/containers/ProfileThreadTracingMarkerOverview.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { connect } from 'react-redux';
 import IntervalMarkerOverview from '../components/IntervalMarkerOverview';
 import { selectorsForThread } from '../reducers/profile-view';

--- a/src/content/containers/ProfileUploadField.js
+++ b/src/content/containers/ProfileUploadField.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import actions from '../actions';

--- a/src/content/containers/ProfileViewerHeader.js
+++ b/src/content/containers/ProfileViewerHeader.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 import ProfileThreadHeaderBar from '../components/ProfileThreadHeaderBar';
 import Reorderable from '../components/Reorderable';

--- a/src/content/containers/Root.js
+++ b/src/content/containers/Root.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 import { connect, Provider } from 'react-redux';
 import actions from '../actions';

--- a/src/content/containers/SymbolicationStatusOverlay.js
+++ b/src/content/containers/SymbolicationStatusOverlay.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { PureComponent, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import actions from '../actions';

--- a/src/content/containers/TimelineFlameChart.css
+++ b/src/content/containers/TimelineFlameChart.css
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 .timelineFlameChartLabels {
   width: 135px;
   display: flex;

--- a/src/content/containers/TimelineFlameChart.js
+++ b/src/content/containers/TimelineFlameChart.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';

--- a/src/content/containers/TimelineView.css
+++ b/src/content/containers/TimelineView.css
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 .timelineView {
   flex: 1;
   display: flex;

--- a/src/content/containers/TimelineView.js
+++ b/src/content/containers/TimelineView.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';

--- a/src/content/containers/URLManager.js
+++ b/src/content/containers/URLManager.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 
 import React, { PureComponent, PropTypes } from 'react';

--- a/src/content/create-store.js
+++ b/src/content/create-store.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { createStore, applyMiddleware, combineReducers } from 'redux';
 import thunk from 'redux-thunk';
 import createLogger from 'redux-logger';

--- a/src/content/css-geometry-tools.js
+++ b/src/content/css-geometry-tools.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /**
  * Return a float number for the number of CSS pixels from the computed style
  * of the supplied CSS property on the supplied element.

--- a/src/content/data-table-utils.js
+++ b/src/content/data-table-utils.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 /**
  * A "data table" is a JS object of the form:

--- a/src/content/errors.js
+++ b/src/content/errors.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 
 export type Attempt = {

--- a/src/content/function-info.js
+++ b/src/content/function-info.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // Imported from the original cleopatra, needs to be double-checked.
 
 const resources = {};

--- a/src/content/gecko-profile-versioning.js
+++ b/src/content/gecko-profile-versioning.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 /**
  * This file deals with old versions of the Gecko profile format, i.e. the

--- a/src/content/gz.js
+++ b/src/content/gz.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 let zeeWorker;
 if (process.env.NODE_ENV === 'test') {
   const Worker = require('workerjs');

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React from 'react';
 import Perf from 'react-addons-perf';
 import { render } from 'react-dom';

--- a/src/content/interval-marker-styles.js
+++ b/src/content/interval-marker-styles.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /* stolen from the light theme at devtools/client/themes/variables.css */
 const themeHighlightGreen = '#2cbb0f';
 const themeHighlightBlue = '#0088cc';

--- a/src/content/labeling-strategies.js
+++ b/src/content/labeling-strategies.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import type { Thread, IndexIntoStackTable } from '../common/types/profile';
 

--- a/src/content/messages/index.js
+++ b/src/content/messages/index.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { profileSummaryProcessed } from '../actions/profile-summary';
 /**
  * Messages are the translation layer from actions dispatched by the worker

--- a/src/content/old-cleopatra-profile-format.js
+++ b/src/content/old-cleopatra-profile-format.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import { UniqueStringArray } from './unique-string-array';
 import { resourceTypes } from './profile-data';

--- a/src/content/process-profile.js
+++ b/src/content/process-profile.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { getContainingLibrary, getClosestLibrary } from './symbolication';
 import { UniqueStringArray } from './unique-string-array';
 import { resourceTypes } from './profile-data';

--- a/src/content/processed-profile-versioning.js
+++ b/src/content/processed-profile-versioning.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 /**
  * This file deals with old versions of the "processed" profile format,

--- a/src/content/profile-data.js
+++ b/src/content/profile-data.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import type {
   Profile,

--- a/src/content/profile-processor-worker.js
+++ b/src/content/profile-processor-worker.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { ProfileProcessor } from './process-profile';
 import { provideWorkerSide } from './promise-worker';
 

--- a/src/content/profile-store.js
+++ b/src/content/profile-store.js
@@ -1,4 +1,6 @@
-
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 export function uploadBinaryProfileData(data, progressChangeCallback = undefined) {
   return new Promise((resolve, reject) => {

--- a/src/content/profile-tree.js
+++ b/src/content/profile-tree.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import { timeCode } from '../common/time-code';
 import { getSampleFuncStacks, resourceTypes } from './profile-data';

--- a/src/content/promise-worker.js
+++ b/src/content/promise-worker.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 export function provideHostSide(workerFilename, methods) {
   return function HostClass() {
     const constructorArguments = Array.from(arguments);

--- a/src/content/range-filters.js
+++ b/src/content/range-filters.js
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 export function parseRangeFilters(stringValue = '') {
   if (!stringValue) {

--- a/src/content/reducers/app.js
+++ b/src/content/reducers/app.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import { combineReducers } from 'redux';
 

--- a/src/content/reducers/flame-chart.js
+++ b/src/content/reducers/flame-chart.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { combineReducers } from 'redux';
 import { getCategoryByImplementation } from '../color-categories';
 import { getFunctionName } from '../labeling-strategies';

--- a/src/content/reducers/icons.js
+++ b/src/content/reducers/icons.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import { createSelector } from 'reselect';
 import type { Action } from '../actions/types';

--- a/src/content/reducers/index.js
+++ b/src/content/reducers/index.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import profileView from './profile-view';
 import app from './app';

--- a/src/content/reducers/profile-view.js
+++ b/src/content/reducers/profile-view.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import { applyFunctionMerging, setFuncNames, setTaskTracerNames } from '../symbolication';
 import { combineReducers } from 'redux';

--- a/src/content/reducers/summary-view.js
+++ b/src/content/reducers/summary-view.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import type { Action } from '../actions/types';
 import type { State, SummaryViewState } from './types';

--- a/src/content/reducers/timeline-view.js
+++ b/src/content/reducers/timeline-view.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import { combineReducers } from 'redux';
 import type { ThreadIndex } from '../../common/types/profile';

--- a/src/content/reducers/types.js
+++ b/src/content/reducers/types.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 
 import type { Summary } from '../../common/summarize-profile';

--- a/src/content/reducers/url-state.js
+++ b/src/content/reducers/url-state.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import { combineReducers } from 'redux';
 import { defaultThreadOrder } from '../profile-data';

--- a/src/content/sha1.js
+++ b/src/content/sha1.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // Copied and adapted from https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest
 
 function hex(buffer) {

--- a/src/content/shorten-url.js
+++ b/src/content/shorten-url.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import fetchJsonP from 'fetch-jsonp';
 import queryString from 'query-string';
 import url from 'url';

--- a/src/content/stack-timing.js
+++ b/src/content/stack-timing.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import type { IndexIntoStackTable, IndexIntoFrameTable, Thread, StackTable } from '../common/types/profile';
 import type { Milliseconds } from '../common/types/units';

--- a/src/content/symbol-store-db-worker.js
+++ b/src/content/symbol-store-db-worker.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { SymbolStoreDB } from './symbol-store-db';
 import { provideWorkerSide } from './promise-worker';
 

--- a/src/content/symbol-store-db.js
+++ b/src/content/symbol-store-db.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 
 export type SymbolTableAsTuple = [

--- a/src/content/symbol-store.js
+++ b/src/content/symbol-store.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import { SymbolStoreDB } from './symbol-store-db';
 import type { SymbolTableAsTuple } from './symbol-store-db';

--- a/src/content/symbolication.js
+++ b/src/content/symbolication.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import bisection from 'bisection';
 import { resourceTypes } from './profile-data';
 import type { Thread, IndexIntoFuncTable } from '../common/types/profile';

--- a/src/content/task-tracer.js
+++ b/src/content/task-tracer.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 
 import { UniqueStringArray } from './unique-string-array';

--- a/src/content/uintarray-encoding.js
+++ b/src/content/uintarray-encoding.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /**
  * Space-efficient url component compatible encoding for arrays of 32bit
  * unsigned integers. Smaller numbers take up fewer characters.

--- a/src/content/unique-string-array.js
+++ b/src/content/unique-string-array.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import type { IndexIntoStringTable } from '../common/types/profile';
 

--- a/src/content/url-handling.js
+++ b/src/content/url-handling.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import queryString from 'query-string';
 import { stringifyRangeFilters, parseRangeFilters } from './range-filters';

--- a/src/content/with-size.js
+++ b/src/content/with-size.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React, { Component } from 'react';
 import { findDOMNode } from 'react-dom';
 

--- a/src/test/fixtures/example-symbol-table.js
+++ b/src/test/fixtures/example-symbol-table.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { TextEncoder } from 'text-encoding';
 import type { SymbolTableAsTuple } from '../../content/symbol-store-db';
 

--- a/src/test/fixtures/fake-symbol-store.js
+++ b/src/test/fixtures/fake-symbol-store.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 export class FakeSymbolStore {
   constructor(symbolTables) {
     this._symbolTables = {};

--- a/src/test/fixtures/mocks/image.js
+++ b/src/test/fixtures/mocks/image.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 export function createImageMock() {
   function Image() {
     instances.push(this);

--- a/src/test/fixtures/profiles/example-profile.js
+++ b/src/test/fixtures/profiles/example-profile.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /**
  * export defaults one object that is an example profile, in the Gecko format,
  * i.e. the format that nsIProfiler.getProfileDataAsync outputs.

--- a/src/test/fixtures/profiles/timings-with-js.js
+++ b/src/test/fixtures/profiles/timings-with-js.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import cloneDeep from 'lodash.clonedeep';
 import exampleProfile from './example-profile';
 

--- a/src/test/fixtures/stores.js
+++ b/src/test/fixtures/stores.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import createStore from '../../content/create-store';
 import { receiveProfileFromAddon } from '../../content/actions/receive-profile';
 import exampleProfile from './profiles/timings-with-js';

--- a/src/test/store/actions.js
+++ b/src/test/store/actions.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { assert } from 'chai';
 import { storeWithProfile } from '../fixtures/stores';
 import * as ProfileViewSelectors from '../../content/reducers/profile-view';

--- a/src/test/store/fixtures/profiles.js
+++ b/src/test/store/fixtures/profiles.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // @flow
 import { getEmptyProfile } from '../../../content/profile-data';
 import { UniqueStringArray } from '../../../content/unique-string-array';

--- a/src/test/store/icons.js
+++ b/src/test/store/icons.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { assert } from 'chai';
 
 import { createImageMock } from '../fixtures/mocks/image';

--- a/src/test/store/receive-profile.js
+++ b/src/test/store/receive-profile.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { assert } from 'chai';
 import sinon from 'sinon';
 import { blankStore } from '../fixtures/stores';

--- a/src/test/unit/profile-data.js
+++ b/src/test/unit/profile-data.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import 'babel-polyfill';
 import { assert, config } from 'chai';
 import { getContainingLibrary, symbolicateProfile, applyFunctionMerging, setFuncNames } from '../../content/symbolication';

--- a/src/test/unit/summarize-profile.js
+++ b/src/test/unit/summarize-profile.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import 'babel-polyfill';
 import { describe, it } from 'mocha';
 import { assert } from 'chai';

--- a/src/test/unit/symbol-store-db.js
+++ b/src/test/unit/symbol-store-db.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import 'babel-polyfill';
 import { assert, config } from 'chai';
 import { SymbolStoreDB } from '../../content/symbol-store-db';

--- a/src/test/unit/symbol-store.js
+++ b/src/test/unit/symbol-store.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import 'babel-polyfill';
 import { assert, config } from 'chai';
 import { SymbolStore } from '../../content/symbol-store';

--- a/src/worker/actions/index.js
+++ b/src/worker/actions/index.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { summarizeProfile } from '../../common/summarize-profile';
 
 export function processProfileSummary() {

--- a/src/worker/index.js
+++ b/src/worker/index.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import {createStore, applyMiddleware} from 'redux';
 import threadDispatcher from '../common/thread-middleware';
 import handleMessages from '../common/message-handler';

--- a/src/worker/messages/index.js
+++ b/src/worker/messages/index.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import {processProfileSummary, profileProcessed} from '../actions';
 /**
  * Messages are the translation layer from actions dispatched by the content

--- a/src/worker/reducers/index.js
+++ b/src/worker/reducers/index.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import {combineReducers} from 'redux';
 
 function profile(state = null, action) {


### PR DESCRIPTION
perf.html is MPL2.0, it has the right LICENSE file in the root folder, and also references the license in package.json, but it doesn't have any license headers in source files.

See https://www.mozilla.org/en-US/MPL/ and https://www.mozilla.org/en-US/MPL/headers/

This PR adds them.