### PR TITLE
Tooltips using React DOM

### DIFF
--- a/res/style.css
+++ b/res/style.css
@@ -17,6 +17,23 @@ body, #root, .profileViewer {
   max-height: 100%;
 }
 
+body {
+  /* Stolen from the light theme at devtools/client/themes/variables.css */
+  --theme-highlight-green: #2cbb0f;
+  --theme-highlight-blue: #0088cc;
+  --theme-highlight-bluegrey: #0072ab;
+  --theme-highlight-purple: #5b5fff;
+  --theme-highlight-lightorange: #d97e00;
+  --theme-highlight-orange: #f13c00;
+  --theme-highlight-red: #ed2655;
+  --theme-highlight-pink: #b82ee5;
+  --theme-highlight-gray: #b4babf;/* except for this one, I made this one darker */
+}
+
+#root {
+  z-index: 0;
+}
+
 .treeView {
   display: flex;
   flex-flow: column nowrap;

--- a/src/common/types/profile.js
+++ b/src/common/types/profile.js
@@ -160,14 +160,6 @@ export type FrameTable = {
  */
 export type FuncTable = {
   address: MemoryOffset[],
-  libs: {
-    breakpadId: string,
-    end: number,
-    name: string,
-    offset: number,
-    pdbName: string,
-    start: number,
-  }[],
   isJS: boolean[],
   length: number,
   name: IndexIntoStringTable[],

--- a/src/common/types/profile.js
+++ b/src/common/types/profile.js
@@ -80,26 +80,26 @@ export type ProfilerMarkerTracing = {
   endTime: Milliseconds, // Same as cpuend
   stack?: Thread,
   interval: "start" | "end",
-} & (
-  { category?: string } |
-  {
-    category: "Paint",
-    name: "RefreshDriverTick" |
-      "FireScrollEvent" |
-      "Scripts" |
-      "Styles" |
-      "Reflow" |
-      "DispatchSynthMouseMove" |
-      "DisplayList" |
-      "LayerBuilding" |
-      "Rasterize" |
-      "ForwardTransaction" |
-      "NotifyDidPaint" |
-      "LayerTransaction" |
-      "Composite",
-  }
-  // TODO - Add more markers.
-);
+}
+
+export type PaintProfilerMarkerTracing = ProfilerMarkerTracing & {
+  category: "Paint",
+  name: "RefreshDriverTick" |
+    "FireScrollEvent" |
+    "Scripts" |
+    "Styles" |
+    "Reflow" |
+    "DispatchSynthMouseMove" |
+    "DisplayList" |
+    "LayerBuilding" |
+    "Rasterize" |
+    "ForwardTransaction" |
+    "NotifyDidPaint" |
+    "LayerTransaction" |
+    "Composite",
+}
+
+// TODO - Add more markers.
 
 /**
  * The payload for the UserTimings API. These are added through performance.measure()
@@ -119,8 +119,8 @@ export type UserTimingMarkerPayload = {
  */
 export type MarkerPayload =
   GPUMarkerPayload |
-  ProfilerMarkerTracing |
   UserTimingMarkerPayload |
+  PaintProfilerMarkerTracing |
   null;
 
 /**
@@ -176,8 +176,9 @@ export type ResourceTable = {
   addonId: any[], // TODO
   icon: any[], // TODO
   length: number,
-  lib: IndexIntoLibs[],
-  name: IndexIntoStringTable[],
+  lib: Array<IndexIntoLibs|null>,
+  name: Array<IndexIntoStringTable|-1>,
+  host: Array<IndexIntoStringTable|null>,
   type: resourceTypeEnum[],
 }
 

--- a/src/content/components/FlameChartCanvas.css
+++ b/src/content/components/FlameChartCanvas.css
@@ -7,3 +7,11 @@
   top: 0;
   left: 0;
 }
+
+/**
+ * This tooltip is multi-line and more intense, so add additional whitespace to make it
+ * more readable.
+ */
+.flameChartCanvasTooltip {
+  padding: 5px;
+}

--- a/src/content/components/TimelineMarkerCanvas.js
+++ b/src/content/components/TimelineMarkerCanvas.js
@@ -22,6 +22,7 @@ type Props = {
   rowHeight: CssPixels,
   markers: TracingMarker[],
   updateProfileSelection: ProfileSelection => Action,
+  isDragging: boolean,
 };
 
 const ROW_HEIGHT = 16;
@@ -246,8 +247,8 @@ class TimelineMarkerCanvas extends PureComponent {
     ctx.fillRect(x + c, bottom - c, width - 2 * c, c);
   }
 
-  getHoveredMarkerInfo(hoveredItem: IndexIntoMarkerTiming): string {
-    const { name, dur } = this.props.markers[hoveredItem];
+  getHoveredMarkerInfo(hoveredItem: IndexIntoMarkerTiming): React$Element<*> {
+    const { name, dur, data } = this.props.markers[hoveredItem];
     let duration;
     if (dur >= 10) {
       duration = dur.toFixed(0);
@@ -258,15 +259,35 @@ class TimelineMarkerCanvas extends PureComponent {
     } else {
       duration = dur.toFixed(3);
     }
-    return `${name} - ${duration}ms`;
+
+    let tooltipName = name;
+    if (data) {
+      switch (data.type) {
+        case 'UserTiming': {
+          tooltipName = data.name;
+        }
+      }
+    }
+
+    return (
+      <div className='tooltipOneLine'>
+        <div className='tooltipTiming'>
+          {duration}ms
+        </div>
+        <div className='tooltipName'>
+          {tooltipName}
+        </div>
+      </div>
+    );
   }
 
   render() {
-    const { containerWidth, containerHeight } = this.props;
+    const { containerWidth, containerHeight, isDragging } = this.props;
 
     return <TimelineCanvas className='timelineMarkerCanvas'
                            containerWidth={containerWidth}
                            containerHeight={containerHeight}
+                           isDragging={isDragging}
                            onDoubleClickItem={this.onDoubleClickMarker}
                            getHoveredItemInfo={this.getHoveredMarkerInfo}
                            drawCanvas={this.drawCanvas}

--- a/src/content/components/TimelineViewport.js
+++ b/src/content/components/TimelineViewport.js
@@ -484,6 +484,7 @@ export default function withTimelineViewport<T>(WrappedComponent: ReactClass<T>)
                             viewportRight={viewportRight}
                             viewportTop={viewportTop}
                             viewportBottom={viewportBottom}
+                            isDragging={isDragging}
                             {...this.props} />
           <div className={shiftScrollClassName}>
             Zoom Timeline:

--- a/src/content/components/Tooltip.css
+++ b/src/content/components/Tooltip.css
@@ -1,0 +1,64 @@
+.tooltipMount {
+  pointer-events: none;
+  /* Stack the tooltip mounting point above the #root element. */
+  z-index: 1;
+}
+
+.tooltip {
+  position: fixed;
+  max-width: 100%;
+  box-sizing: border-box;
+  display: inline-block;
+  padding: 2px 5px;
+  border: 1px solid #ccc;
+  background-color: #f9f9f9;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: opacity 250ms;
+  box-sizing: border-box;
+}
+
+.tooltipTiming {
+  padding-right: 0.5em;
+  color: #666;
+  font-weight: bold;
+}
+
+.tooltipOneLine {
+  display: flex;
+  max-width: 100%;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.tooltipName {
+  flex: 1;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+.tooltipSwatch {
+  width: 10px;
+  height: 10px;
+  display: inline-block;
+  border: 1px solid #888;
+  margin-right: 3px;
+}
+
+.tooltipHeader {
+  padding-bottom: 10px;
+  margin-bottom: 10px;
+  border-bottom: 1px solid var(--theme-highlight-gray);
+}
+
+.tooltipDetails {
+  margin: 5px 0;
+}
+
+.tooltipLabel {
+  display: block;
+  width: 60px;
+  color: #666;
+}

--- a/src/content/components/Tooltip.js
+++ b/src/content/components/Tooltip.js
@@ -1,0 +1,137 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+import React, { PureComponent } from 'react';
+import ReactDOM from 'react-dom';
+import type { CssPixels } from '../../common/types/units';
+
+require('./Tooltip.css');
+
+const MOUSE_OFFSET = 21;
+
+type Props = {
+  mouseX: CssPixels,
+  mouseY: CssPixels,
+  children?: React$Element<*>,
+}
+
+export default class Tooltip extends PureComponent {
+  props: Props;
+
+  state: {
+    interiorElement: HTMLElement | null,
+    isNewContentLaidOut: boolean,
+  };
+
+  _isMounted: boolean;
+  _mountElement: ?HTMLElement;
+
+  constructor(props: Props) {
+    super(props);
+    (this: any)._setMountElement = this._setMountElement.bind(this);
+    this.state = {
+      interiorElement: null,
+      isNewContentLaidOut: false,
+    };
+  }
+
+  _setMountElement(el: HTMLElement) {
+    this.setState({ interiorElement: el });
+  }
+
+  componentDidMount() {
+    this._isMounted = true;
+    // Create a DOM node outside of the normal heirarchy.
+    const el = document.createElement('div');
+    el.className = 'tooltipMount';
+
+    // Satisfy flow null checks.
+    if (!document.body) {
+      throw new Error('No document body was found to append to.');
+    }
+    document.body.appendChild(el);
+    this._mountElement = el;
+    this._renderTooltipContents();
+  }
+
+  componentWillUnmount() {
+    ReactDOM.unmountComponentAtNode(this._mountElement);
+    // Satisfy flow null checks.
+    if (this._mountElement) {
+      this._mountElement.remove();
+    }
+    this._isMounted = false;
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    if (nextProps.children !== this.props.children) {
+      // If the children are different, allow them to do an initial lay out on the DOM.
+      this.setState({isNewContentLaidOut: false });
+      this._forceUpdateAfterRAF();
+    }
+  }
+
+  componentDidUpdate() {
+    // Force an additional update to this component if the children content is
+    // different as it needs to fully lay out one time on the DOM to proper calculate
+    // sizing and positioning.
+    const { interiorElement, isNewContentLaidOut } = this.state;
+    if (interiorElement && !isNewContentLaidOut) {
+      this._forceUpdateAfterRAF();
+    }
+
+    this._renderTooltipContents();
+  }
+
+  /**
+   * Children content needs to be on the DOM (not just virtual DOM) in order to correctly
+   * calculate the sizing and positioning of the tooltip.
+   */
+  _forceUpdateAfterRAF() {
+    requestAnimationFrame(() => {
+      if (this._isMounted) {
+        this.setState({ isNewContentLaidOut: true });
+      }
+    });
+  }
+
+  /**
+   * This is really ugly, but the tooltip needs to be outside of the normal
+   * DOM heirarchy so it isn't clipped by some arbitrary stacking context.
+   */
+  _renderTooltipContents() {
+    const { children, mouseX, mouseY } = this.props;
+    const { interiorElement } = this.state;
+
+    const offsetX = interiorElement
+      ? Math.max(0, (mouseX + interiorElement.offsetWidth) - window.innerWidth)
+      : 0;
+
+    let offsetY = 0;
+    if (interiorElement) {
+      if (mouseY + interiorElement.offsetHeight + MOUSE_OFFSET > window.innerHeight) {
+        offsetY = interiorElement.offsetHeight + MOUSE_OFFSET;
+      } else {
+        offsetY = -MOUSE_OFFSET;
+      }
+    }
+
+    const style = {
+      left: mouseX - offsetX,
+      top: mouseY - offsetY,
+    };
+
+    ReactDOM.render(
+      <div className='tooltip' style={style} ref={this._setMountElement}>
+        {children}
+      </div>,
+      this._mountElement
+    );
+  }
+
+  render() {
+    return null;
+  }
+}

--- a/src/content/containers/ProfileViewerHeader.js
+++ b/src/content/containers/ProfileViewerHeader.js
@@ -84,7 +84,8 @@ class ProfileViewerHeader extends PureComponent {
                                            rangeEnd={timeRange.end}
                                            threadIndex={threadIndex}
                                            key={threadIndex}
-                                           onSelect={this._onIntervalMarkerSelect} /> : null)
+                                           onSelect={this._onIntervalMarkerSelect}
+                                           isModifyingSelection={selection.isModifying} /> : null)
             );
           })
         }
@@ -101,7 +102,8 @@ class ProfileViewerHeader extends PureComponent {
                                                     rangeEnd={timeRange.end}
                                                     threadIndex={threadIndex}
                                                     key={threadIndex}
-                                                    onSelect={this._onIntervalMarkerSelect} /> : null)
+                                                    onSelect={this._onIntervalMarkerSelect}
+                                                    isModifyingSelection={selection.isModifying} /> : null)
             );
           })
         }

