### PR TITLE
TimelineMarkers snapshot test

### DIFF
--- a/flow-typed/npm/jest_v20.x.x.js
+++ b/flow-typed/npm/jest_v20.x.x.js
@@ -1,0 +1,471 @@
+// flow-typed signature: eb392bde0440325fce2421d18447acde
+// flow-typed version: 0786be2fed/jest_v20.x.x/flow_>=v0.33.x
+
+type JestMockFn = {
+  (...args: Array<any>): any,
+  /**
+   * An object for introspecting mock calls
+   */
+  mock: {
+    /**
+     * An array that represents all calls that have been made into this mock
+     * function. Each call is represented by an array of arguments that were
+     * passed during the call.
+     */
+    calls: Array<Array<any>>,
+    /**
+     * An array that contains all the object instances that have been
+     * instantiated from this mock function.
+     */
+    instances: mixed
+  },
+  /**
+   * Resets all information stored in the mockFn.mock.calls and
+   * mockFn.mock.instances arrays. Often this is useful when you want to clean
+   * up a mock's usage data between two assertions.
+   */
+  mockClear(): Function,
+  /**
+   * Resets all information stored in the mock. This is useful when you want to
+   * completely restore a mock back to its initial state.
+   */
+  mockReset(): Function,
+  /**
+   * Accepts a function that should be used as the implementation of the mock.
+   * The mock itself will still record all calls that go into and instances
+   * that come from itself -- the only difference is that the implementation
+   * will also be executed when the mock is called.
+   */
+  mockImplementation(fn: Function): JestMockFn,
+  /**
+   * Accepts a function that will be used as an implementation of the mock for
+   * one call to the mocked function. Can be chained so that multiple function
+   * calls produce different results.
+   */
+  mockImplementationOnce(fn: Function): JestMockFn,
+  /**
+   * Just a simple sugar function for returning `this`
+   */
+  mockReturnThis(): void,
+  /**
+   * Deprecated: use jest.fn(() => value) instead
+   */
+  mockReturnValue(value: any): JestMockFn,
+  /**
+   * Sugar for only returning a value once inside your mock
+   */
+  mockReturnValueOnce(value: any): JestMockFn
+};
+
+type JestAsymmetricEqualityType = {
+  /**
+   * A custom Jasmine equality tester
+   */
+  asymmetricMatch(value: mixed): boolean
+};
+
+type JestCallsType = {
+  allArgs(): mixed,
+  all(): mixed,
+  any(): boolean,
+  count(): number,
+  first(): mixed,
+  mostRecent(): mixed,
+  reset(): void
+};
+
+type JestClockType = {
+  install(): void,
+  mockDate(date: Date): void,
+  tick(): void,
+  uninstall(): void
+};
+
+type JestMatcherResult = {
+  message?: string | (() => string),
+  pass: boolean
+};
+
+type JestMatcher = (actual: any, expected: any) => JestMatcherResult;
+
+type JestPromiseType = {
+  /**
+   * Use rejects to unwrap the reason of a rejected promise so any other
+   * matcher can be chained. If the promise is fulfilled the assertion fails.
+   */
+  rejects: JestExpectType,
+  /**
+   * Use resolves to unwrap the value of a fulfilled promise so any other
+   * matcher can be chained. If the promise is rejected the assertion fails.
+   */
+  resolves: JestExpectType
+};
+
+type JestExpectType = {
+  not: JestExpectType,
+  /**
+   * If you have a mock function, you can use .lastCalledWith to test what
+   * arguments it was last called with.
+   */
+  lastCalledWith(...args: Array<any>): void,
+  /**
+   * toBe just checks that a value is what you expect. It uses === to check
+   * strict equality.
+   */
+  toBe(value: any): void,
+  /**
+   * Use .toHaveBeenCalled to ensure that a mock function got called.
+   */
+  toBeCalled(): void,
+  /**
+   * Use .toBeCalledWith to ensure that a mock function was called with
+   * specific arguments.
+   */
+  toBeCalledWith(...args: Array<any>): void,
+  /**
+   * Using exact equality with floating point numbers is a bad idea. Rounding
+   * means that intuitive things fail.
+   */
+  toBeCloseTo(num: number, delta: any): void,
+  /**
+   * Use .toBeDefined to check that a variable is not undefined.
+   */
+  toBeDefined(): void,
+  /**
+   * Use .toBeFalsy when you don't care what a value is, you just want to
+   * ensure a value is false in a boolean context.
+   */
+  toBeFalsy(): void,
+  /**
+   * To compare floating point numbers, you can use toBeGreaterThan.
+   */
+  toBeGreaterThan(number: number): void,
+  /**
+   * To compare floating point numbers, you can use toBeGreaterThanOrEqual.
+   */
+  toBeGreaterThanOrEqual(number: number): void,
+  /**
+   * To compare floating point numbers, you can use toBeLessThan.
+   */
+  toBeLessThan(number: number): void,
+  /**
+   * To compare floating point numbers, you can use toBeLessThanOrEqual.
+   */
+  toBeLessThanOrEqual(number: number): void,
+  /**
+   * Use .toBeInstanceOf(Class) to check that an object is an instance of a
+   * class.
+   */
+  toBeInstanceOf(cls: Class<*>): void,
+  /**
+   * .toBeNull() is the same as .toBe(null) but the error messages are a bit
+   * nicer.
+   */
+  toBeNull(): void,
+  /**
+   * Use .toBeTruthy when you don't care what a value is, you just want to
+   * ensure a value is true in a boolean context.
+   */
+  toBeTruthy(): void,
+  /**
+   * Use .toBeUndefined to check that a variable is undefined.
+   */
+  toBeUndefined(): void,
+  /**
+   * Use .toContain when you want to check that an item is in a list. For
+   * testing the items in the list, this uses ===, a strict equality check.
+   */
+  toContain(item: any): void,
+  /**
+   * Use .toContainEqual when you want to check that an item is in a list. For
+   * testing the items in the list, this matcher recursively checks the
+   * equality of all fields, rather than checking for object identity.
+   */
+  toContainEqual(item: any): void,
+  /**
+   * Use .toEqual when you want to check that two objects have the same value.
+   * This matcher recursively checks the equality of all fields, rather than
+   * checking for object identity.
+   */
+  toEqual(value: any): void,
+  /**
+   * Use .toHaveBeenCalled to ensure that a mock function got called.
+   */
+  toHaveBeenCalled(): void,
+  /**
+   * Use .toHaveBeenCalledTimes to ensure that a mock function got called exact
+   * number of times.
+   */
+  toHaveBeenCalledTimes(number: number): void,
+  /**
+   * Use .toHaveBeenCalledWith to ensure that a mock function was called with
+   * specific arguments.
+   */
+  toHaveBeenCalledWith(...args: Array<any>): void,
+  /**
+   * Check that an object has a .length property and it is set to a certain
+   * numeric value.
+   */
+  toHaveLength(number: number): void,
+  /**
+   *
+   */
+  toHaveProperty(propPath: string, value?: any): void,
+  /**
+   * Use .toMatch to check that a string matches a regular expression.
+   */
+  toMatch(regexp: RegExp): void,
+  /**
+   * Use .toMatchObject to check that a javascript object matches a subset of the properties of an object.
+   */
+  toMatchObject(object: Object): void,
+  /**
+   * This ensures that a React component matches the most recent snapshot.
+   */
+  toMatchSnapshot(name?: string): void,
+  /**
+   * Use .toThrow to test that a function throws when it is called.
+   */
+  toThrow(message?: string | Error): void,
+  /**
+   * Use .toThrowError to test that a function throws a specific error when it
+   * is called. The argument can be a string for the error message, a class for
+   * the error, or a regex that should match the error.
+   */
+  toThrowError(message?: string | Error | RegExp): void,
+  /**
+   * Use .toThrowErrorMatchingSnapshot to test that a function throws a error
+   * matching the most recent snapshot when it is called.
+   */
+  toThrowErrorMatchingSnapshot(): void
+};
+
+type JestObjectType = {
+  /**
+   *  Disables automatic mocking in the module loader.
+   *
+   *  After this method is called, all `require()`s will return the real
+   *  versions of each module (rather than a mocked version).
+   */
+  disableAutomock(): JestObjectType,
+  /**
+   * An un-hoisted version of disableAutomock
+   */
+  autoMockOff(): JestObjectType,
+  /**
+   * Enables automatic mocking in the module loader.
+   */
+  enableAutomock(): JestObjectType,
+  /**
+   * An un-hoisted version of enableAutomock
+   */
+  autoMockOn(): JestObjectType,
+  /**
+   * Clears the mock.calls and mock.instances properties of all mocks.
+   * Equivalent to calling .mockClear() on every mocked function.
+   */
+  clearAllMocks(): JestObjectType,
+  /**
+   * Resets the state of all mocks. Equivalent to calling .mockReset() on every
+   * mocked function.
+   */
+  resetAllMocks(): JestObjectType,
+  /**
+   * Removes any pending timers from the timer system.
+   */
+  clearAllTimers(): void,
+  /**
+   * The same as `mock` but not moved to the top of the expectation by
+   * babel-jest.
+   */
+  doMock(moduleName: string, moduleFactory?: any): JestObjectType,
+  /**
+   * The same as `unmock` but not moved to the top of the expectation by
+   * babel-jest.
+   */
+  dontMock(moduleName: string): JestObjectType,
+  /**
+   * Returns a new, unused mock function. Optionally takes a mock
+   * implementation.
+   */
+  fn(implementation?: Function): JestMockFn,
+  /**
+   * Determines if the given function is a mocked function.
+   */
+  isMockFunction(fn: Function): boolean,
+  /**
+   * Given the name of a module, use the automatic mocking system to generate a
+   * mocked version of the module for you.
+   */
+  genMockFromModule(moduleName: string): any,
+  /**
+   * Mocks a module with an auto-mocked version when it is being required.
+   *
+   * The second argument can be used to specify an explicit module factory that
+   * is being run instead of using Jest's automocking feature.
+   *
+   * The third argument can be used to create virtual mocks -- mocks of modules
+   * that don't exist anywhere in the system.
+   */
+  mock(moduleName: string, moduleFactory?: any): JestObjectType,
+  /**
+   * Resets the module registry - the cache of all required modules. This is
+   * useful to isolate modules where local state might conflict between tests.
+   */
+  resetModules(): JestObjectType,
+  /**
+   * Exhausts the micro-task queue (usually interfaced in node via
+   * process.nextTick).
+   */
+  runAllTicks(): void,
+  /**
+   * Exhausts the macro-task queue (i.e., all tasks queued by setTimeout(),
+   * setInterval(), and setImmediate()).
+   */
+  runAllTimers(): void,
+  /**
+   * Exhausts all tasks queued by setImmediate().
+   */
+  runAllImmediates(): void,
+  /**
+   * Executes only the macro task queue (i.e. all tasks queued by setTimeout()
+   * or setInterval() and setImmediate()).
+   */
+  runTimersToTime(msToRun: number): void,
+  /**
+   * Executes only the macro-tasks that are currently pending (i.e., only the
+   * tasks that have been queued by setTimeout() or setInterval() up to this
+   * point)
+   */
+  runOnlyPendingTimers(): void,
+  /**
+   * Explicitly supplies the mock object that the module system should return
+   * for the specified module. Note: It is recommended to use jest.mock()
+   * instead.
+   */
+  setMock(moduleName: string, moduleExports: any): JestObjectType,
+  /**
+   * Indicates that the module system should never return a mocked version of
+   * the specified module from require() (e.g. that it should always return the
+   * real module).
+   */
+  unmock(moduleName: string): JestObjectType,
+  /**
+   * Instructs Jest to use fake versions of the standard timer functions
+   * (setTimeout, setInterval, clearTimeout, clearInterval, nextTick,
+   * setImmediate and clearImmediate).
+   */
+  useFakeTimers(): JestObjectType,
+  /**
+   * Instructs Jest to use the real versions of the standard timer functions.
+   */
+  useRealTimers(): JestObjectType,
+  /**
+   * Creates a mock function similar to jest.fn but also tracks calls to
+   * object[methodName].
+   */
+  spyOn(object: Object, methodName: string): JestMockFn
+};
+
+type JestSpyType = {
+  calls: JestCallsType
+};
+
+/** Runs this function after every test inside this context */
+declare function afterEach(fn: Function): void;
+/** Runs this function before every test inside this context */
+declare function beforeEach(fn: Function): void;
+/** Runs this function after all tests have finished inside this context */
+declare function afterAll(fn: Function): void;
+/** Runs this function before any tests have started inside this context */
+declare function beforeAll(fn: Function): void;
+/** A context for grouping tests together */
+declare function describe(name: string, fn: Function): void;
+
+/** An individual test unit */
+declare var it: {
+  /**
+   * An individual test unit
+   *
+   * @param {string} Name of Test
+   * @param {Function} Test
+   */
+  (name: string, fn?: Function): ?Promise<void>,
+  /**
+   * Only run this test
+   *
+   * @param {string} Name of Test
+   * @param {Function} Test
+   */
+  only(name: string, fn?: Function): ?Promise<void>,
+  /**
+   * Skip running this test
+   *
+   * @param {string} Name of Test
+   * @param {Function} Test
+   */
+  skip(name: string, fn?: Function): ?Promise<void>,
+  /**
+   * Run the test concurrently
+   *
+   * @param {string} Name of Test
+   * @param {Function} Test
+   */
+  concurrent(name: string, fn?: Function): ?Promise<void>
+};
+declare function fit(name: string, fn: Function): ?Promise<void>;
+/** An individual test unit */
+declare var test: typeof it;
+/** A disabled group of tests */
+declare var xdescribe: typeof describe;
+/** A focused group of tests */
+declare var fdescribe: typeof describe;
+/** A disabled individual test */
+declare var xit: typeof it;
+/** A disabled individual test */
+declare var xtest: typeof it;
+
+/** The expect function is used every time you want to test a value */
+declare var expect: {
+  /** The object that you want to make assertions against */
+  (value: any): JestExpectType & JestPromiseType,
+  /** Add additional Jasmine matchers to Jest's roster */
+  extend(matchers: { [name: string]: JestMatcher }): void,
+  /** Add a module that formats application-specific data structures. */
+  addSnapshotSerializer(serializer: (input: Object) => string): void,
+  assertions(expectedAssertions: number): void,
+  hasAssertions(): void,
+  any(value: mixed): JestAsymmetricEqualityType,
+  anything(): void,
+  arrayContaining(value: Array<mixed>): void,
+  objectContaining(value: Object): void,
+  /** Matches any received string that contains the exact expected string. */
+  stringContaining(value: string): void,
+  stringMatching(value: string | RegExp): void
+};
+
+// TODO handle return type
+// http://jasmine.github.io/2.4/introduction.html#section-Spies
+declare function spyOn(value: mixed, method: string): Object;
+
+/** Holds all functions related to manipulating test runner */
+declare var jest: JestObjectType;
+
+/**
+ * The global Jamine object, this is generally not exposed as the public API,
+ * using features inside here could break in later versions of Jest.
+ */
+declare var jasmine: {
+  DEFAULT_TIMEOUT_INTERVAL: number,
+  any(value: mixed): JestAsymmetricEqualityType,
+  anything(): void,
+  arrayContaining(value: Array<mixed>): void,
+  clock(): JestClockType,
+  createSpy(name: string): JestSpyType,
+  createSpyObj(
+    baseName: string,
+    methodNames: Array<string>
+  ): { [methodName: string]: JestSpyType },
+  objectContaining(value: Object): void,
+  stringMatching(value: string): void
+};

