### PR TITLE
Mention thread name in jank marker tooltips

### DIFF
--- a/src/content/profile-data.js
+++ b/src/content/profile-data.js
@@ -710,7 +710,11 @@ export function getSampleIndexClosestToTime(samples: SamplesTable, time: number)
   return samples.length - 1;
 }
 
-export function getJankInstances(samples: SamplesTable, processType: string, thresholdInMs: number): TracingMarker[] {
+function addTracingMarker(tracingMarkers: TracingMarker[], start, dur, title, name, data) {
+  tracingMarkers.push({start, dur, title, name, data});
+}
+
+export function getJankInstances(samples: SamplesTable, threadName: string, thresholdInMs: number): TracingMarker[] {
   let lastResponsiveness = 0;
   let lastTimestamp = 0;
   const jankInstances = [];
@@ -718,26 +722,24 @@ export function getJankInstances(samples: SamplesTable, processType: string, thr
     const currentResponsiveness = samples.responsiveness[i];
     if (currentResponsiveness < lastResponsiveness) {
       if (lastResponsiveness >= thresholdInMs) {
-        jankInstances.push({
-          start: lastTimestamp - lastResponsiveness,
-          dur: lastResponsiveness,
-          title: `${lastResponsiveness.toFixed(2)}ms event processing delay on ${processType} thread`,
-          name: 'Jank',
-          data: null,
-        });
+        addTracingMarker(jankInstances,
+                         lastTimestamp - lastResponsiveness,
+                         lastResponsiveness,
+                         `${lastResponsiveness.toFixed(2)}ms event processing delay on ${threadName}`,
+                         'Jank',
+                         null);
       }
     }
     lastResponsiveness = currentResponsiveness;
     lastTimestamp = samples.time[i];
   }
   if (lastResponsiveness >= thresholdInMs) {
-    jankInstances.push({
-      start: lastTimestamp - lastResponsiveness,
-      dur: lastResponsiveness,
-      title: `${lastResponsiveness.toFixed(2)}ms event processing delay on ${processType} thread`,
-      name: 'Jank',
-      data: null,
-    });
+    addTracingMarker(jankInstances,
+                     lastTimestamp - lastResponsiveness,
+                     lastResponsiveness,
+                     `${lastResponsiveness.toFixed(2)}ms event processing delay on ${threadName}`,
+                     'Jank',
+                     null);
   }
   return jankInstances;
 }

--- a/src/content/profile-data.js
+++ b/src/content/profile-data.js
@@ -735,11 +735,15 @@ export function getSampleIndexClosestToTime(samples: SamplesTable, time: number)
   return samples.length - 1;
 }
 
-function addTracingMarker(tracingMarkers: TracingMarker[], start, dur, title, name, data) {
-  tracingMarkers.push({start, dur, title, name, data});
-}
-
 export function getJankInstances(samples: SamplesTable, threadName: string, thresholdInMs: number): TracingMarker[] {
+  const addTracingMarker = () => jankInstances.push({
+    start: lastTimestamp - lastResponsiveness,
+    dur: lastResponsiveness,
+    title: `${lastResponsiveness.toFixed(2)}ms event processing delay on ${threadName}`,
+    name: 'Jank',
+    data: null,
+  });
+
   let lastResponsiveness = 0;
   let lastTimestamp = 0;
   const jankInstances = [];
@@ -747,24 +751,14 @@ export function getJankInstances(samples: SamplesTable, threadName: string, thre
     const currentResponsiveness = samples.responsiveness[i];
     if (currentResponsiveness < lastResponsiveness) {
       if (lastResponsiveness >= thresholdInMs) {
-        addTracingMarker(jankInstances,
-                         lastTimestamp - lastResponsiveness,
-                         lastResponsiveness,
-                         `${lastResponsiveness.toFixed(2)}ms event processing delay on ${threadName}`,
-                         'Jank',
-                         null);
+        addTracingMarker();
       }
     }
     lastResponsiveness = currentResponsiveness;
     lastTimestamp = samples.time[i];
   }
   if (lastResponsiveness >= thresholdInMs) {
-    addTracingMarker(jankInstances,
-                     lastTimestamp - lastResponsiveness,
-                     lastResponsiveness,
-                     `${lastResponsiveness.toFixed(2)}ms event processing delay on ${threadName}`,
-                     'Jank',
-                     null);
+    addTracingMarker();
   }
   return jankInstances;
 }

--- a/src/content/reducers/profile-view.js
+++ b/src/content/reducers/profile-view.js
@@ -423,8 +423,8 @@ export const selectorsForThread = (threadIndex: ThreadIndex): SelectorsForThread
     );
     const getJankInstances = createSelector(
       _getRangeFilteredThreadSamples,
-      (state: State): string => getThread(state).processType,
-      (samples, processType): TracingMarker[] => ProfileData.getJankInstances(samples, processType, 50)
+      getFriendlyThreadName,
+      (samples, threadName): TracingMarker[] => ProfileData.getJankInstances(samples, threadName, 50)
     );
     const getTracingMarkers = createSelector(
       getThread,


### PR DESCRIPTION
This is addressing #368 . I reused `getFriendlyThreadName`, so the tooltips does not match exactly what was written in the issue. Happy to change that if needed.