### PR TITLE
Display duration of time range while selecting

### DIFF
--- a/res/style.css
+++ b/res/style.css
@@ -545,6 +545,14 @@ body {
   min-height: 0;
 }
 
+.selectionScrubberRange {
+  opacity: 0.5;
+}
+
+.selectionScrubberRange.hidden {
+  display: none;
+}
+
 .selectionScrubberZoomButton {
   width: 30px;
   height: 30px;

--- a/res/style.css
+++ b/res/style.css
@@ -546,16 +546,20 @@ body {
 }
 
 .selectionScrubberRange {
-  background-color: white;
-  border: 1px solid;
-  border-radius: 3px;
-  font-size: 1.2em;
-  opacity: 0.5;
-  padding: 0.2em 1em;
+  top: 20px;
+  position: absolute;
+  padding: 4px 8px;
+  color: #fff;
+  background-color: #8095ca;
+  border-radius: 0 0 4px 4px;
+  box-shadow: 0 2px 2px rgba(0, 0, 0, 0.2);
+  pointer-events: none;
+  opacity: 1;
+  transition: opacity 200ms;
 }
 
 .selectionScrubberRange.hidden {
-  display: none;
+  opacity: 0;
 }
 
 .selectionScrubberZoomButton {

--- a/res/style.css
+++ b/res/style.css
@@ -546,7 +546,12 @@ body {
 }
 
 .selectionScrubberRange {
+  background-color: white;
+  border: 1px solid;
+  border-radius: 3px;
+  font-size: 1.2em;
   opacity: 0.5;
+  padding: 0.2em 1em;
 }
 
 .selectionScrubberRange.hidden {

--- a/src/components/header/SelectionScrubberOverlay.js
+++ b/src/components/header/SelectionScrubberOverlay.js
@@ -8,7 +8,6 @@ import clamp from 'clamp';
 import Draggable from '../shared/Draggable';
 import { getFormattedTimeLength } from '../../profile-logic/range-filters';
 
-
 export default class SelectionScubberOverlay extends PureComponent {
   constructor(props) {
     super(props);
@@ -100,7 +99,11 @@ export default class SelectionScubberOverlay extends PureComponent {
             />
           </div>
           <div className="selectionScrubberInner">
-            <span className={classNames('selectionScrubberRange', { hidden: !isModifying })}>
+            <span
+              className={classNames('selectionScrubberRange', {
+                hidden: !isModifying,
+              })}
+            >
               {getFormattedTimeLength(selectionEnd - selectionStart)}
             </span>
             <button

--- a/src/components/header/SelectionScrubberOverlay.js
+++ b/src/components/header/SelectionScrubberOverlay.js
@@ -6,6 +6,8 @@ import React, { PureComponent, PropTypes } from 'react';
 import classNames from 'classnames';
 import clamp from 'clamp';
 import Draggable from '../shared/Draggable';
+import { getFormattedTimeLength } from '../../profile-logic/range-filters';
+
 
 export default class SelectionScubberOverlay extends PureComponent {
   constructor(props) {
@@ -98,6 +100,9 @@ export default class SelectionScubberOverlay extends PureComponent {
             />
           </div>
           <div className="selectionScrubberInner">
+            <span className={classNames('selectionScrubberRange', { hidden: !isModifying })}>
+              {getFormattedTimeLength(selectionEnd - selectionStart)}
+            </span>
             <button
               className={classNames('selectionScrubberZoomButton', {
                 hidden: isModifying,


### PR DESCRIPTION
Fixes #363

This is what it looks like: 

![timerange](https://user-images.githubusercontent.com/167767/27714943-ea5ad872-5ce8-11e7-98d0-61770e032697.png)

As soon as the range is not modified anymore, this disappears and the zoom button is displayed.

Thoughts?