### PR TITLE
Rename funcStack to CallNodes, funcArray to CallNodePath, ProfileTree to CallTree

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,4 +22,4 @@ This project is a client for reading profiles from the Gecko Profiler and potent
  * [Upgrading profiles](./upgrading-profiles.md)
  * [Potential performance data sources in Gecko](./data-sources.md)
  * [Call tree](./call-tree.md)
- * [Frames, funcs, stacks and funcStacks in C++](./func-stacks.md)
+ * [Frames, funcs, stacks and CallNodes in C++](./call-nodes-in-cpp.md)

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -20,13 +20,13 @@ import type {
  * and filtering. Currently the call tree's actions are in this file, but should be
  * split apart. These actions should most likely affect every panel.
  */
-export function changeSelectedFuncStack(
+export function changeSelectedCallNode(
   threadIndex: ThreadIndex,
-  selectedFuncStack: IndexIntoFuncTable[]
+  selectedCallNodePath: IndexIntoFuncTable[]
 ): Action {
   return {
-    type: 'CHANGE_SELECTED_FUNC_STACK',
-    selectedFuncStack,
+    type: 'CHANGE_SELECTED_CALL_NODE',
+    selectedCallNodePath,
     threadIndex,
   };
 }
@@ -81,14 +81,14 @@ export function changeCallTreeSearchString(searchString: string): Action {
   };
 }
 
-export function changeExpandedFuncStacks(
+export function changeExpandedCallNodes(
   threadIndex: ThreadIndex,
-  expandedFuncStacks: Array<IndexIntoFuncTable[]>
+  expandedCallNodePaths: Array<IndexIntoFuncTable[]>
 ): Action {
   return {
-    type: 'CHANGE_EXPANDED_FUNC_STACKS',
+    type: 'CHANGE_EXPANDED_CALL_NODES',
     threadIndex,
-    expandedFuncStacks,
+    expandedCallNodePaths,
   };
 }
 

--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -30,7 +30,7 @@ import {
 } from '../../actions/profile-view';
 
 import type { IconWithClassName, State } from '../../types/reducers';
-import type { ProfileTreeClass } from '../../profile-logic/profile-tree';
+import type { CallTree } from '../../profile-logic/call-tree';
 import type { Thread, ThreadIndex } from '../../types/profile';
 import type {
   CallNodeInfo,
@@ -43,7 +43,7 @@ type Props = {
   threadIndex: ThreadIndex,
   scrollToSelectionGeneration: number,
   interval: number,
-  tree: ProfileTreeClass,
+  tree: CallTree,
   callNodeInfo: CallNodeInfo,
   selectedCallNodeIndex: IndexIntoCallNodeTable | null,
   expandedCallNodeIndexes: Array<IndexIntoCallNodeTable | null>,
@@ -57,7 +57,7 @@ type Props = {
   addCallTreeFilter: typeof addCallTreeFilter,
 };
 
-class ProfileTreeView extends PureComponent {
+class CallTreeComponent extends PureComponent {
   props: Props;
   _fixedColumns: Column[];
   _mainColumn: Column;
@@ -232,4 +232,4 @@ export default connect(
   { changeSelectedCallNode, changeExpandedCallNodes, addCallTreeFilter },
   null,
   { withRef: true }
-)(ProfileTreeView);
+)(CallTreeComponent);

--- a/src/components/calltree/ProfileCallTreeContextMenu.js
+++ b/src/components/calltree/ProfileCallTreeContextMenu.js
@@ -12,15 +12,15 @@ import { stripFunctionArguments } from '../../profile-logic/function-info';
 import copy from 'copy-to-clipboard';
 
 import type {
-  IndexIntoFuncStackTable,
-  FuncStackInfo,
+  IndexIntoCallNodeTable,
+  CallNodeInfo,
 } from '../../types/profile-derived';
 import type { Thread } from '../../types/profile';
 
 type Props = {
   thread: Thread,
-  funcStackInfo: FuncStackInfo,
-  selectedFuncStack: IndexIntoFuncStackTable,
+  callNodeInfo: CallNodeInfo,
+  selectedCallNodeIndex: IndexIntoCallNodeTable,
 };
 
 class ProfileCallTreeContextMenu extends PureComponent {
@@ -32,12 +32,12 @@ class ProfileCallTreeContextMenu extends PureComponent {
 
   copyFunctionName(): void {
     const {
-      selectedFuncStack,
+      selectedCallNodeIndex,
       thread: { stringTable, funcTable },
-      funcStackInfo: { funcStackTable },
+      callNodeInfo: { callNodeTable },
     } = this.props;
 
-    const funcIndex = funcStackTable.func[selectedFuncStack];
+    const funcIndex = callNodeTable.func[selectedCallNodeIndex];
     const stringIndex = funcTable.name[funcIndex];
     const functionCall = stringTable.getString(stringIndex);
     const name = stripFunctionArguments(functionCall);
@@ -46,12 +46,12 @@ class ProfileCallTreeContextMenu extends PureComponent {
 
   copyUrl(): void {
     const {
-      selectedFuncStack,
+      selectedCallNodeIndex,
       thread: { stringTable, funcTable },
-      funcStackInfo: { funcStackTable },
+      callNodeInfo: { callNodeTable },
     } = this.props;
 
-    const funcIndex = funcStackTable.func[selectedFuncStack];
+    const funcIndex = callNodeTable.func[selectedCallNodeIndex];
     const stringIndex = funcTable.fileName[funcIndex];
     if (stringIndex !== null) {
       const fileName = stringTable.getString(stringIndex);
@@ -61,20 +61,20 @@ class ProfileCallTreeContextMenu extends PureComponent {
 
   copyStack(): void {
     const {
-      selectedFuncStack,
+      selectedCallNodeIndex,
       thread: { stringTable, funcTable },
-      funcStackInfo: { funcStackTable },
+      callNodeInfo: { callNodeTable },
     } = this.props;
 
     let stack = '';
-    let funcStackIndex = selectedFuncStack;
+    let callNodeIndex = selectedCallNodeIndex;
 
     do {
-      const funcIndex = funcStackTable.func[funcStackIndex];
+      const funcIndex = callNodeTable.func[callNodeIndex];
       const stringIndex = funcTable.name[funcIndex];
       stack += stringTable.getString(stringIndex) + '\n';
-      funcStackIndex = funcStackTable.prefix[funcStackIndex];
-    } while (funcStackIndex !== -1);
+      callNodeIndex = callNodeTable.prefix[callNodeIndex];
+    } while (callNodeIndex !== -1);
 
     copy(stack);
   }
@@ -100,11 +100,11 @@ class ProfileCallTreeContextMenu extends PureComponent {
 
   render() {
     const {
-      selectedFuncStack,
+      selectedCallNodeIndex,
       thread: { funcTable },
-      funcStackInfo: { funcStackTable },
+      callNodeInfo: { callNodeTable },
     } = this.props;
-    const funcIndex = funcStackTable.func[selectedFuncStack];
+    const funcIndex = callNodeTable.func[selectedCallNodeIndex];
     const isJS = funcTable.isJS[funcIndex];
 
     return (
@@ -133,8 +133,10 @@ class ProfileCallTreeContextMenu extends PureComponent {
 export default connect(
   state => ({
     thread: selectedThreadSelectors.getFilteredThread(state),
-    funcStackInfo: selectedThreadSelectors.getFuncStackInfo(state),
-    selectedFuncStack: selectedThreadSelectors.getSelectedFuncStack(state),
+    callNodeInfo: selectedThreadSelectors.getCallNodeInfo(state),
+    selectedCallNodeIndex: selectedThreadSelectors.getSelectedCallNodeIndex(
+      state
+    ),
   }),
   actions
 )(ProfileCallTreeContextMenu);

--- a/src/components/calltree/ProfileCallTreeView.js
+++ b/src/components/calltree/ProfileCallTreeView.js
@@ -5,7 +5,7 @@
 // @flow
 
 import React from 'react';
-import ProfileTreeView from './ProfileTreeView';
+import CallTree from './CallTree';
 import ProfileCallTreeSettings from './ProfileCallTreeSettings';
 import ProfileCallTreeFilterNavigator from './ProfileCallTreeFilterNavigator';
 
@@ -13,7 +13,7 @@ const ProfileCallTreeView = () =>
   <div className="treeAndSidebarWrapper">
     <ProfileCallTreeFilterNavigator />
     <ProfileCallTreeSettings />
-    <ProfileTreeView />
+    <CallTree />
   </div>;
 
 ProfileCallTreeView.propTypes = {};

--- a/src/components/header/ProfileThreadHeaderBar.js
+++ b/src/components/header/ProfileThreadHeaderBar.js
@@ -11,7 +11,7 @@ import { selectorsForThread } from '../../reducers/profile-view';
 import { getSelectedThreadIndex } from '../../reducers/url-state';
 import {
   getSampleIndexClosestToTime,
-  getFuncStackAsFuncArray,
+  getCallNodePath,
 } from '../../profile-logic/profile-data';
 import actions from '../../actions';
 import ContextMenuTrigger from '../shared/ContextMenuTrigger';
@@ -23,27 +23,27 @@ import type {
 } from '../../types/profile';
 import type { Milliseconds } from '../../types/units';
 import type {
-  FuncStackInfo,
-  IndexIntoFuncStackTable,
+  CallNodeInfo,
+  IndexIntoCallNodeTable,
 } from '../../types/profile-derived';
 import type { State } from '../../types/reducers';
 
 type Props = {
   threadIndex: ThreadIndex,
   thread: Thread,
-  funcStackInfo: FuncStackInfo,
+  callNodeInfo: CallNodeInfo,
   interval: Milliseconds,
   rangeStart: Milliseconds,
   rangeEnd: Milliseconds,
-  selectedFuncStack: IndexIntoFuncStackTable,
+  selectedCallNodeIndex: IndexIntoCallNodeTable,
   isSelected: boolean,
   isHidden: boolean,
   style: Object,
   threadName: string,
   processDetails: string,
   changeSelectedThread: ThreadIndex => void,
-  changeSelectedFuncStack: (
-    IndexIntoFuncStackTable,
+  changeSelectedCallNode: (
+    IndexIntoCallNodeTable,
     IndexIntoFuncTable[]
   ) => void,
 };
@@ -72,19 +72,16 @@ class ProfileThreadHeaderBar extends PureComponent {
     const { threadIndex, changeSelectedThread } = this.props;
     changeSelectedThread(threadIndex);
     if (time !== undefined) {
-      const { thread, funcStackInfo, changeSelectedFuncStack } = this.props;
+      const { thread, callNodeInfo, changeSelectedCallNode } = this.props;
       const sampleIndex = getSampleIndexClosestToTime(thread.samples, time);
       const newSelectedStack = thread.samples.stack[sampleIndex];
-      const newSelectedFuncStack =
+      const newSelectedCallNode =
         newSelectedStack === null
           ? -1
-          : funcStackInfo.stackIndexToFuncStackIndex[newSelectedStack];
-      changeSelectedFuncStack(
+          : callNodeInfo.stackIndexToCallNodeIndex[newSelectedStack];
+      changeSelectedCallNode(
         threadIndex,
-        getFuncStackAsFuncArray(
-          newSelectedFuncStack,
-          funcStackInfo.funcStackTable
-        )
+        getCallNodePath(newSelectedCallNode, callNodeInfo.callNodeTable)
       );
     }
   }
@@ -97,8 +94,8 @@ class ProfileThreadHeaderBar extends PureComponent {
       interval,
       rangeStart,
       rangeEnd,
-      funcStackInfo,
-      selectedFuncStack,
+      callNodeInfo,
+      selectedCallNodeIndex,
       isSelected,
       style,
       threadName,
@@ -132,8 +129,8 @@ class ProfileThreadHeaderBar extends PureComponent {
           className="threadStackGraph"
           rangeStart={rangeStart}
           rangeEnd={rangeEnd}
-          funcStackInfo={funcStackInfo}
-          selectedFuncStack={selectedFuncStack}
+          callNodeInfo={callNodeInfo}
+          selectedCallNodeIndex={selectedCallNodeIndex}
           onClick={this._onGraphClick}
           onMarkerSelect={this._onMarkerSelect}
         />
@@ -150,10 +147,10 @@ export default connect((state: State, props) => {
     thread: selectors.getFilteredThread(state),
     threadName: selectors.getFriendlyThreadName(state),
     processDetails: selectors.getThreadProcessDetails(state),
-    funcStackInfo: selectors.getFuncStackInfo(state),
-    selectedFuncStack:
+    callNodeInfo: selectors.getCallNodeInfo(state),
+    selectedCallNodeIndex:
       threadIndex === selectedThread
-        ? selectors.getSelectedFuncStack(state)
+        ? selectors.getSelectedCallNodeIndex(state)
         : -1,
     isSelected: threadIndex === selectedThread,
     threadIndex,

--- a/src/components/shared/TreeView.js
+++ b/src/components/shared/TreeView.js
@@ -11,10 +11,7 @@ import { BackgroundImageStyleDef } from './StyleDef';
 
 import ContextMenuTrigger from './ContextMenuTrigger';
 
-import type {
-  IndexIntoFuncStackTable,
-  Node,
-} from '../../types/profile-derived';
+import type { IndexIntoCallNodeTable, Node } from '../../types/profile-derived';
 import type { ProfileTreeClass } from '../../profile-logic/profile-tree';
 import type { IconWithClassName } from '../../types/reducers';
 
@@ -76,11 +73,11 @@ function reactStringWithHighlightedSubstrings(
 
 type TreeViewRowFixedColumnsProps = {
   node: Node,
-  nodeId: IndexIntoFuncStackTable,
+  nodeId: IndexIntoCallNodeTable,
   columns: Column[],
   index: number,
   selected: boolean,
-  onClick: (IndexIntoFuncStackTable, MouseEvent) => mixed,
+  onClick: (IndexIntoCallNodeTable, MouseEvent) => mixed,
   highlightString: string,
 };
 
@@ -133,7 +130,7 @@ class TreeViewRowFixedColumns extends PureComponent {
 
 type TreeViewRowScrolledColumnsProps = {
   node: Node,
-  nodeId: IndexIntoFuncStackTable,
+  nodeId: IndexIntoCallNodeTable,
   depth: number,
   mainColumn: Column,
   appendageColumn: Column,
@@ -142,10 +139,10 @@ type TreeViewRowScrolledColumnsProps = {
   canBeExpanded: boolean,
   isExpanded: boolean,
   selected: boolean,
-  onToggle: (IndexIntoFuncStackTable, boolean, boolean) => mixed,
-  onClick: (IndexIntoFuncStackTable, MouseEvent) => mixed,
+  onToggle: (IndexIntoCallNodeTable, boolean, boolean) => mixed,
+  onClick: (IndexIntoCallNodeTable, MouseEvent) => mixed,
   onAppendageButtonClick:
-    | ((IndexIntoFuncStackTable | null, string) => mixed)
+    | ((IndexIntoCallNodeTable | null, string) => mixed)
     | null,
   highlightString: string,
 };
@@ -252,8 +249,8 @@ type TreeViewProps = {
   fixedColumns: Column[],
   mainColumn: Column,
   tree: ProfileTreeClass,
-  expandedNodeIds: Array<IndexIntoFuncStackTable | null>,
-  selectedNodeId: IndexIntoFuncStackTable | null,
+  expandedNodeIds: Array<IndexIntoCallNodeTable | null>,
+  selectedNodeId: IndexIntoCallNodeTable | null,
   onExpandedNodesChange: PropTypes.func.isRequired,
   highlightString: string,
   appendageColumn: Column,
@@ -263,15 +260,15 @@ type TreeViewProps = {
   contextMenu?: React$Element<*>,
   contextMenuId?: string,
   onAppendageButtonClick:
-    | ((IndexIntoFuncStackTable | null, string) => mixed)
+    | ((IndexIntoCallNodeTable | null, string) => mixed)
     | null,
-  onSelectionChange: IndexIntoFuncStackTable => mixed,
+  onSelectionChange: IndexIntoCallNodeTable => mixed,
 };
 
 class TreeView extends PureComponent {
   props: TreeViewProps;
-  _specialItems: (IndexIntoFuncStackTable | null)[];
-  _visibleRows: IndexIntoFuncStackTable[];
+  _specialItems: (IndexIntoCallNodeTable | null)[];
+  _visibleRows: IndexIntoCallNodeTable[];
   _list: VirtualList | null;
 
   constructor(props: TreeViewProps) {
@@ -309,7 +306,7 @@ class TreeView extends PureComponent {
   }
 
   _renderRow(
-    nodeId: IndexIntoFuncStackTable,
+    nodeId: IndexIntoCallNodeTable,
     index: number,
     columnIndex: number
   ) {
@@ -362,8 +359,8 @@ class TreeView extends PureComponent {
 
   _addVisibleRowsFromNode(
     props: TreeViewProps,
-    arr: IndexIntoFuncStackTable[],
-    nodeId: IndexIntoFuncStackTable,
+    arr: IndexIntoCallNodeTable[],
+    nodeId: IndexIntoCallNodeTable,
     depth: number
   ) {
     arr.push(nodeId);
@@ -385,13 +382,13 @@ class TreeView extends PureComponent {
     return allRows;
   }
 
-  _isCollapsed(nodeId: IndexIntoFuncStackTable) {
+  _isCollapsed(nodeId: IndexIntoCallNodeTable) {
     return !this.props.expandedNodeIds.includes(nodeId);
   }
 
   _addAllDescendants(
-    newSet: Set<IndexIntoFuncStackTable | null>,
-    nodeId: IndexIntoFuncStackTable
+    newSet: Set<IndexIntoCallNodeTable | null>,
+    nodeId: IndexIntoCallNodeTable
   ) {
     this.props.tree.getChildren(nodeId).forEach(childId => {
       newSet.add(childId);
@@ -400,7 +397,7 @@ class TreeView extends PureComponent {
   }
 
   _toggle(
-    nodeId: IndexIntoFuncStackTable,
+    nodeId: IndexIntoCallNodeTable,
     newExpanded: boolean = this._isCollapsed(nodeId),
     toggleAll: * = false
   ) {
@@ -417,17 +414,17 @@ class TreeView extends PureComponent {
   }
 
   _toggleAll(
-    nodeId: IndexIntoFuncStackTable,
+    nodeId: IndexIntoCallNodeTable,
     newExpanded: boolean = this._isCollapsed(nodeId)
   ) {
     this._toggle(nodeId, newExpanded, true);
   }
 
-  _select(nodeId: IndexIntoFuncStackTable) {
+  _select(nodeId: IndexIntoCallNodeTable) {
     this.props.onSelectionChange(nodeId);
   }
 
-  _onRowClicked(nodeId: IndexIntoFuncStackTable, event: MouseEvent) {
+  _onRowClicked(nodeId: IndexIntoCallNodeTable, event: MouseEvent) {
     this._select(nodeId);
     if (event.detail === 2) {
       // double click

--- a/src/components/shared/TreeView.js
+++ b/src/components/shared/TreeView.js
@@ -12,7 +12,7 @@ import { BackgroundImageStyleDef } from './StyleDef';
 import ContextMenuTrigger from './ContextMenuTrigger';
 
 import type { IndexIntoCallNodeTable, Node } from '../../types/profile-derived';
-import type { ProfileTreeClass } from '../../profile-logic/profile-tree';
+import type { CallTree } from '../../profile-logic/call-tree';
 import type { IconWithClassName } from '../../types/reducers';
 
 export type Column = {
@@ -248,7 +248,7 @@ class TreeViewRowScrolledColumns extends PureComponent {
 type TreeViewProps = {
   fixedColumns: Column[],
   mainColumn: Column,
-  tree: ProfileTreeClass,
+  tree: CallTree,
   expandedNodeIds: Array<IndexIntoCallNodeTable | null>,
   selectedNodeId: IndexIntoCallNodeTable | null,
   onExpandedNodesChange: PropTypes.func.isRequired,

--- a/src/components/timeline/TimelineFlameChart.js
+++ b/src/components/timeline/TimelineFlameChart.js
@@ -187,7 +187,7 @@ export default connect((state, ownProps) => {
     thread: threadSelectors.getFilteredThreadForFlameChart(state),
     isRowExpanded,
     maxStackDepth: isRowExpanded
-      ? threadSelectors.getFuncStackMaxDepthForFlameChart(state)
+      ? threadSelectors.getCallNodeMaxDepthForFlameChart(state)
       : 1,
     stackTimingByDepth,
     isSelected: true,

--- a/src/profile-logic/call-tree-filters.js
+++ b/src/profile-logic/call-tree-filters.js
@@ -73,8 +73,8 @@ export function stringifyCallTreeFilters(arrayValue = []) {
 export function getCallTreeFilterLabels(thread, threadName, callTreeFilters) {
   const { funcTable, stringTable } = thread;
   const labels = callTreeFilters.map(filter => {
-    function lastFuncString(funcArray) {
-      const lastFunc = funcArray[funcArray.length - 1];
+    function lastFuncString(callNodePath) {
+      const lastFunc = callNodePath[callNodePath.length - 1];
       const nameIndex = funcTable.name[lastFunc];
       return stringTable.getString(nameIndex);
     }

--- a/src/profile-logic/call-tree.js
+++ b/src/profile-logic/call-tree.js
@@ -37,7 +37,7 @@ function extractFaviconFromLibname(libname: string): string | null {
   return url.href;
 }
 
-class ProfileTree {
+export class CallTree {
   _callNodeTable: CallNodeTable;
   _callNodeTimes: CallNodeTimes;
   _callNodeChildCount: Uint32Array; // A table column matching the callNodeTable
@@ -123,7 +123,7 @@ class ProfileTree {
     return this._callNodeTable.depth[callNodeIndex];
   }
 
-  hasSameNodeIds(tree: ProfileTree): boolean {
+  hasSameNodeIds(tree: CallTree): boolean {
     return this._callNodeTable === tree._callNodeTable;
   }
 
@@ -186,8 +186,6 @@ class ProfileTree {
     return '';
   }
 }
-
-export type ProfileTreeClass = ProfileTree;
 
 function _getInvertedStackSelfTimes(
   thread: Thread,
@@ -321,9 +319,9 @@ export function computeCallTreeCountsAndTimings(
 }
 
 /**
- * An exported interface to get an instance of the ProfileTree class.
+ * An exported interface to get an instance of the CallTree class.
  * This handles computing timing information, and passing it all into
- * the ProfileTree constructor.
+ * the CallTree constructor.
  */
 export function getCallTree(
   thread: Thread,
@@ -331,7 +329,7 @@ export function getCallTree(
   callNodeInfo: CallNodeInfo,
   implementationFilter: string,
   invertCallstack: boolean
-): ProfileTree {
+): CallTree {
   return timeCode('getCallTree', () => {
     const {
       callNodeTimes,
@@ -347,7 +345,7 @@ export function getCallTree(
 
     const jsOnly = implementationFilter === 'js';
 
-    return new ProfileTree(
+    return new CallTree(
       thread,
       callNodeInfo.callNodeTable,
       callNodeTimes,

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -19,9 +19,9 @@ import type {
   ThreadIndex,
 } from '../types/profile';
 import type {
-  FuncStackInfo,
-  FuncStackTable,
-  IndexIntoFuncStackTable,
+  CallNodeInfo,
+  CallNodeTable,
+  IndexIntoCallNodeTable,
   TracingMarker,
 } from '../types/profile-derived';
 import type { StartEndRange } from '../types/units';
@@ -43,34 +43,34 @@ export const resourceTypes = {
 };
 
 /**
- * Generate the FuncStackInfo which contains the FuncStackTable, and a map to convert
- * an IndexIntoStackTable to a IndexIntoFuncStackTable. This function runs through
+ * Generate the CallNodeInfo which contains the CallNodeTable, and a map to convert
+ * an IndexIntoStackTable to a IndexIntoCallNodeTable. This function runs through
  * a stackTable, and de-duplicates stacks that have frames that point to the same
  * function.
  *
  * See `src/types/profile-derived.js` for the type definitions.
- * See `docs/func-stacks.md` for a detailed explanation of funcStacks.
+ * See `docs/call-trees.md` for a detailed explanation of CallNodes.
  */
-export function getFuncStackInfo(
+export function getCallNodeInfo(
   stackTable: StackTable,
   frameTable: FrameTable,
   funcTable: FuncTable
-): FuncStackInfo {
-  return timeCode('getFuncStackInfo', () => {
-    const stackIndexToFuncStackIndex = new Uint32Array(stackTable.length);
+): CallNodeInfo {
+  return timeCode('getCallNodeInfo', () => {
+    const stackIndexToCallNodeIndex = new Uint32Array(stackTable.length);
     const funcCount = funcTable.length;
-    // Maps can't key off of two items, so combine the prefixFuncStack and the funcIndex
-    // using the following formula: prefixFuncStack * funcCount + funcIndex => funcStack
-    const prefixFuncStackAndFuncToFuncStackMap = new Map();
+    // Maps can't key off of two items, so combine the prefixCallNode and the funcIndex
+    // using the following formula: prefixCallNode * funcCount + funcIndex => callNode
+    const prefixCallNodeAndFuncToCallNodeMap = new Map();
 
-    // The funcStackTable components.
-    const prefix: Array<IndexIntoFuncStackTable> = [];
+    // The callNodeTable components.
+    const prefix: Array<IndexIntoCallNodeTable> = [];
     const func: Array<IndexIntoFuncTable> = [];
     const depth: Array<number> = [];
     let length = 0;
 
-    function addFuncStack(
-      prefixIndex: IndexIntoFuncStackTable,
+    function addCallNode(
+      prefixIndex: IndexIntoCallNodeTable,
       funcIndex: IndexIntoFuncTable
     ) {
       const index = length++;
@@ -83,51 +83,50 @@ export function getFuncStackInfo(
       }
     }
 
-    // Go through each stack, and create a new funcStack table, which is based off of
+    // Go through each stack, and create a new callNode table, which is based off of
     // functions rather than frames.
     for (let stackIndex = 0; stackIndex < stackTable.length; stackIndex++) {
       const prefixStack = stackTable.prefix[stackIndex];
       // We know that at this point the following condition holds:
       // assert(prefixStack === null || prefixStack < stackIndex);
-      const prefixFuncStack =
-        prefixStack === null ? -1 : stackIndexToFuncStackIndex[prefixStack];
+      const prefixCallNode =
+        prefixStack === null ? -1 : stackIndexToCallNodeIndex[prefixStack];
       const frameIndex = stackTable.frame[stackIndex];
       const funcIndex = frameTable.func[frameIndex];
-      const prefixFuncStackAndFuncIndex =
-        prefixFuncStack * funcCount + funcIndex;
-      let funcStackIndex = prefixFuncStackAndFuncToFuncStackMap.get(
-        prefixFuncStackAndFuncIndex
+      const prefixCallNodeAndFuncIndex = prefixCallNode * funcCount + funcIndex;
+      let callNodeIndex = prefixCallNodeAndFuncToCallNodeMap.get(
+        prefixCallNodeAndFuncIndex
       );
-      if (funcStackIndex === undefined) {
-        funcStackIndex = length;
-        addFuncStack(prefixFuncStack, funcIndex);
-        prefixFuncStackAndFuncToFuncStackMap.set(
-          prefixFuncStackAndFuncIndex,
-          funcStackIndex
+      if (callNodeIndex === undefined) {
+        callNodeIndex = length;
+        addCallNode(prefixCallNode, funcIndex);
+        prefixCallNodeAndFuncToCallNodeMap.set(
+          prefixCallNodeAndFuncIndex,
+          callNodeIndex
         );
       }
-      stackIndexToFuncStackIndex[stackIndex] = funcStackIndex;
+      stackIndexToCallNodeIndex[stackIndex] = callNodeIndex;
     }
 
-    const funcStackTable: FuncStackTable = {
+    const callNodeTable: CallNodeTable = {
       prefix: new Int32Array(prefix),
       func: new Int32Array(func),
       depth,
       length,
     };
 
-    return { funcStackTable, stackIndexToFuncStackIndex };
+    return { callNodeTable, stackIndexToCallNodeIndex };
   });
 }
 
-export function getSampleFuncStacks(
+export function getSampleCallNodes(
   samples: SamplesTable,
-  stackIndexToFuncStackIndex: {
-    [key: IndexIntoStackTable]: IndexIntoFuncStackTable,
+  stackIndexToCallNodeIndex: {
+    [key: IndexIntoStackTable]: IndexIntoCallNodeTable,
   }
-): Array<IndexIntoFuncStackTable | null> {
+): Array<IndexIntoCallNodeTable | null> {
   return samples.stack.map(stack => {
-    return stack === null ? null : stackIndexToFuncStackIndex[stack];
+    return stack === null ? null : stackIndexToCallNodeIndex[stack];
   });
 }
 
@@ -686,24 +685,24 @@ export function filterThreadToRange(
   });
 }
 
-export function getFuncStackFromFuncArray(
-  funcArray: IndexIntoFuncTable[],
-  funcStackTable: FuncStackTable
-): IndexIntoFuncStackTable | null {
+export function getCallNodeFromPath(
+  callNodePath: IndexIntoFuncTable[],
+  callNodeTable: CallNodeTable
+): IndexIntoCallNodeTable | null {
   let fs = -1;
-  for (let i = 0; i < funcArray.length; i++) {
-    const func = funcArray[i];
+  for (let i = 0; i < callNodePath.length; i++) {
+    const func = callNodePath[i];
     let nextFS = -1;
     for (
-      let funcStackIndex = fs + 1;
-      funcStackIndex < funcStackTable.length;
-      funcStackIndex++
+      let callNodeIndex = fs + 1;
+      callNodeIndex < callNodeTable.length;
+      callNodeIndex++
     ) {
       if (
-        funcStackTable.prefix[funcStackIndex] === fs &&
-        funcStackTable.func[funcStackIndex] === func
+        callNodeTable.prefix[callNodeIndex] === fs &&
+        callNodeTable.func[callNodeIndex] === func
       ) {
-        nextFS = funcStackIndex;
+        nextFS = callNodeIndex;
         break;
       }
     }
@@ -715,28 +714,25 @@ export function getFuncStackFromFuncArray(
   return fs;
 }
 
-export function getFuncStackAsFuncArray(
-  funcStackIndex: IndexIntoFuncStackTable | null,
-  funcStackTable: FuncStackTable
+export function getCallNodePath(
+  callNodeIndex: IndexIntoCallNodeTable | null,
+  callNodeTable: CallNodeTable
 ): IndexIntoFuncTable[] {
-  if (funcStackIndex === null) {
+  if (callNodeIndex === null) {
     return [];
   }
-  if (funcStackIndex * 1 !== funcStackIndex) {
-    console.log(
-      'bad funcStackIndex in getFuncStackAsFuncArray:',
-      funcStackIndex
-    );
+  if (callNodeIndex * 1 !== callNodeIndex) {
+    console.log('bad callNodeIndex in getCallNodePath:', callNodeIndex);
     return [];
   }
-  const funcArray = [];
-  let fs = funcStackIndex;
+  const callNodePath = [];
+  let fs = callNodeIndex;
   while (fs !== -1) {
-    funcArray.push(funcStackTable.func[fs]);
-    fs = funcStackTable.prefix[fs];
+    callNodePath.push(callNodeTable.func[fs]);
+    fs = callNodeTable.prefix[fs];
   }
-  funcArray.reverse();
-  return funcArray;
+  callNodePath.reverse();
+  return callNodePath;
 }
 
 export function invertCallstack(thread: Thread): Thread {

--- a/src/profile-logic/stack-timing.js
+++ b/src/profile-logic/stack-timing.js
@@ -10,7 +10,7 @@ import type {
   StackTable,
 } from '../types/profile';
 import type { Milliseconds } from '../types/units';
-import type { FuncStackInfo } from '../types/profile-derived';
+import type { CallNodeInfo } from '../types/profile-derived';
 import type { GetCategory } from './color-categories';
 /**
  * The StackTimingByDepth data structure organizes stack frames by their depth, and start
@@ -66,18 +66,18 @@ type LastSeen = {
  * Build a StackTimingByDepth table from a given thread.
  *
  * @param {object} thread - The profile thread.
- * @param {object} funcStackInfo - from the funcStackInfo selector.
+ * @param {object} callNodeInfo - from the callNodeInfo selector.
  * @param {integer} maxDepth - The max depth of the all the stacks.
  * @param {number} interval - The sampling interval that the profile was recorded with.
  * @return {array} stackTimingByDepth
  */
 export function getStackTimingByDepth(
   thread: Thread,
-  funcStackInfo: FuncStackInfo,
+  callNodeInfo: CallNodeInfo,
   maxDepth: number,
   interval: number
 ): StackTimingByDepth {
-  const { funcStackTable, stackIndexToFuncStackIndex } = funcStackInfo;
+  const { callNodeTable, stackIndexToCallNodeIndex } = callNodeInfo;
   const stackTimingByDepth = Array.from({ length: maxDepth + 1 }, () => ({
     start: [],
     end: [],
@@ -103,8 +103,8 @@ export function getStackTimingByDepth(
       _popStacks(stackTimingByDepth, lastSeen, -1, previousDepth, sampleTime);
       previousDepth = -1;
     } else {
-      const funcStackIndex = stackIndexToFuncStackIndex[stackIndex];
-      const depth = funcStackTable.depth[funcStackIndex];
+      const callNodeIndex = stackIndexToCallNodeIndex[stackIndex];
+      const depth = callNodeTable.depth[callNodeIndex];
 
       // Find the depth of the nearest shared stack.
       const depthToPop = _findNearestSharedStackDepth(
@@ -196,18 +196,18 @@ function _pushStacks(
   }
 }
 
-export function computeFuncStackMaxDepth(
+export function computeCallNodeMaxDepth(
   rangedThread: Thread,
-  funcStackInfo: FuncStackInfo
+  callNodeInfo: CallNodeInfo
 ): number {
   let maxDepth = 0;
   const { samples } = rangedThread;
-  const { funcStackTable, stackIndexToFuncStackIndex } = funcStackInfo;
+  const { callNodeTable, stackIndexToCallNodeIndex } = callNodeInfo;
   for (let i = 0; i < rangedThread.samples.length; i++) {
     const stackIndex = samples.stack[i];
     if (stackIndex !== null) {
-      const funcStackIndex = stackIndexToFuncStackIndex[stackIndex];
-      const depth = funcStackTable.depth[funcStackIndex];
+      const callNodeIndex = stackIndexToCallNodeIndex[stackIndex];
+      const depth = callNodeTable.depth[callNodeIndex];
       if (depth > maxDepth) {
         maxDepth = depth;
       }

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -15,7 +15,7 @@ import * as URLState from './url-state';
 import * as ProfileData from '../profile-logic/profile-data';
 import * as StackTiming from '../profile-logic/stack-timing';
 import * as MarkerTiming from '../profile-logic/marker-timing';
-import * as ProfileTree from '../profile-logic/profile-tree';
+import * as CallTree from '../profile-logic/call-tree';
 import * as TaskTracerTools from '../profile-logic/task-tracer';
 import { getCategoryColorStrategy } from './flame-chart';
 
@@ -395,7 +395,7 @@ export type SelectorsForThread = {
   getCallNodeInfo: State => CallNodeInfo,
   getSelectedCallNodeIndex: State => IndexIntoCallNodeTable | null,
   getExpandedCallNodeIndexes: State => Array<IndexIntoCallNodeTable | null>,
-  getCallTree: State => ProfileTree.ProfileTreeClass,
+  getCallTree: State => CallTree.CallTree,
   getFilteredThreadForFlameChart: State => Thread,
   getCallNodeInfoOfFilteredThreadForFlameChart: State => CallNodeInfo,
   getCallNodeMaxDepthForFlameChart: State => number,
@@ -571,7 +571,7 @@ export const selectorsForThread = (
       getCallNodeInfo,
       URLState.getImplementationFilter,
       URLState.getInvertCallstack,
-      ProfileTree.getCallTree
+      CallTree.getCallTree
     );
 
     // The selectors below diverge from the thread filtering that's done above;

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -29,8 +29,8 @@ import type {
 } from '../types/profile';
 import type {
   TracingMarker,
-  FuncStackInfo,
-  IndexIntoFuncStackTable,
+  CallNodeInfo,
+  IndexIntoCallNodeTable,
   MarkerTimingRows,
 } from '../types/profile-derived';
 import type { Milliseconds, StartEndRange } from '../types/units';
@@ -97,27 +97,27 @@ function profile(
   }
 }
 
-function funcStackAfterCallTreeFilter(
-  funcArray: IndexIntoFuncTable[],
+function callNodeAfterCallTreeFilter(
+  callNodePath: IndexIntoFuncTable[],
   filter: CallTreeFilter
 ) {
   if (filter.type === 'prefix' && !filter.matchJSOnly) {
-    return removePrefixFromFuncArray(filter.prefixFuncs, funcArray);
+    return removePrefixFromCallNodePath(filter.prefixFuncs, callNodePath);
   }
-  return funcArray;
+  return callNodePath;
 }
 
-function removePrefixFromFuncArray(
+function removePrefixFromCallNodePath(
   prefixFuncs: IndexIntoFuncTable[],
-  funcArray: IndexIntoFuncTable[]
+  callNodePath: IndexIntoFuncTable[]
 ) {
   if (
-    prefixFuncs.length > funcArray.length ||
-    prefixFuncs.some((prefixFunc, i) => prefixFunc !== funcArray[i])
+    prefixFuncs.length > callNodePath.length ||
+    prefixFuncs.some((prefixFunc, i) => prefixFunc !== callNodePath[i])
   ) {
     return [];
   }
-  return funcArray.slice(prefixFuncs.length - 1);
+  return callNodePath.slice(prefixFuncs.length - 1);
 }
 
 function symbolicationStatus(
@@ -141,29 +141,29 @@ function viewOptionsPerThread(state: ThreadViewOptions[] = [], action: Action) {
     case 'RECEIVE_PROFILE_FROM_URL':
     case 'RECEIVE_PROFILE_FROM_FILE':
       return action.profile.threads.map(() => ({
-        selectedFuncStack: [],
-        expandedFuncStacks: [],
+        selectedCallNodePath: [],
+        expandedCallNodePaths: [],
         selectedMarker: -1,
       }));
     case 'COALESCED_FUNCTIONS_UPDATE': {
       const { functionsUpdatePerThread } = action;
       // For each thread, apply oldFuncToNewFuncMap to that thread's
-      // selectedFuncStack and expandedFuncStacks.
+      // selectedCallNodePath and expandedCallNodePaths.
       return state.map((threadViewOptions, threadIndex) => {
         if (!functionsUpdatePerThread[threadIndex]) {
           return threadViewOptions;
         }
         const { oldFuncToNewFuncMap } = functionsUpdatePerThread[threadIndex];
         return {
-          selectedFuncStack: threadViewOptions.selectedFuncStack.map(
+          selectedCallNodePath: threadViewOptions.selectedCallNodePath.map(
             oldFunc => {
               const newFunc = oldFuncToNewFuncMap.get(oldFunc);
               return newFunc === undefined ? oldFunc : newFunc;
             }
           ),
-          expandedFuncStacks: threadViewOptions.expandedFuncStacks.map(
-            oldFuncArray => {
-              return oldFuncArray.map(oldFunc => {
+          expandedCallNodePaths: threadViewOptions.expandedCallNodePaths.map(
+            oldPath => {
+              return oldPath.map(oldFunc => {
                 const newFunc = oldFuncToNewFuncMap.get(oldFunc);
                 return newFunc === undefined ? oldFunc : newFunc;
               });
@@ -173,26 +173,28 @@ function viewOptionsPerThread(state: ThreadViewOptions[] = [], action: Action) {
         };
       });
     }
-    case 'CHANGE_SELECTED_FUNC_STACK': {
-      const { selectedFuncStack, threadIndex } = action;
-      const expandedFuncStacks = state[threadIndex].expandedFuncStacks.slice();
-      for (let i = 1; i < selectedFuncStack.length; i++) {
-        expandedFuncStacks.push(selectedFuncStack.slice(0, i));
+    case 'CHANGE_SELECTED_CALL_NODE': {
+      const { selectedCallNodePath, threadIndex } = action;
+      const expandedCallNodePaths = state[
+        threadIndex
+      ].expandedCallNodePaths.slice();
+      for (let i = 1; i < selectedCallNodePath.length; i++) {
+        expandedCallNodePaths.push(selectedCallNodePath.slice(0, i));
       }
       return [
         ...state.slice(0, threadIndex),
         Object.assign({}, state[threadIndex], {
-          selectedFuncStack,
-          expandedFuncStacks,
+          selectedCallNodePath,
+          expandedCallNodePaths,
         }),
         ...state.slice(threadIndex + 1),
       ];
     }
-    case 'CHANGE_EXPANDED_FUNC_STACKS': {
-      const { threadIndex, expandedFuncStacks } = action;
+    case 'CHANGE_EXPANDED_CALL_NODES': {
+      const { threadIndex, expandedCallNodePaths } = action;
       return [
         ...state.slice(0, threadIndex),
-        Object.assign({}, state[threadIndex], { expandedFuncStacks }),
+        Object.assign({}, state[threadIndex], { expandedCallNodePaths }),
         ...state.slice(threadIndex + 1),
       ];
     }
@@ -206,18 +208,20 @@ function viewOptionsPerThread(state: ThreadViewOptions[] = [], action: Action) {
     }
     case 'ADD_CALL_TREE_FILTER': {
       const { threadIndex, filter } = action;
-      const expandedFuncStacks = state[threadIndex].expandedFuncStacks.map(fs =>
-        funcStackAfterCallTreeFilter(fs, filter)
+      const expandedCallNodePaths = state[
+        threadIndex
+      ].expandedCallNodePaths.map(path =>
+        callNodeAfterCallTreeFilter(path, filter)
       );
-      const selectedFuncStack = funcStackAfterCallTreeFilter(
-        state[threadIndex].selectedFuncStack,
+      const selectedCallNodePath = callNodeAfterCallTreeFilter(
+        state[threadIndex].selectedCallNodePath,
         filter
       );
       return [
         ...state.slice(0, threadIndex),
         Object.assign({}, state[threadIndex], {
-          selectedFuncStack,
-          expandedFuncStacks,
+          selectedCallNodePath,
+          expandedCallNodePaths,
         }),
         ...state.slice(threadIndex + 1),
       ];
@@ -261,7 +265,7 @@ function scrollToSelectionGeneration(state: number = 0, action: Action) {
   switch (action.type) {
     case 'CHANGE_INVERT_CALLSTACK':
     case 'CHANGE_JS_ONLY':
-    case 'CHANGE_SELECTED_FUNC_STACK':
+    case 'CHANGE_SELECTED_CALL_NODE':
     case 'CHANGE_SELECTED_THREAD':
     case 'HIDE_THREAD':
       return state + 1;
@@ -388,13 +392,13 @@ export type SelectorsForThread = {
   getRangeSelectionFilteredTracingMarkers: State => TracingMarker[],
   getFilteredThread: State => Thread,
   getRangeSelectionFilteredThread: State => Thread,
-  getFuncStackInfo: State => FuncStackInfo,
-  getSelectedFuncStack: State => IndexIntoFuncStackTable | null,
-  getExpandedFuncStacks: State => Array<IndexIntoFuncStackTable | null>,
+  getCallNodeInfo: State => CallNodeInfo,
+  getSelectedCallNodeIndex: State => IndexIntoCallNodeTable | null,
+  getExpandedCallNodeIndexes: State => Array<IndexIntoCallNodeTable | null>,
   getCallTree: State => ProfileTree.ProfileTreeClass,
   getFilteredThreadForFlameChart: State => Thread,
-  getFuncStackInfoOfFilteredThreadForFlameChart: State => FuncStackInfo,
-  getFuncStackMaxDepthForFlameChart: State => number,
+  getCallNodeInfoOfFilteredThreadForFlameChart: State => CallNodeInfo,
+  getCallNodeMaxDepthForFlameChart: State => number,
   getStackTimingByDepthForFlameChart: State => StackTiming.StackTimingByDepth,
   getLeafCategoryStackTimingForFlameChart: State => StackTiming.StackTimingByDepth,
   getFriendlyThreadName: State => string,
@@ -523,40 +527,40 @@ export const selectorsForThread = (
         );
       }
     );
-    const getFuncStackInfo = createSelector(
+    const getCallNodeInfo = createSelector(
       getFilteredThread,
-      ({ stackTable, frameTable, funcTable }: Thread): FuncStackInfo => {
-        return ProfileData.getFuncStackInfo(stackTable, frameTable, funcTable);
+      ({ stackTable, frameTable, funcTable }: Thread): CallNodeInfo => {
+        return ProfileData.getCallNodeInfo(stackTable, frameTable, funcTable);
       }
     );
-    const _getSelectedFuncStackAsFuncArray = createSelector(
+    const _getSelectedCallNodeAsPath = createSelector(
       getViewOptions,
       (threadViewOptions): IndexIntoFuncTable[] =>
-        threadViewOptions.selectedFuncStack
+        threadViewOptions.selectedCallNodePath
     );
-    const getSelectedFuncStack = createSelector(
-      getFuncStackInfo,
-      _getSelectedFuncStackAsFuncArray,
-      (funcStackInfo, funcArray): IndexIntoFuncStackTable | null => {
-        return ProfileData.getFuncStackFromFuncArray(
-          funcArray,
-          funcStackInfo.funcStackTable
+    const getSelectedCallNodeIndex = createSelector(
+      getCallNodeInfo,
+      _getSelectedCallNodeAsPath,
+      (callNodeInfo, callNodePath): IndexIntoCallNodeTable | null => {
+        return ProfileData.getCallNodeFromPath(
+          callNodePath,
+          callNodeInfo.callNodeTable
         );
       }
     );
-    const _getExpandedFuncStacksAsFuncArrays = createSelector(
+    const _getExpandedCallNodePaths = createSelector(
       getViewOptions,
       (threadViewOptions): Array<IndexIntoFuncTable[]> =>
-        threadViewOptions.expandedFuncStacks
+        threadViewOptions.expandedCallNodePaths
     );
-    const getExpandedFuncStacks = createSelector(
-      getFuncStackInfo,
-      _getExpandedFuncStacksAsFuncArrays,
-      (funcStackInfo, funcArrays): (IndexIntoFuncStackTable | null)[] => {
-        return funcArrays.map(funcArray =>
-          ProfileData.getFuncStackFromFuncArray(
-            funcArray,
-            funcStackInfo.funcStackTable
+    const getExpandedCallNodeIndexes = createSelector(
+      getCallNodeInfo,
+      _getExpandedCallNodePaths,
+      (callNodeInfo, callNodePaths): (IndexIntoCallNodeTable | null)[] => {
+        return callNodePaths.map(callNodePath =>
+          ProfileData.getCallNodeFromPath(
+            callNodePath,
+            callNodeInfo.callNodeTable
           )
         );
       }
@@ -564,7 +568,7 @@ export const selectorsForThread = (
     const getCallTree = createSelector(
       getRangeSelectionFilteredThread,
       getProfileInterval,
-      getFuncStackInfo,
+      getCallNodeInfo,
       URLState.getImplementationFilter,
       URLState.getInvertCallstack,
       ProfileTree.getCallTree
@@ -605,21 +609,21 @@ export const selectorsForThread = (
         return filteredThread;
       }
     );
-    const getFuncStackInfoOfFilteredThreadForFlameChart = createSelector(
+    const getCallNodeInfoOfFilteredThreadForFlameChart = createSelector(
       getFilteredThreadForFlameChart,
-      ({ stackTable, frameTable, funcTable }): FuncStackInfo => {
-        return ProfileData.getFuncStackInfo(stackTable, frameTable, funcTable);
+      ({ stackTable, frameTable, funcTable }): CallNodeInfo => {
+        return ProfileData.getCallNodeInfo(stackTable, frameTable, funcTable);
       }
     );
-    const getFuncStackMaxDepthForFlameChart = createSelector(
+    const getCallNodeMaxDepthForFlameChart = createSelector(
       getFilteredThreadForFlameChart,
-      getFuncStackInfoOfFilteredThreadForFlameChart,
-      StackTiming.computeFuncStackMaxDepth
+      getCallNodeInfoOfFilteredThreadForFlameChart,
+      StackTiming.computeCallNodeMaxDepth
     );
     const getStackTimingByDepthForFlameChart = createSelector(
       getFilteredThreadForFlameChart,
-      getFuncStackInfoOfFilteredThreadForFlameChart,
-      getFuncStackMaxDepthForFlameChart,
+      getCallNodeInfoOfFilteredThreadForFlameChart,
+      getCallNodeMaxDepthForFlameChart,
       getProfileInterval,
       StackTiming.getStackTimingByDepth
     );
@@ -642,13 +646,13 @@ export const selectorsForThread = (
       getRangeSelectionFilteredTracingMarkers,
       getFilteredThread,
       getRangeSelectionFilteredThread,
-      getFuncStackInfo,
-      getSelectedFuncStack,
-      getExpandedFuncStacks,
+      getCallNodeInfo,
+      getSelectedCallNodeIndex,
+      getExpandedCallNodeIndexes,
       getCallTree,
       getFilteredThreadForFlameChart,
-      getFuncStackInfoOfFilteredThreadForFlameChart,
-      getFuncStackMaxDepthForFlameChart,
+      getCallNodeInfoOfFilteredThreadForFlameChart,
+      getCallNodeMaxDepthForFlameChart,
       getStackTimingByDepthForFlameChart,
       getLeafCategoryStackTimingForFlameChart,
       getFriendlyThreadName,

--- a/src/test/fixtures/profiles/call-nodes.js
+++ b/src/test/fixtures/profiles/call-nodes.js
@@ -15,19 +15,19 @@ import { getEmptyProfile } from '../../../profile-logic/profile-data';
 import { getEmptyThread } from '../../store/fixtures/profiles';
 
 /**
- *            stack0 (funcA)                               funcStack0 (funcA)
+ *            stack0 (funcA)                               callNode0 (funcA)
  *                 |                                            |
  *                 v                                            v
- *            stack1 (funcB)            merged             funcStack1 (funcB)
+ *            stack1 (funcB)            merged             callNode1 (funcB)
  *                 |                  stackTable                |
  *                 v                      ->                    v
- *            stack2 (funcC)                               funcStack2 (funcC)
+ *            stack2 (funcC)                               callNode2 (funcC)
  *            /            \                                    |
  *           V              V                                   v
- *    stack3 (funcD)     stack5 (funcD)                    funcStack3 (funcD)
+ *    stack3 (funcD)     stack5 (funcD)                    callNode3 (funcD)
  *         |                  |                          /               \
  *         v                  V                         V                 V
- *    stack4 (funcE)     stack6 (funcF)         funcStack4 (funcE)       funcStack5 (funcF)
+ *    stack4 (funcE)     stack6 (funcF)         callNode4 (funcE)       callNode5 (funcF)
  */
 export default function getProfile(): Profile {
   const profile = getEmptyProfile();

--- a/src/test/store/actions.test.js
+++ b/src/test/store/actions.test.js
@@ -145,15 +145,15 @@ describe('selectors/getStackTimingByDepthForFlameChart', function() {
   });
 });
 
-describe('selectors/getFuncStackMaxDepthForFlameChart', function() {
+describe('selectors/getCallNodeMaxDepthForFlameChart', function() {
   it('calculates the max func depth and observes of platform-detail filters', function() {
     const store = storeWithProfile();
-    const allSamplesMaxDepth = selectedThreadSelectors.getFuncStackMaxDepthForFlameChart(
+    const allSamplesMaxDepth = selectedThreadSelectors.getCallNodeMaxDepthForFlameChart(
       store.getState()
     );
     expect(allSamplesMaxDepth).toEqual(6);
     store.dispatch(changeHidePlatformDetails(true));
-    const jsOnlySamplesMaxDepth = selectedThreadSelectors.getFuncStackMaxDepthForFlameChart(
+    const jsOnlySamplesMaxDepth = selectedThreadSelectors.getCallNodeMaxDepthForFlameChart(
       store.getState()
     );
     expect(jsOnlySamplesMaxDepth).toEqual(4);
@@ -162,12 +162,12 @@ describe('selectors/getFuncStackMaxDepthForFlameChart', function() {
   it('acts upon the current range', function() {
     const store = storeWithProfile();
     store.dispatch(addRangeFilter(0, 20));
-    const allSamplesMaxDepth = selectedThreadSelectors.getFuncStackMaxDepthForFlameChart(
+    const allSamplesMaxDepth = selectedThreadSelectors.getCallNodeMaxDepthForFlameChart(
       store.getState()
     );
     expect(allSamplesMaxDepth).toEqual(2);
     store.dispatch(changeHidePlatformDetails(true));
-    const jsOnlySamplesMaxDepth = selectedThreadSelectors.getFuncStackMaxDepthForFlameChart(
+    const jsOnlySamplesMaxDepth = selectedThreadSelectors.getCallNodeMaxDepthForFlameChart(
       store.getState()
     );
     expect(jsOnlySamplesMaxDepth).toEqual(0);

--- a/src/test/unit/profile-tree.test.js
+++ b/src/test/unit/profile-tree.test.js
@@ -11,16 +11,16 @@ import {
   computeCallTreeCountsAndTimings,
 } from '../../profile-logic/profile-tree';
 import {
-  getFuncStackInfo,
+  getCallNodeInfo,
   invertCallstack,
-  getFuncStackFromFuncArray,
+  getCallNodeFromPath,
 } from '../../profile-logic/profile-data';
 import type { ProfileTreeClass } from '../../profile-logic/profile-tree';
-import type { IndexIntoFuncStackTable } from '../../types/profile-derived';
+import type { IndexIntoCallNodeTable } from '../../types/profile-derived';
 
 describe('unfiltered call tree', function() {
   // These values are hoisted at the top for the ease of access. In the profile fixture
-  // for the unfiltered call tree, the indexes for funcs, frames, stacks, and funcStacks
+  // for the unfiltered call tree, the indexes for funcs, frames, stacks, and callNodes
   // all happen to share the same indexes as there is a 1 to 1 relationship between them.
   const A = 0;
   const B = 1;
@@ -36,12 +36,12 @@ describe('unfiltered call tree', function() {
     const profile = getProfileForUnfilteredCallTree();
     const [thread] = profile.threads;
     const { interval } = profile.meta;
-    const funcStackInfo = getFuncStackInfo(
+    const callNodeInfo = getCallNodeInfo(
       thread.stackTable,
       thread.frameTable,
       thread.funcTable
     );
-    return getCallTree(thread, interval, funcStackInfo, 'combined', false);
+    return getCallTree(thread, interval, callNodeInfo, 'combined', false);
   }
 
   /**
@@ -51,7 +51,7 @@ describe('unfiltered call tree', function() {
   describe('computed counts and timings', function() {
     const profile = getProfileForUnfilteredCallTree();
     const [thread] = profile.threads;
-    const funcStackInfo = getFuncStackInfo(
+    const callNodeInfo = getCallNodeInfo(
       thread.stackTable,
       thread.frameTable,
       thread.funcTable
@@ -61,15 +61,15 @@ describe('unfiltered call tree', function() {
       expect(
         computeCallTreeCountsAndTimings(
           thread,
-          funcStackInfo,
+          callNodeInfo,
           profile.meta.interval,
           false
         )
       ).toEqual({
         rootCount: 1,
         rootTotalTime: 3,
-        funcStackChildCount: new Uint32Array([1, 2, 2, 1, 0, 1, 0, 1, 0]),
-        funcStackTimes: {
+        callNodeChildCount: new Uint32Array([1, 2, 2, 1, 0, 1, 0, 1, 0]),
+        callNodeTimes: {
           selfTime: new Float32Array([0, 0, 0, 0, 1, 0, 1, 0, 1]),
           totalTime: new Float32Array([3, 3, 2, 1, 1, 1, 1, 1, 1]),
         },
@@ -118,12 +118,12 @@ describe('unfiltered call tree', function() {
 
     describe('root node A', function() {
       const roots = callTree.getRoots();
-      const rootFuncStackIndex = roots[0];
+      const rootCallNodeIndex = roots[0];
       it('is the root of the call tree', function() {
         expect(roots.length).toBe(1);
-        expect(rootFuncStackIndex).toBe(A);
+        expect(rootCallNodeIndex).toBe(A);
       });
-      _assertNode(callTree, rootFuncStackIndex, {
+      _assertNode(callTree, rootCallNodeIndex, {
         children: [B],
         parent: -1,
         selfTime: 0,
@@ -225,14 +225,14 @@ describe('unfiltered call tree', function() {
     });
 
     describe('getParent()', function() {
-      it("finds a funcStack's parent", function() {
+      it("finds a callNode's parent", function() {
         expect(callTree.getParent(A)).toBe(-1);
         expect(callTree.getParent(B)).toBe(A);
       });
     });
 
     describe('getDepth()', function() {
-      it('returns the depth of funcStacks in the tree', function() {
+      it('returns the depth of callNodes in the tree', function() {
         expect(callTree.getDepth(A)).toBe(0);
         expect(callTree.getDepth(B)).toBe(1);
       });
@@ -240,7 +240,7 @@ describe('unfiltered call tree', function() {
 
     describe('hasSameNodeIds()', function() {
       it('determines if the node IDs are the same between two trees', function() {
-        // This is tested through strict equality, so re-generating funcStacks is
+        // This is tested through strict equality, so re-generating callNodes is
         // the only thing this method expects.
         const otherTree = getUnfilteredCallTree();
         expect(callTree.hasSameNodeIds(callTree)).toBe(true);
@@ -249,7 +249,7 @@ describe('unfiltered call tree', function() {
     });
 
     describe('getNode()', function() {
-      it('gets a node for a given funcStackIndex', function() {
+      it('gets a node for a given callNodeIndex', function() {
         expect(callTree.getNode(A)).toEqual({
           dim: false,
           icon: null,
@@ -267,21 +267,19 @@ describe('unfiltered call tree', function() {
    * While not specifically part of the call tree, this is a core function
    * to help navigate stacks through a list of functions.
    */
-  describe('getFuncStackFromFuncArray', function() {
+  describe('getCallNodeFromPath', function() {
     const profile = getProfileForUnfilteredCallTree();
     const [thread] = profile.threads;
-    const { funcStackTable } = getFuncStackInfo(
+    const { callNodeTable } = getCallNodeInfo(
       thread.stackTable,
       thread.frameTable,
       thread.funcTable
     );
 
     // Helper to make the assertions a little less verbose.
-    function checkStack(funcArray, index, name) {
+    function checkStack(callNodePath, index, name) {
       it(`finds stack that ends in ${name}`, function() {
-        expect(getFuncStackFromFuncArray(funcArray, funcStackTable)).toBe(
-          index
-        );
+        expect(getCallNodeFromPath(callNodePath, callNodeTable)).toBe(index);
       });
     }
 
@@ -298,15 +296,15 @@ describe('unfiltered call tree', function() {
     checkStack([A, B, H, I], I, 'I');
 
     it(`doesn't find a non-existent stack`, function() {
-      expect(
-        getFuncStackFromFuncArray([A, B, C, D, E, F, G], funcStackTable)
-      ).toBe(null);
+      expect(getCallNodeFromPath([A, B, C, D, E, F, G], callNodeTable)).toBe(
+        null
+      );
     });
   });
 });
 
 describe('inverted call tree', function() {
-  // These indexes were saved by observing the generated inverted funcStackTable.
+  // These indexes were saved by observing the generated inverted callNodeTable.
   const stackA_branchR = 12;
   const stackB_branchR = 11;
   const stackC_branchR = 10;
@@ -328,7 +326,7 @@ describe('inverted call tree', function() {
     const profile = getProfileForInvertedCallTree();
     const invertedThread = invertCallstack(profile.threads[0]);
     const { interval } = profile.meta;
-    const funcStackInfo = getFuncStackInfo(
+    const callNodeInfo = getCallNodeInfo(
       invertedThread.stackTable,
       invertedThread.frameTable,
       invertedThread.funcTable
@@ -337,7 +335,7 @@ describe('inverted call tree', function() {
     return getCallTree(
       invertedThread,
       interval,
-      funcStackInfo,
+      callNodeInfo,
       'combined',
       true
     );
@@ -498,21 +496,21 @@ describe('inverted call tree', function() {
  */
 function _assertNode(
   callTree: ProfileTreeClass,
-  funcStackIndex: IndexIntoFuncStackTable,
+  callNodeIndex: IndexIntoCallNodeTable,
   expected: {
-    children: IndexIntoFuncStackTable[],
-    parent: IndexIntoFuncStackTable,
+    children: IndexIntoCallNodeTable[],
+    parent: IndexIntoCallNodeTable,
     selfTime: number,
     totalTime: number,
   }
 ) {
-  // Transform any FuncStackIndexes into ProfileTree nodes.
-  const getNode = (funcStackIndex: IndexIntoFuncStackTable) =>
-    funcStackIndex === -1 ? null : callTree.getNode(funcStackIndex);
+  // Transform any CallNodeIndexes into ProfileTree nodes.
+  const getNode = (callNodeIndex: IndexIntoCallNodeTable) =>
+    callNodeIndex === -1 ? null : callTree.getNode(callNodeIndex);
 
-  const children = callTree.getChildren(funcStackIndex).map(getNode);
-  const parent = getNode(callTree.getParent(funcStackIndex));
-  const node = getNode(funcStackIndex);
+  const children = callTree.getChildren(callNodeIndex).map(getNode);
+  const parent = getNode(callTree.getParent(callNodeIndex));
+  const node = getNode(callNodeIndex);
   const expectedParent = getNode(expected.parent);
   const expectedChildren = expected.children.map(getNode);
   if (!node) {

--- a/src/test/unit/profile-tree.test.js
+++ b/src/test/unit/profile-tree.test.js
@@ -9,13 +9,13 @@ import {
 import {
   getCallTree,
   computeCallTreeCountsAndTimings,
-} from '../../profile-logic/profile-tree';
+  CallTree,
+} from '../../profile-logic/call-tree';
 import {
   getCallNodeInfo,
   invertCallstack,
   getCallNodeFromPath,
 } from '../../profile-logic/profile-data';
-import type { ProfileTreeClass } from '../../profile-logic/profile-tree';
 import type { IndexIntoCallNodeTable } from '../../types/profile-derived';
 
 describe('unfiltered call tree', function() {
@@ -32,7 +32,7 @@ describe('unfiltered call tree', function() {
   const H = 7;
   const I = 8;
 
-  function getUnfilteredCallTree(): ProfileTreeClass {
+  function getUnfilteredCallTree(): CallTree {
     const profile = getProfileForUnfilteredCallTree();
     const [thread] = profile.threads;
     const { interval } = profile.meta;
@@ -45,7 +45,7 @@ describe('unfiltered call tree', function() {
   }
 
   /**
-   * Before creating a ProfileTree instance some timings are pre-computed.
+   * Before creating a CallTree instance some timings are pre-computed.
    * This test ensures that these generated values are correct.
    */
   describe('computed counts and timings', function() {
@@ -197,11 +197,11 @@ describe('unfiltered call tree', function() {
   });
 
   /**
-   * These tests provides coverage for every method of the ProfileTree. It's less about
+   * These tests provides coverage for every method of the CallTree. It's less about
    * correct tree structure, and more of simple assertions about how the interface
    * is supposed to behave. There is probably duplication of coverage with other tests.
    */
-  describe('ProfileTree methods', function() {
+  describe('CallTree methods', function() {
     const callTree = getUnfilteredCallTree();
 
     describe('getRoots()', function() {
@@ -322,7 +322,7 @@ describe('inverted call tree', function() {
   const stackD_branchL = 1;
   const stackE_branchL = 0;
 
-  function getInvertedCallTreeFromProfile(): ProfileTreeClass {
+  function getInvertedCallTreeFromProfile(): CallTree {
     const profile = getProfileForInvertedCallTree();
     const invertedThread = invertCallstack(profile.threads[0]);
     const { interval } = profile.meta;
@@ -495,7 +495,7 @@ describe('inverted call tree', function() {
  * node, so that the error messages are nice and helpful for when things fail.
  */
 function _assertNode(
-  callTree: ProfileTreeClass,
+  callTree: CallTree,
   callNodeIndex: IndexIntoCallNodeTable,
   expected: {
     children: IndexIntoCallNodeTable[],
@@ -504,7 +504,7 @@ function _assertNode(
     totalTime: number,
   }
 ) {
-  // Transform any CallNodeIndexes into ProfileTree nodes.
+  // Transform any CallNodeIndexes into CallTree nodes.
   const getNode = (callNodeIndex: IndexIntoCallNodeTable) =>
     callNodeIndex === -1 ? null : callTree.getNode(callNodeIndex);
 

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -75,14 +75,14 @@ type ProfileAction =
       symbolNames: string[],
     }
   | {
-      type: 'CHANGE_SELECTED_FUNC_STACK',
+      type: 'CHANGE_SELECTED_CALL_NODE',
       threadIndex: ThreadIndex,
-      selectedFuncStack: IndexIntoFuncTable[],
+      selectedCallNodePath: IndexIntoFuncTable[],
     }
   | {
-      type: 'CHANGE_EXPANDED_FUNC_STACKS',
+      type: 'CHANGE_EXPANDED_CALL_NODES',
       threadIndex: ThreadIndex,
-      expandedFuncStacks: Array<IndexIntoFuncTable[]>,
+      expandedCallNodePaths: Array<IndexIntoFuncTable[]>,
     }
   | {
       type: 'CHANGE_SELECTED_MARKER',

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -6,33 +6,34 @@
 import type { Milliseconds } from './units';
 import type { MarkerPayload } from './markers';
 
-export type IndexIntoFuncStackTable = number;
+export type IndexIntoCallNodeTable = number;
 
 /**
- * Contains a table of stack information that is unique to the function as opposed to
- * being unique to the frame. There can be multiple frames for a single C++ function.
- * Using stacks as opposed to funcStacks can cause duplicated functions in reports
- * like the call tree.
+ * Contains a table of function call information that represents the stacks of what
+ * functions were called, as opposed to stacks based on frames. There can be multiple
+ * frames for a single function call. Using stacks as opposed to a computed tree of
+ * CallNodes can cause duplicated functions in the call tree.
  *
  * For example:
  *
- *            stack1 (funcA)                             funcStack1 (funcA)
+ *            stack1 (funcA)                             callNode1 (funcA)
  *                 |                                            |
  *                 v                                            v
- *            stack2 (funcB)         stackTable to       funcStack2 (funcB)
- *                 |                funcStackTable              |
+ *            stack2 (funcB)         StackTable to       callNode2 (funcB)
+ *                 |                 CallNodeTable              |
  *                 v                      ->                    v
- *            stack3 (funcC)                             funcStack3 (funcC)
+ *            stack3 (funcC)                             callNode3 (funcC)
  *            /            \                                    |
  *           V              V                                   v
- *    stack4 (funcD)     stack5 (funcD)                  funcStack4 (funcD)
+ *    stack4 (funcD)     stack5 (funcD)                  callNode4 (funcD)
  *         |                  |                          /               \
  *         v                  V                         V                 V
- *    stack6 (funcE)     stack7 (funcF)       funcStack5 (funcE)     funcStack6 (funcF)
+ *    stack6 (funcE)     stack7 (funcF)       callNode5 (funcE)     callNode6 (funcF)
  *
- * For a detailed explanation of funcStacks see `docs/func-stacks.md`.
+ * For a detailed explanation of callNodes see `docs/call-tree.md` and
+ * `docs/call-nodes-in-cpp.md`.
  */
-export type FuncStackTable = {
+export type CallNodeTable = {
   prefix: Int32Array,
   func: Int32Array,
   depth: number[],
@@ -40,13 +41,13 @@ export type FuncStackTable = {
 };
 
 /**
- * Both the funcStackTable and a map that converts an IndexIntoStackTable
- * into an IndexIntoFuncStackTable.
+ * Both the callNodeTable and a map that converts an IndexIntoStackTable
+ * into an IndexIntoCallNodeTable.
  */
-export type FuncStackInfo = {
-  funcStackTable: FuncStackTable,
-  // IndexIntoStackTable -> IndexIntoFuncStackTable
-  stackIndexToFuncStackIndex: Uint32Array,
+export type CallNodeInfo = {
+  callNodeTable: CallNodeTable,
+  // IndexIntoStackTable -> IndexIntoCallNodeTable
+  stackIndexToCallNodeIndex: Uint32Array,
 };
 
 export type TracingMarker = {

--- a/src/types/reducers.js
+++ b/src/types/reducers.js
@@ -29,8 +29,8 @@ export type Reducer<T> = (T, Action) => T;
 export type RequestedLib = { debugName: string, breakpadId: string };
 export type SymbolicationStatus = 'DONE' | 'SYMBOLICATING';
 export type ThreadViewOptions = {
-  selectedFuncStack: IndexIntoFuncTable[],
-  expandedFuncStacks: Array<IndexIntoFuncTable[]>,
+  selectedCallNodePath: IndexIntoFuncTable[],
+  expandedCallNodePaths: Array<IndexIntoFuncTable[]>,
   selectedMarker: IndexIntoMarkersTable | -1,
 };
 export type ProfileViewState = {


### PR DESCRIPTION
Hopefully this will be a little bit more explicit and consistent for future code patches.