### PR TITLE
add Flow type definitions to TabBar

### DIFF
--- a/src/components/app/ProfileViewer.js
+++ b/src/components/app/ProfileViewer.js
@@ -28,6 +28,8 @@ import ProfileCallTreeContextMenu from '../calltree/ProfileCallTreeContextMenu';
 import ProfileThreadHeaderContextMenu from '../header/ProfileThreadHeaderContextMenu';
 
 import type { StartEndRange } from '../../types/units';
+import type { Tab } from './TabBar';
+import type { Action } from '../../types/actions';
 
 type Props = {
   className: string,
@@ -35,7 +37,7 @@ type Props = {
   timeRange: StartEndRange,
   selectedTab: string,
   changeSelectedTab: string => void,
-  changeTabOrder: (number[]) => void,
+  changeTabOrder: (number[]) => Action,
 };
 
 class ProfileViewer extends PureComponent {
@@ -43,7 +45,7 @@ class ProfileViewer extends PureComponent {
   state: {
     isMounted: boolean,
   };
-  _tabs: { name: string, title: string }[];
+  _tabs: Tab[];
 
   constructor(props) {
     super(props);

--- a/src/components/app/TabBar.js
+++ b/src/components/app/TabBar.js
@@ -2,17 +2,35 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+// @flow
+
 import React, { PureComponent, PropTypes } from 'react';
 import classNames from 'classnames';
 import Reorderable from '../shared/Reorderable';
 
+import type { Action } from '../../types/actions';
+
+export type Tab = {
+  name: string,
+  title: string,
+};
+
+type Props = {
+  className?: string,
+  tabs: Tab[],
+  selectedTabName: string,
+  tabOrder: number[],
+  onSelectTab: string => void,
+  onChangeTabOrder: (number[]) => Action,
+};
+
 class TabBar extends PureComponent {
-  constructor(props) {
+  constructor(props: Props) {
     super(props);
-    this._mouseDownListener = this._mouseDownListener.bind(this);
+    (this: any)._mouseDownListener = this._mouseDownListener.bind(this);
   }
 
-  _mouseDownListener(e) {
+  _mouseDownListener(e: SyntheticMouseEvent & { target: HTMLElement }) {
     this.props.onSelectTab(e.target.dataset.name);
   }
 

--- a/src/components/shared/Reorderable.js
+++ b/src/components/shared/Reorderable.js
@@ -9,14 +9,16 @@ import bisection from 'bisection';
 import clamp from 'clamp';
 import arrayMove from 'array-move';
 import { getContentRect, getMarginRect } from '../../utils/css-geometry-tools';
+
 import type { DOMRectLiteral } from '../../utils/dom-rect';
+import type { Action } from '../../types/actions';
 
 type Props = {|
   orient: 'horizontal' | 'vertical',
   tagName: string,
   className: string,
   order: number[],
-  onChangeOrder: (number[]) => {},
+  onChangeOrder: (number[]) => Action,
   children?: React$Element<*>,
 |};
 


### PR DESCRIPTION
`TabBar` exports a new `Tab` type for use by TabBar consumers (that is, `ProfileViewer`).

This changes the signatures of `ProfileViewer.changeTabOrder` and `Reorderable.onChangeOrder` to both return `Action`, so that `TabBar.onChangeTabOrder` doesn't have to use an `any` return type.