### PR TITLE
Add a max-width for the breadcrumbs so they stay usable

### DIFF
--- a/src/components/calltree/FilterNavigatorBar.css
+++ b/src/components/calltree/FilterNavigatorBar.css
@@ -27,6 +27,7 @@
   border-right-color: transparent !important;
   padding: 0 6px 0 8px;
   background-clip: padding-box;
+  max-width: 20%;
 }
 
 .filterNavigatorBarRootItem {

--- a/src/components/calltree/FilterNavigatorBar.js
+++ b/src/components/calltree/FilterNavigatorBar.js
@@ -37,6 +37,7 @@ class FilterNavigatorBar extends PureComponent {
                     'filterNavigatorBarSelectedItem': i === selectedItem,
                     'filterNavigatorBarLeafItem': i === items.length - 1,
                   })}
+                title={item}
                 onClick={this._onLiClick}>
               <span className='filterNavigatorBarItemContent'>{item}</span>
             </li>


### PR DESCRIPTION
Fixes #340

I believe a `max-width` of `20%` makes sense, thoughts?

Here's what it looks like:

<img width="573" alt="screen shot 2017-06-28 at 15 13 31" src="https://user-images.githubusercontent.com/167767/27662871-9d081244-5c14-11e7-88ae-17980cb310c3.png">
