### PR TITLE
Add the GC reason to the timeline tooltips for GCMajor and GCSlice

### DIFF
--- a/src/components/shared/MarkerTooltipContents.js
+++ b/src/components/shared/MarkerTooltipContents.js
@@ -11,26 +11,37 @@ import formatTimeLength from '../../utils/format-time-length';
 import type { TracingMarker } from '../../types/profile-derived';
 import type { MarkerPayload } from '../../types/markers';
 
+function _markerDetail<T>(
+  key: string,
+  label: string,
+  value: string
+): Array<React$Element<*> | string> {
+  if (value) {
+    return [
+      <div className="tooltipLabel" key="{key}">
+        {label}:
+      </div>,
+      value,
+    ];
+  } else {
+    return [];
+  }
+}
+
 function getMarkerDetails(data: MarkerPayload): React$Element<*> | null {
   if (data) {
     switch (data.type) {
       case 'UserTiming': {
         return (
           <div className="tooltipDetails">
-            <div className="tooltipLabel" key="name">
-              Name:
-            </div>
-            {data.name}
+            {_markerDetail('name', 'Name', data.name)}
           </div>
         );
       }
       case 'DOMEvent': {
         return (
           <div className="tooltipDetails">
-            <div className="tooltipLabel" key="type">
-              Type:
-            </div>
-            {data.eventType}
+            {_markerDetail('type', 'Type', data.eventType)}
           </div>
         );
       }

--- a/src/components/shared/MarkerTooltipContents.js
+++ b/src/components/shared/MarkerTooltipContents.js
@@ -47,7 +47,7 @@ function getMarkerDetails(data: MarkerPayload): React$Element<*> | null {
         );
       }
       case 'GCMinor': {
-        if (data.nursery && data.nursery.reason) {
+        if (data.nursery) {
           return (
             <div className="tooltipDetails">
               {_markerDetail('gcreason', 'Reason', data.nursery.reason)}

--- a/src/components/shared/MarkerTooltipContents.js
+++ b/src/components/shared/MarkerTooltipContents.js
@@ -45,6 +45,54 @@ function getMarkerDetails(data: MarkerPayload): React$Element<*> | null {
           </div>
         );
       }
+      case 'GCMinor': {
+        if (data.nursery && data.nursery.reason) {
+          return (
+            <div className="tooltipDetails">
+              {_markerDetail('gcreason', 'Reason', data.nursery.reason)}
+            </div>
+          );
+        } else {
+          return null;
+        }
+      }
+      case 'GCMajor':
+        return (
+          <div className="tooltipDetails">
+            {_markerDetail('gcreason', 'Reason', data.timings.reason)}
+            {data.timings.nonincremental_reason !== 'None' &&
+              _markerDetail(
+                'gcnonincrementalreason',
+                'Non-incremental reason',
+                data.timings.nonincremental_reason
+              )}
+            {_markerDetail('gcmaxpause', 'Max Pause', data.timings.max_pause)}
+            {_markerDetail(
+              'gcnumminors',
+              'Minor GCs Count',
+              data.timings.minor_gcs
+            )}
+            {_markerDetail('gcnumslices', 'Slices Count', data.timings.slices)}
+            {_markerDetail(
+              'gcnumzones',
+              'Zones Collected',
+              data.timings.zones_collected
+            )}
+          </div>
+        );
+      case 'GCSlice': {
+        return (
+          <div className="tooltipDetails">
+            {_markerDetail('gcreason', 'Reason', data.timings.reason)}
+            {_markerDetail('gcbudget', 'Budget', data.timings.budget)}
+            {_markerDetail(
+              'gcstate',
+              'States',
+              data.timings.initial_state + ' \u2013 ' + data.timings.final_state
+            )}
+          </div>
+        );
+      }
       default:
     }
   }

--- a/src/components/shared/MarkerTooltipContents.js
+++ b/src/components/shared/MarkerTooltipContents.js
@@ -14,14 +14,15 @@ import type { MarkerPayload } from '../../types/markers';
 function _markerDetail<T>(
   key: string,
   label: string,
-  value: string
+  value: T,
+  fn: T => string = String
 ): Array<React$Element<*> | string> {
   if (value) {
     return [
       <div className="tooltipLabel" key="{key}">
         {label}:
       </div>,
-      value,
+      fn(value),
     ];
   } else {
     return [];
@@ -56,7 +57,12 @@ function getMarkerDetails(data: MarkerPayload): React$Element<*> | null {
           return null;
         }
       }
-      case 'GCMajor':
+      case 'GCMajor': {
+        let zones_collected_total;
+        if (data.timings.zones_collected && data.timings.total_zones) {
+          zones_collected_total =
+            data.timings.zones_collected + ' / ' + data.timings.total_zones;
+        }
         return (
           <div className="tooltipDetails">
             {_markerDetail('gcreason', 'Reason', data.timings.reason)}
@@ -66,20 +72,18 @@ function getMarkerDetails(data: MarkerPayload): React$Element<*> | null {
                 'Non-incremental reason',
                 data.timings.nonincremental_reason
               )}
-            {_markerDetail('gcmaxpause', 'Max Pause', data.timings.max_pause)}
             {_markerDetail(
-              'gcnumminors',
-              'Minor GCs Count',
-              data.timings.minor_gcs
+              'gcmaxpause',
+              'Max Pause',
+              data.timings.max_pause,
+              x => x + 'ms'
             )}
-            {_markerDetail('gcnumslices', 'Slices Count', data.timings.slices)}
-            {_markerDetail(
-              'gcnumzones',
-              'Zones Collected',
-              data.timings.zones_collected
-            )}
+            {_markerDetail('gcnumminors', 'Minor GCs', data.timings.minor_gcs)}
+            {_markerDetail('gcnumslices', 'Slices', data.timings.slices)}
+            {_markerDetail('gcnumzones', 'Zones', zones_collected_total)}
           </div>
         );
+      }
       case 'GCSlice': {
         return (
           <div className="tooltipDetails">

--- a/src/components/shared/Tooltip.css
+++ b/src/components/shared/Tooltip.css
@@ -61,4 +61,6 @@
 
 .tooltipLabel {
   color: #666;
+  white-space: nowrap;
+  text-align: right;
 }

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -48,6 +48,44 @@ export type PaintProfilerMarkerTracing = ProfilerMarkerTracing & {
     | 'Composite',
 };
 
+export type GCMinorMarkerPayload = {
+  type: 'GCMinor',
+  startTime: Milliseconds,
+  endTime: Milliseconds,
+  // nursery is only present in newer profile format.
+  nursery?: {|
+    reason?: string,
+    status?: string,
+  |},
+};
+
+export type GCMajorMarkerPayload = {
+  type: 'GCMajor',
+  startTime: Milliseconds,
+  endTime: Milliseconds,
+  timings: {|
+    zones_collected: number,
+    total_zones: number,
+    reason: string,
+    nonincremental_reason: string,
+    max_pause: Milliseconds,
+    minor_gcs: number,
+    slices: number,
+  |},
+};
+
+export type GCSliceMarkerPayload = {
+  type: 'GCSlice',
+  startTime: Milliseconds,
+  endTime: Milliseconds,
+  timings: {|
+    reason: string,
+    budget: Milliseconds,
+    initial_state: string,
+    final_state: string,
+  |},
+};
+
 // TODO - Add more markers.
 
 /**
@@ -79,4 +117,7 @@ export type MarkerPayload =
   | UserTimingMarkerPayload
   | PaintProfilerMarkerTracing
   | DOMEventMarkerPayload
+  | GCMinorMarkerPayload
+  | GCMajorMarkerPayload
+  | GCSliceMarkerPayload
   | null;


### PR DESCRIPTION
Add the GC reason to the tooltip for GCSlice and GCMajor markers in the timeline view.  Note that GCMinor doesn't currently have this data so it cannot be shown.

This is intentionally a simple change for my first contribution to a JavaScript project.  There's plenty more information on these markers that could be exposed.

Thank you.