--- a/src/content/profile-data.js
+++ b/src/content/profile-data.js
@@ -249,17 +249,17 @@ function _filterThreadByFunc(
  * @param {Object} thread - A thread.
  * @returns {Object} The thread with collapsed samples.
  */
-export function collapsePlatformStackFrames(thread: Thread) {
+export function collapsePlatformStackFrames(thread: Thread): Thread {
   return timeCode('collapsePlatformStackFrames', () => {
     const { stackTable, funcTable, frameTable, samples, stringTable } = thread;
 
     // Create new tables for the data.
-    const newStackTable = {
+    const newStackTable: StackTable = {
       length: 0,
       frame: [],
       prefix: [],
     };
-    const newFrameTable = {
+    const newFrameTable: FrameTable = {
       length: frameTable.length,
       implementation: frameTable.implementation.slice(),
       optimizations: frameTable.optimizations.slice(),
@@ -268,12 +268,14 @@ export function collapsePlatformStackFrames(thread: Thread) {
       func: frameTable.func.slice(),
       address: frameTable.address.slice(),
     };
-    const newFuncTable = {
+    const newFuncTable: FuncTable = {
       length: funcTable.length,
       name: funcTable.name.slice(),
       resource: funcTable.resource.slice(),
       address: funcTable.address.slice(),
       isJS: funcTable.isJS.slice(),
+      fileName: funcTable.fileName.slice(),
+      lineNumber: funcTable.lineNumber.slice(),
     };
 
     // Create a Map that takes a prefix and frame as input, and maps it to the new stack
@@ -320,6 +322,8 @@ export function collapsePlatformStackFrames(thread: Thread) {
               newFuncTable.resource.push(-1);
               newFuncTable.address.push(-1);
               newFuncTable.isJS.push(false);
+              newFuncTable.fileName.push(null);
+              newFuncTable.lineNumber.push(null);
               if (newFuncTable.name.length !== newFuncTable.length) {
                 console.error('length is not correct', newFuncTable.name.length, newFuncTable.length);
               }

--- a/src/test/components/__snapshots__/TimelineMarkers.test.js.snap
+++ b/src/test/components/__snapshots__/TimelineMarkers.test.js.snap
@@ -29,13 +29,14 @@ exports[`renders TimelineMarkers correctly 1`] = `
     onMouseDown={[Function]}
     onWheel={[Function]}
   >
-    <canvas
-      className="timelineCanvas timelineMarkerCanvas"
-      onDoubleClick={[Function]}
-      onMouseMove={[Function]}
-      onMouseOut={[Function]}
-      title={null}
-    />
+    <div>
+      <canvas
+        className="timelineCanvas timelineMarkerCanvas"
+        onDoubleClick={[Function]}
+        onMouseMove={[Function]}
+        onMouseOut={[Function]}
+      />
+    </div>
     <div
       className="timelineViewportShiftScroll hidden"
     >

--- a/src/test/store/fixtures/profiles.js
+++ b/src/test/store/fixtures/profiles.js
@@ -79,7 +79,6 @@ export function getEmptyThread(overrides: ?Object): Thread {
     libs: [],
     funcTable: {
       address: [],
-      libs: [],
       isJS: false,
       name: [],
       resource: [],


### PR DESCRIPTION
This adds a styled `Tooltip` component. Tooltips are surprisingly difficult, because a `Tooltip` component wants to be controlled and instantiated from some arbitrary point in the DOM and component hierarchy. However, tooltips DOM elements need to be created outside of that point to avoid clipping and placement issues with the current stacking context. React does not have a good built-in metaphor to do this.

# Approaches

## React DOM (Currently implemented)

With this implementation it's nice because each `Tooltip` component can be local to where it is created, but it doesn't create any DOM nodes until it's actually used. The React metaphor is maintained when actually using `Tooltip` component, as tooltips can be created locally by individual components. However the actual implementation has some funkiness where it re-renders manually on props changes using React DOM. I don't foresee any way this is brittle at the moment, as it works similarly to how any component manually editing the DOM would work, but uses the React DOM render method.

## Using redux:

I evaluated placing the tooltip into the Redux store, but I was afraid of the performance impacts of constantly updating tooltip positions on `mousemove`.

## Shared react component

This implementation would create a separate `Tooltip` mounted at startup, and existing for the lifetime of the application. It would then be passed somehow (either manually through props, globally, or through a connected component) and those components could set and unset the text.

## React Context

Another approach could be to use a React context, but the docs make it sound like we can't guarantee on this feature continuing to exist. The pros would be a pretty clear abstraction for how the Tooltip works, but then the cons is trusting on a React API with an unclear future.

## In conclusion

I'm fine with this current ReactDOM approach, but would listen to feedback if anyone feels strongly against it.