### PR TITLE
Turn on external sourcemaps for production builds

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,6 +35,7 @@ const baseConfig = {
     },
     extensions: ['.js'],
   },
+  devtool: 'source-map',
   module: {
     rules: [
       {


### PR DESCRIPTION
This will make it easier to debug production issues, and only adds a short URL to the production bundle.

the tail of `ec505ba8b5a09105a404.bundle.js`:
```
...ect(e)})}}function o(e,t){if(n())return void navigator.serviceWorker.getRegistration().then(function(n){if(!n||!n.waiting)return void(t&&t());n.waiting.postMessage({action:"skipWaiting"}),e&&e()})}function a(){n()&&navigator.serviceWorker.getRegistration().then(function(e){if(e)return e.update()})}t.install=r,t.applyUpdate=o,t.update=a}]);
//# sourceMappingURL=ec505ba8b5a09105a404.bundle.js.map
```