--- a/package.json
+++ b/package.json
@@ -102,12 +102,12 @@
     "browserify": "^13.0.1",
     "chai": "^3.5.0",
     "css-loader": "^0.26.0",
+    "devtools-license-check": "^0.2.0",
     "eslint": "^3.10.2",
     "eslint-config-google": "^0.6.0",
     "eslint-plugin-flowtype": "^2.30.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-react": "^6.4.0",
-    "devtools-license-check": "^0.2.0",
     "fake-indexeddb": "^1.0.12",
     "file-loader": "^0.9.0",
     "flow-bin": "^0.40.0",
@@ -121,6 +121,7 @@
     "lodash.clonedeep": "^4.5.0",
     "mkdirp": "^0.5.1",
     "raw-loader": "^0.5.1",
+    "react-test-renderer": "^15.5.4",
     "rimraf": "^2.5.4",
     "sinon": "^2.1.0",
     "style-loader": "^0.13.1",
@@ -130,10 +131,18 @@
     "webpack-hot-middleware": "^2.13.2"
   },
   "jest": {
-    "collectCoverageFrom" : ["src/**/*.{js,jsx}", "!**/node_modules/**"],
+    "collectCoverageFrom": [
+      "src/**/*.{js,jsx}",
+      "!**/node_modules/**"
+    ],
     "testEnvironment": "jsdom",
-    "moduleFileExtensions": ["js", "jsx"],
-    "moduleDirectories": ["node_modules"],
+    "moduleFileExtensions": [
+      "js",
+      "jsx"
+    ],
+    "moduleDirectories": [
+      "node_modules"
+    ],
     "moduleNameMapper": {
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/src/test/fixtures/mocks/file-mock.js",
       "\\.(css|less)$": "<rootDir>/src/test/fixtures/mocks/style-mock.js"

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
   },
   "jest": {
     "collectCoverageFrom" : ["src/**/*.{js,jsx}", "!**/node_modules/**"],
-    "testEnvironment": "node",
+    "testEnvironment": "jsdom",
     "moduleFileExtensions": ["js", "jsx"],
     "moduleDirectories": ["node_modules"],
     "moduleNameMapper": {

--- a/src/test/components/TimelineMarkers.test.js
+++ b/src/test/components/TimelineMarkers.test.js
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+import React from 'react';
+import TimelineMarkers from '../../content/containers/TimelineMarkers';
+import renderer from 'react-test-renderer';
+import { Provider } from 'react-redux';
+import mockCanvasContext from '../fixtures/mocks/canvas-context';
+import { storeWithProfile } from '../fixtures/stores';
+import { getProfileWithMarkers } from '../store/fixtures/profiles';
+
+jest.useFakeTimers();
+
+it('renders TimelineMarkers correctly', () => {
+  // Tie the requestAnimationFrame into jest's fake timers.
+  window.requestAnimationFrame = fn => setTimeout(fn, 0);
+  window.devicePixelRatio = 1;
+  const ctx = mockCanvasContext();
+
+  /**
+   * Mock out any created refs for the components with relevant information.
+   */
+  function createNodeMock(element) {
+    // <TimelineCanvas><canvas /></TimelineCanvas>
+    if (element.type === 'canvas') {
+      return {
+        getBoundingClientRect: () => _getBoundingBox(200, 300),
+        getContext: () => ctx,
+        style: {},
+      };
+    }
+    // <TimelineViewport />
+    if (element.props.className.split(' ').includes('timelineViewport')) {
+      return {
+        getBoundingClientRect: () => _getBoundingBox(200, 300),
+      };
+    }
+    return null;
+  }
+
+  const profile = getProfileWithMarkers([
+    ['Marker A', 0, {startTime: 0, endTime: 10}],
+    ['Marker B', 0, {startTime: 0, endTime: 10}],
+    ['Marker C', 0, {startTime: 5, endTime: 15}],
+  ]);
+
+  const timeline = renderer.create(
+    <Provider store={storeWithProfile(profile)}>
+      <TimelineMarkers threadIndex={0} viewHeight={1000} />
+    </Provider>,
+    {createNodeMock}
+  );
+
+  // Flush any requestAnimationFrames.
+  jest.runAllTimers();
+
+  const tree = timeline.toJSON();
+  const drawCalls = ctx.__flushDrawLog();
+
+  expect(tree).toMatchSnapshot();
+  expect(drawCalls).toMatchSnapshot();
+
+  delete window.requestAnimationFrame;
+  delete window.devicePixelRatio;
+});
+
+function _getBoundingBox(width, height) {
+  return {
+    width,
+    height,
+    left: 0,
+    x: 0,
+    top: 0,
+    y: 0,
+    right: width,
+    bottom: height,
+  };
+}

--- a/src/test/components/__snapshots__/TimelineMarkers.test.js.snap
+++ b/src/test/components/__snapshots__/TimelineMarkers.test.js.snap
@@ -1,0 +1,184 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders TimelineMarkers correctly 1`] = `
+<div
+  className="timelineMarkers"
+  style={
+    Object {
+      "height": 72,
+    }
+  }
+>
+  <div
+    className="timelineMarkersLabels grippy"
+    title="thread: \\"Empty\\" (0)
+  process: \\"default\\" (0)"
+  >
+    <span
+      className="timelineMarkersLabelsName"
+    >
+      Empty
+    </span>
+    <button
+      className="timelineMarkersCollapseButton expanded"
+      onClick={[Function]}
+    />
+  </div>
+  <div
+    className="timelineViewport expanded"
+    onMouseDown={[Function]}
+    onWheel={[Function]}
+  >
+    <canvas
+      className="timelineCanvas timelineMarkerCanvas"
+      onDoubleClick={[Function]}
+      onMouseMove={[Function]}
+      onMouseOut={[Function]}
+      title={null}
+    />
+    <div
+      className="timelineViewportShiftScroll hidden"
+    >
+      Zoom Timeline:
+      <kbd
+        className="timelineViewportShiftScrollKbd"
+      >
+        Shift
+      </kbd>
+      <kbd
+        className="timelineViewportShiftScrollKbd"
+      >
+        Scroll
+      </kbd>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders TimelineMarkers correctly 2`] = `
+Array [
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "clearRect",
+    0,
+    0,
+    200,
+    300,
+  ],
+  Array [
+    "measureText",
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.()< /:-_",
+  ],
+  Array [
+    "measureText",
+    "…",
+  ],
+  Array [
+    "set lineWidth",
+    1,
+  ],
+  Array [
+    "set lineWidth",
+    1,
+  ],
+  Array [
+    "set lineWidth",
+    1,
+  ],
+  Array [
+    "set fillStyle",
+    "#eee",
+  ],
+  Array [
+    "fillRect",
+    0,
+    16,
+    200,
+    1,
+  ],
+  Array [
+    "fillRect",
+    0,
+    32,
+    200,
+    1,
+  ],
+  Array [
+    "fillRect",
+    0,
+    48,
+    200,
+    1,
+  ],
+  Array [
+    "createLinearGradient",
+    0,
+    0,
+    150,
+    0,
+  ],
+  Array [
+    "addColorStop",
+    0,
+    "rgba(255, 255, 255, 0.8)",
+  ],
+  Array [
+    "addColorStop",
+    1,
+    "rgba(255, 255, 255, 0.0)",
+  ],
+  Array [
+    "set fillStyle",
+    Object {
+      "addColorStop": [Function],
+    },
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    150,
+    16,
+  ],
+  Array [
+    "fillRect",
+    0,
+    16,
+    150,
+    16,
+  ],
+  Array [
+    "fillRect",
+    0,
+    32,
+    150,
+    16,
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "Marker A",
+    5,
+    11,
+  ],
+  Array [
+    "fillText",
+    "Marker B",
+    5,
+    27,
+  ],
+  Array [
+    "fillText",
+    "Marker C",
+    5,
+    43,
+  ],
+]
+`;

--- a/src/test/fixtures/mocks/canvas-context.js
+++ b/src/test/fixtures/mocks/canvas-context.js
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+type MaybeFn = (any => any) | void
+const identity = () => {};
+
+export default function mockCanvasContext() {
+  const log: Array<any> = [];
+
+  /**
+   * Logs canvas operations. The log will preserve the order of operations, which is
+   * important for canvas rendering.
+   */
+  function spyLog(name: string, fn: MaybeFn = identity) {
+    return jest.fn((...args) => {
+      log.push([name, ...args]);
+      if (fn) {
+        return fn.apply(null, args);
+      }
+      return undefined;
+    });
+  }
+
+  return new Proxy(
+    {
+      scale: spyLog('scale'),
+      fillRect: spyLog('fillRect'),
+      fillText: spyLog('fillText'),
+      clearRect: spyLog('clearRect'),
+      beginPath: spyLog('beginPath'),
+      closePath: spyLog('closePath'),
+      arc: spyLog('arc'),
+      measureText: spyLog('measureText', text => ({width: text.length * 5})),
+      createLinearGradient: spyLog('createLinearGradient', () => ({
+        addColorStop: spyLog('addColorStop'),
+      })),
+      __flushDrawLog: (): Array<any> => {
+        const oldLog = log.slice();
+        log.splice(0, log.length);
+        return oldLog;
+      },
+    },
+    {
+      // Record what values are set on the context.
+      set(target, property, value) {
+        target[property] = value;
+        log.push(['set ' + property, value]);
+        return true;
+      },
+    }
+  );
+}

--- a/src/test/store/icons.test.js
+++ b/src/test/store/icons.test.js
@@ -23,11 +23,11 @@ describe('actions/icons', function () {
   beforeEach(() => {
     const mock = createImageMock();
     instances = mock.instances;
-    global.Image = mock.Image;
+    window.Image = mock.Image;
   });
 
   afterEach(() => {
-    delete global.Image;
+    delete window.Image;
     instances = null;
   });
 

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -56,14 +56,14 @@ describe('actions/receive-profile', function () {
         getProfile: () => Promise.resolve(exampleProfile),
         getSymbolTable: () => Promise.resolve(),
       };
-      global.window = { geckoProfilerPromise: Promise.resolve(geckoProfiler) };
+      window.geckoProfilerPromise = Promise.resolve(geckoProfiler);
     });
 
     afterEach(function () {
       clock.restore();
 
       geckoProfiler = null;
-      delete global.window;
+      delete window.geckoProfilerPromise;
     });
 
     it('can retrieve a profile from the addon', async function () {
@@ -121,21 +121,21 @@ describe('actions/receive-profile', function () {
       // The stub makes it easy to return different values for different
       // arguments. Here we define the default return value because there is no
       // argument specified.
-      global.fetch = sinon.stub();
-      global.fetch.resolves(fetch404Response);
+      window.fetch = sinon.stub();
+      window.fetch.resolves(fetch404Response);
 
-      sinon.stub(global, 'setTimeout').yieldsAsync(); // will call its argument asynchronously
+      sinon.stub(window, 'setTimeout').yieldsAsync(); // will call its argument asynchronously
     });
 
     afterEach(function () {
-      delete global.fetch;
-      global.setTimeout.restore();
+      delete window.fetch;
+      window.setTimeout.restore();
     });
 
     it('can retrieve a profile from the web and save it to state', async function () {
       const hash = 'c5e53f9ab6aecef926d4be68c84f2de550e2ac2f';
       const expectedUrl = `https://profile-store.commondatastorage.googleapis.com/${hash}`;
-      global.fetch.withArgs(expectedUrl).resolves(fetch200Response);
+      window.fetch.withArgs(expectedUrl).resolves(fetch200Response);
 
       const store = blankStore();
       await store.dispatch(retrieveProfileFromWeb(hash));
@@ -151,7 +151,7 @@ describe('actions/receive-profile', function () {
       const hash = 'c5e53f9ab6aecef926d4be68c84f2de550e2ac2f';
       const expectedUrl = `https://profile-store.commondatastorage.googleapis.com/${hash}`;
       // The first call will still be a 404 -- remember, it's the default return value.
-      global.fetch.withArgs(expectedUrl).onSecondCall().resolves(fetch200Response);
+      window.fetch.withArgs(expectedUrl).onSecondCall().resolves(fetch200Response);
 
       const store = blankStore();
       const views = (await observeStoreStateChanges(
@@ -194,7 +194,7 @@ describe('actions/receive-profile', function () {
 
     it('fails in case the fetch returns a server error', async function () {
       const hash = 'c5e53f9ab6aecef926d4be68c84f2de550e2ac2f';
-      global.fetch.resolves(fetch500Response);
+      window.fetch.resolves(fetch500Response);
 
       const store = blankStore();
       await store.dispatch(retrieveProfileFromWeb(hash));

--- a/src/test/unit/symbol-store-db.test.js
+++ b/src/test/unit/symbol-store-db.test.js
@@ -12,14 +12,13 @@ describe('SymbolStoreDB', function () {
   const libs = Array.from({ length: 10 }).map((_, i) => ({ debugName: `firefox${i}`, breakpadId: `breakpadId${i}` }));
 
   beforeAll(function () {
-    global.window = {
-      indexedDB: fakeIndexedDB,
-      IDBKeyRange: FDBKeyRange,
-    };
+    window.indexedDB = fakeIndexedDB;
+    window.IDBKeyRange = FDBKeyRange;
   });
 
   afterAll(function () {
-    delete global.window;
+    delete window.indexedDB;
+    delete window.IDBKeyRange;
   });
 
   it('should respect the maximum number of tables limit', async function () {

--- a/src/test/unit/symbol-store.test.js
+++ b/src/test/unit/symbol-store.test.js
@@ -21,13 +21,15 @@ describe('SymbolStore', function () {
   }
 
   beforeAll(function () {
-    global.window = { indexedDB: fakeIndexedDB, IDBKeyRange: FDBKeyRange };
-    global.TextDecoder = TextDecoder;
+    window.indexedDB = fakeIndexedDB;
+    window.IDBKeyRange = FDBKeyRange;
+    window.TextDecoder = TextDecoder;
   });
 
   afterAll(function () {
-    delete global.window;
-    delete global.TextDecoder;
+    delete window.indexedDB;
+    delete window.IDBKeyRange;
+    delete window.TextDecoder;
 
     symbolStore = null;
   });


### PR DESCRIPTION
This is my first attempt at a snapshot test for a component. My thoughts here are that snapshots should be a good first line of defense for catching component regressions. Snapshot tests would only be sanity checks for when things change. They should be fairly lightweight in the implementation, and easy to regenerate. As the components change over time you can see that the snapshots fail, inspect the output, re-generate the snapshot, and then move on with your life. I think these are good candidates for higher level connected components that have some complexity. This tests the integration of several components.

For more a unit-test level of individual components, I think enzyme would be a better fit. You can command the component at a more granular level, and check individual properties. I think the moment that we start trying to _do_ things with the test, we should consider switching over to an enzyme test and be more strict with testing the desired output.

I would say at this point, let's create some enzyme tests of some components, and compare how this looks to a snapshot test. I think a good approach would be to go ahead and merge in these experiments, but with the option to strip them out, or refactor them.