### PR TITLE
Use PERFHTML_PORT env variable for the 'npm run start' script

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ yarn install
 yarn start
 ```
 
+> To run on a different port, set the `PERFHTML_PORT` env variable to something else, eg `PERFHTML_PORT=1234 yarn start`
+
 > To run a faster production version use `yarn start-prod` instead of `yarn start`
 
 Assuming you've installed the add-on from [perf-html.io](https://perf-html.io/) you'll need to configure it to point to your local web development server.

--- a/server.js
+++ b/server.js
@@ -13,10 +13,10 @@ new WebpackDevServer(webpack(config), {
   stats: {
     colors: true,
   },
-}).listen(4242, 'localhost', function (err) {
+}).listen(process.env.PERFHTML_PORT || 4242, 'localhost', function (err) {
   if (err) {
     console.log(err);
   }
 
-  console.log('Listening at localhost:4242');
+  console.log(`Listening at localhost:${process.env.PERFHTML_PORT}`);
 });

--- a/server.js
+++ b/server.js
@@ -20,4 +20,7 @@ new WebpackDevServer(webpack(config), {
   }
 
   console.log(`Listening at localhost:${port}`);
+  if (port === 4242) {
+    console.log('You can change this default port with the environment variable PERFHTML_PORT.');
+  }
 });

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ const webpack = require('webpack');
 const WebpackDevServer = require('webpack-dev-server');
 const config = require('./webpack.config');
 const baseConfig = config[0];
+const port = process.env.PERFHTML_PORT || 4242;
 
 new WebpackDevServer(webpack(config), {
   contentBase: baseConfig.output.path,
@@ -13,10 +14,10 @@ new WebpackDevServer(webpack(config), {
   stats: {
     colors: true,
   },
-}).listen(process.env.PERFHTML_PORT || 4242, 'localhost', function (err) {
+}).listen(port, 'localhost', function (err) {
   if (err) {
     console.log(err);
   }
 
-  console.log(`Listening at localhost:${process.env.PERFHTML_PORT}`);
+  console.log(`Listening at localhost:${port}`);
 });


### PR DESCRIPTION
Fixes #396