### PR TITLE
Add DOMEvent name to the Markers View

### DIFF
--- a/src/components/markers/ProfileMarkersView.js
+++ b/src/components/markers/ProfileMarkersView.js
@@ -11,6 +11,7 @@ import {
 } from '../../reducers/profile-view';
 import { getSelectedThreadIndex } from '../../reducers/url-state';
 import actions from '../../actions';
+import formatTimeLength from '../../utils/format-time-length';
 
 class MarkerTree {
   constructor(thread, zeroAt) {
@@ -83,6 +84,13 @@ class MarkerTree {
           case 'UserTiming':
             name = `${name} [${data.name}]`;
             break;
+
+          case 'DOMEvent': {
+            category = 'DOMEvent';
+            const duration = data.endTime - data.startTime;
+            name = `[${formatTimeLength(duration)}ms] ${data.eventType}`;
+            break;
+          }
 
           default:
         }


### PR DESCRIPTION
@julienw I'm not sure if changing `category` is a good idea here since for GC and UserTiming are still using `unknown`. It looks better to me this way though.

![screenshot from 2017-07-28 18-21-33](https://user-images.githubusercontent.com/17571/28713668-a3af7cfc-73c2-11e7-9498-d7705246053e.png)
