### PR TITLE
Remove console.error from SymbolStore test

### DIFF
--- a/src/test/unit/symbol-store.test.js
+++ b/src/test/unit/symbol-store.test.js
@@ -82,6 +82,11 @@ describe('SymbolStore', function() {
   });
 
   it('should persist in DB', async function() {
+    // This test outputs a console.error that muddies up test output. Temporarily
+    // disable the output.
+    const originalConsoleError = console.error;
+    console.error = () => {};
+
     // Using another symbol store simulates a page reload
     const symbolStore2 = new SymbolStore(
       'perf-html-async-storage',
@@ -94,5 +99,6 @@ describe('SymbolStore', function() {
 
     expect(symbolProvider.requestSymbolTable).toHaveBeenCalledTimes(1);
     expect(addrsForLib2).toEqual(addrsForLib1);
+    console.error = originalConsoleError;
   });
 });


### PR DESCRIPTION
This hides a big red ugly error. I tried to make the error not happen, but the async code is a little hard for me to follow. The error is really getting in the way of the test output.