### PR TITLE
Add latency info to DOMEvent markers

### DIFF
--- a/src/components/shared/MarkerTooltipContents.js
+++ b/src/components/shared/MarkerTooltipContents.js
@@ -40,9 +40,14 @@ function getMarkerDetails(data: MarkerPayload): React$Element<*> | null {
         );
       }
       case 'DOMEvent': {
+        let latency;
+        if (data.timeStamp) {
+          latency = `${formatTimeLength(data.startTime - data.timeStamp)}ms`;
+        }
         return (
           <div className="tooltipDetails">
             {_markerDetail('type', 'Type', data.eventType)}
+            {data.timeStamp && _markerDetail('latency', 'Latency', latency)}
           </div>
         );
       }

--- a/src/components/shared/MarkerTooltipContents.js
+++ b/src/components/shared/MarkerTooltipContents.js
@@ -40,14 +40,14 @@ function getMarkerDetails(data: MarkerPayload): React$Element<*> | null {
         );
       }
       case 'DOMEvent': {
-        let latency;
+        let latency = 0;
         if (data.timeStamp) {
           latency = `${formatTimeLength(data.startTime - data.timeStamp)}ms`;
         }
         return (
           <div className="tooltipDetails">
             {_markerDetail('type', 'Type', data.eventType)}
-            {data.timeStamp && _markerDetail('latency', 'Latency', latency)}
+            {latency && _markerDetail('latency', 'Latency', latency)}
           </div>
         );
       }

--- a/src/components/shared/MarkerTooltipContents.js
+++ b/src/components/shared/MarkerTooltipContents.js
@@ -47,7 +47,7 @@ function getMarkerDetails(data: MarkerPayload): React$Element<*> | null {
         return (
           <div className="tooltipDetails">
             {_markerDetail('type', 'Type', data.eventType)}
-            {latency && _markerDetail('latency', 'Latency', latency)}
+            {latency ? _markerDetail('latency', 'Latency', latency) : null}
           </div>
         );
       }

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -577,6 +577,9 @@ function _adjustMarkerTimestamps(
       if ('endTime' in newData) {
         newData.endTime += delta;
       }
+      if (newData.type === 'DOMEvent' && 'timeStamp' in newData) {
+        newData.timeStamp += delta;
+      }
       return newData;
     }),
   });

--- a/src/profile-logic/processed-profile-versioning.js
+++ b/src/profile-logic/processed-profile-versioning.js
@@ -332,6 +332,9 @@ const _upgraders = {
     // milliseconds relative to meta.startTime.  Adjust it by adding
     // the thread.processStartupTime which is the delta to
     // meta.startTime.
+    // Only the timeStamp property is updated because it's new and
+    // perf.html wasn't updated to handle it when it appeared in
+    // Firefox.
     for (const thread of profile.threads) {
       if (thread.processType === 'default') {
         continue;

--- a/src/test/fixtures/profiles/example-profile.js
+++ b/src/test/fixtures/profiles/example-profile.js
@@ -175,6 +175,7 @@ const thread = {
           // DOMEvent at time 5ms from 5ms to 6ms
           startTime: 9,
           endTime: 10,
+          timeStamp: 1,
           type: 'mouseout',
           phase: 3,
         },

--- a/src/test/fixtures/upgrades/processed-7a.json
+++ b/src/test/fixtures/upgrades/processed-7a.json
@@ -648,9 +648,9 @@
       "name": "GeckoMain",
       "processType": "tab",
       "pausedRanges": [],
-      "processStartupTime": 0,
+      "processStartupTime": 1000,
       "processShutdownTime": null,
-      "registerTime": 0,
+      "registerTime": 1000,
       "unregisterTime": null,
       "libs": [
         {
@@ -885,6 +885,7 @@
             "type": "DOMEvent",
             "startTime": 1009,
             "endTime": 1010,
+            "timeStamp": 1,
             "eventType": "mouseout",
             "phase": 3
           },

--- a/src/test/fixtures/upgrades/processed-8.json
+++ b/src/test/fixtures/upgrades/processed-8.json
@@ -1,0 +1,995 @@
+{
+  "meta": {
+    "abi": "x86_64-gcc3",
+    "interval": 1,
+    "misc": "rv:48.0",
+    "oscpu": "Intel Mac OS X 10.11",
+    "platform": "Macintosh",
+    "processType": 0,
+    "product": "Firefox",
+    "stackwalk": 1,
+    "startTime": 1460221352723.438,
+    "toolkit": "cocoa",
+    "version": 4,
+    "preprocessedProfileVersion": 8
+  },
+  "threads": [
+    {
+      "name": "GeckoMain",
+      "processType": "default",
+      "pausedRanges": [],
+      "processStartupTime": 0,
+      "processShutdownTime": null,
+      "registerTime": 0,
+      "unregisterTime": null,
+      "libs": [
+        {
+          "breakpadId": "F1D957D30B413D55A539BBA06F90DD8F0",
+          "arch": "x86_64",
+          "debugPath": "",
+          "debugName": "firefox",
+          "name": "firefox",
+          "path": "/Applications/FirefoxNightly.app/Contents/MacOS/firefox",
+          "start": 4294967296,
+          "end": 4294977296
+        },
+        {
+          "breakpadId": "1000000000000000000000000000000A1",
+          "arch": "x86_64",
+          "debugPath": "",
+          "debugName": "examplebinary",
+          "name": "examplebinary",
+          "path": "/tmp/examplebinary",
+          "start": 8589934592,
+          "end": 8589934612
+        },
+        {
+          "breakpadId": "100000000000000000000000000000A27",
+          "arch": "x86_64",
+          "debugPath": "",
+          "debugName": "examplebinary2.pdb",
+          "name": "examplebinary2",
+          "path": "C:\\examplebinary2",
+          "start": 8589934612,
+          "end": 8589934632
+        }
+      ],
+      "frameTable": {
+        "length": 5,
+        "implementation": [
+          null,
+          null,
+          null,
+          null,
+          6
+        ],
+        "optimizations": [
+          null,
+          null,
+          null,
+          null,
+          null
+        ],
+        "line": [
+          null,
+          null,
+          null,
+          4391,
+          34
+        ],
+        "category": [
+          null,
+          null,
+          null,
+          16,
+          null
+        ],
+        "func": [
+          0,
+          1,
+          2,
+          3,
+          4
+        ],
+        "address": [
+          -1,
+          3972,
+          6725,
+          -1,
+          -1
+        ]
+      },
+      "funcTable": {
+        "length": 5,
+        "name": [
+          0,
+          1,
+          2,
+          3,
+          13
+        ],
+        "resource": [
+          -1,
+          0,
+          0,
+          -1,
+          1
+        ],
+        "address": [
+          -1,
+          3972,
+          6725,
+          -1,
+          -1
+        ],
+        "isJS": [
+          false,
+          false,
+          false,
+          false,
+          true
+        ],
+        "fileName": [
+          null,
+          null,
+          null,
+          null,
+          12
+        ],
+        "lineNumber": [
+          null,
+          null,
+          null,
+          null,
+          34
+        ]
+      },
+      "resourceTable": {
+        "length": 2,
+        "type": [
+          1,
+          5
+        ],
+        "name": [
+          11,
+          12
+        ],
+        "lib": [
+          0
+        ],
+        "icon": [],
+        "addonId": [],
+        "host": []
+      },
+      "stackTable": {
+        "length": 5,
+        "prefix": [
+          null,
+          0,
+          1,
+          1,
+          1
+        ],
+        "frame": [
+          0,
+          1,
+          2,
+          3,
+          4
+        ]
+      },
+      "markers": {
+        "length": 7,
+        "name": [
+          4,
+          5,
+          10,
+          10,
+          5,
+          8,
+          9
+        ],
+        "time": [
+          0,
+          2,
+          4,
+          5,
+          8,
+          9,
+          11
+        ],
+        "data": [
+          {
+            "category": "VsyncTimestamp",
+            "vsync": 0
+          },
+          {
+            "category": "Paint",
+            "interval": "start",
+            "stack": {
+              "markers": {
+                "schema": {
+                  "name": 0,
+                  "time": 1,
+                  "data": 2
+                },
+                "data": []
+              },
+              "name": "SyncProfile",
+              "samples": {
+                "schema": {
+                  "stack": 0,
+                  "time": 1,
+                  "responsiveness": 2,
+                  "rss": 3,
+                  "uss": 4,
+                  "frameNumber": 5,
+                  "power": 6
+                },
+                "data": [
+                  [
+                    2,
+                    1
+                  ]
+                ]
+              }
+            },
+            "type": "tracing"
+          },
+          {
+            "category": "Paint",
+            "interval": "start",
+            "type": "tracing"
+          },
+          {
+            "category": "Paint",
+            "interval": "end",
+            "type": "tracing"
+          },
+          {
+            "category": "Paint",
+            "interval": "end",
+            "type": "tracing"
+          },
+          {
+            "type": "DOMEvent",
+            "startTime": 9,
+            "endTime": 10,
+            "eventType": "mouseout",
+            "phase": 3
+          },
+          {
+            "startTime": 11,
+            "endTime": 12
+          }
+        ]
+      },
+      "samples": {
+        "length": 7,
+        "stack": [
+          1,
+          2,
+          2,
+          3,
+          0,
+          1,
+          4
+        ],
+        "time": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "responsiveness": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0
+        ],
+        "rss": [
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ],
+        "uss": [
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ]
+      },
+      "stringArray": [
+        "(root)",
+        "0x100000f84",
+        "0x100001a45",
+        "Startup::XRE_Main",
+        "VsyncTimestamp",
+        "Reflow",
+        "baseline",
+        "frobnicate (chrome://blargh:34)",
+        "DOMEvent",
+        "MinorGC",
+        "Rasterize",
+        "firefox",
+        "chrome://blargh",
+        "frobnicate"
+      ]
+    },
+    {
+      "name": "Compositor",
+      "processType": "default",
+      "pausedRanges": [],
+      "processStartupTime": 0,
+      "processShutdownTime": null,
+      "registerTime": 0,
+      "unregisterTime": null,
+      "libs": [
+        {
+          "breakpadId": "F1D957D30B413D55A539BBA06F90DD8F0",
+          "arch": "x86_64",
+          "debugPath": "",
+          "debugName": "firefox",
+          "name": "firefox",
+          "path": "/Applications/FirefoxNightly.app/Contents/MacOS/firefox",
+          "start": 4294967296,
+          "end": 4294977296
+        },
+        {
+          "breakpadId": "1000000000000000000000000000000A1",
+          "arch": "x86_64",
+          "debugPath": "",
+          "debugName": "examplebinary",
+          "name": "examplebinary",
+          "path": "/tmp/examplebinary",
+          "start": 8589934592,
+          "end": 8589934612
+        },
+        {
+          "breakpadId": "100000000000000000000000000000A27",
+          "arch": "x86_64",
+          "debugPath": "",
+          "debugName": "examplebinary2.pdb",
+          "name": "examplebinary2",
+          "path": "C:\\examplebinary2",
+          "start": 8589934612,
+          "end": 8589934632
+        }
+      ],
+      "frameTable": {
+        "length": 5,
+        "implementation": [
+          null,
+          null,
+          null,
+          null,
+          6
+        ],
+        "optimizations": [
+          null,
+          null,
+          null,
+          null,
+          null
+        ],
+        "line": [
+          null,
+          null,
+          null,
+          4391,
+          34
+        ],
+        "category": [
+          null,
+          null,
+          null,
+          16,
+          null
+        ],
+        "func": [
+          0,
+          1,
+          2,
+          3,
+          4
+        ],
+        "address": [
+          -1,
+          3972,
+          6725,
+          -1,
+          -1
+        ]
+      },
+      "funcTable": {
+        "length": 5,
+        "name": [
+          0,
+          1,
+          2,
+          3,
+          13
+        ],
+        "resource": [
+          -1,
+          0,
+          0,
+          -1,
+          1
+        ],
+        "address": [
+          -1,
+          3972,
+          6725,
+          -1,
+          -1
+        ],
+        "isJS": [
+          false,
+          false,
+          false,
+          false,
+          true
+        ],
+        "fileName": [
+          null,
+          null,
+          null,
+          null,
+          12
+        ],
+        "lineNumber": [
+          null,
+          null,
+          null,
+          null,
+          34
+        ]
+      },
+      "resourceTable": {
+        "length": 2,
+        "type": [
+          1,
+          5
+        ],
+        "name": [
+          11,
+          12
+        ],
+        "lib": [
+          0
+        ],
+        "icon": [],
+        "addonId": [],
+        "host": []
+      },
+      "stackTable": {
+        "length": 5,
+        "prefix": [
+          null,
+          0,
+          1,
+          1,
+          1
+        ],
+        "frame": [
+          0,
+          1,
+          2,
+          3,
+          4
+        ]
+      },
+      "markers": {
+        "length": 7,
+        "name": [
+          4,
+          5,
+          10,
+          10,
+          5,
+          8,
+          9
+        ],
+        "time": [
+          0,
+          2,
+          4,
+          5,
+          8,
+          9,
+          11
+        ],
+        "data": [
+          {
+            "category": "VsyncTimestamp",
+            "vsync": 0
+          },
+          {
+            "category": "Paint",
+            "interval": "start",
+            "stack": {
+              "markers": {
+                "schema": {
+                  "name": 0,
+                  "time": 1,
+                  "data": 2
+                },
+                "data": []
+              },
+              "name": "SyncProfile",
+              "samples": {
+                "schema": {
+                  "stack": 0,
+                  "time": 1,
+                  "responsiveness": 2,
+                  "rss": 3,
+                  "uss": 4,
+                  "frameNumber": 5,
+                  "power": 6
+                },
+                "data": [
+                  [
+                    2,
+                    1
+                  ]
+                ]
+              }
+            },
+            "type": "tracing"
+          },
+          {
+            "category": "Paint",
+            "interval": "start",
+            "type": "tracing"
+          },
+          {
+            "category": "Paint",
+            "interval": "end",
+            "type": "tracing"
+          },
+          {
+            "category": "Paint",
+            "interval": "end",
+            "type": "tracing"
+          },
+          {
+            "type": "DOMEvent",
+            "startTime": 9,
+            "endTime": 10,
+            "eventType": "mouseout",
+            "phase": 3
+          },
+          {
+            "startTime": 11,
+            "endTime": 12
+          }
+        ]
+      },
+      "samples": {
+        "length": 7,
+        "stack": [
+          1,
+          2,
+          2,
+          3,
+          0,
+          1,
+          4
+        ],
+        "time": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "responsiveness": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0
+        ],
+        "rss": [
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ],
+        "uss": [
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ]
+      },
+      "stringArray": [
+        "(root)",
+        "0x100000f84",
+        "0x100001a45",
+        "Startup::XRE_Main",
+        "VsyncTimestamp",
+        "Reflow",
+        "baseline",
+        "frobnicate (chrome://blargh:34)",
+        "DOMEvent",
+        "MinorGC",
+        "Rasterize",
+        "firefox",
+        "chrome://blargh",
+        "frobnicate"
+      ]
+    },
+    {
+      "name": "GeckoMain",
+      "processType": "tab",
+      "pausedRanges": [],
+      "processStartupTime": 0,
+      "processShutdownTime": null,
+      "registerTime": 0,
+      "unregisterTime": null,
+      "libs": [
+        {
+          "breakpadId": "9F950E2CE3CD3E1ABD06D80788B606E60",
+          "arch": "x86_64",
+          "debugPath": "",
+          "debugName": "firefox-webcontent",
+          "name": "firefox-webcontent",
+          "path": "/Applications/FirefoxNightly.app/Contents/MacOS/firefox-webcontent.app/Contents/MacOS/firefox-webcontent",
+          "start": 4294967296,
+          "end": 4294977296
+        },
+        {
+          "breakpadId": "1000000000000000000000000000000A1",
+          "arch": "x86_64",
+          "debugPath": "",
+          "debugName": "examplebinary",
+          "name": "examplebinary",
+          "path": "/tmp/examplebinary",
+          "start": 8589934592,
+          "end": 8589934612
+        },
+        {
+          "breakpadId": "100000000000000000000000000000A27",
+          "arch": "x86_64",
+          "debugPath": "",
+          "debugName": "examplebinary2.pdb",
+          "name": "examplebinary2",
+          "path": "C:\\examplebinary2",
+          "start": 8589934612,
+          "end": 8589934632
+        }
+      ],
+      "frameTable": {
+        "length": 5,
+        "implementation": [
+          null,
+          null,
+          null,
+          null,
+          6
+        ],
+        "optimizations": [
+          null,
+          null,
+          null,
+          null,
+          null
+        ],
+        "line": [
+          null,
+          null,
+          null,
+          4391,
+          34
+        ],
+        "category": [
+          null,
+          null,
+          null,
+          16,
+          null
+        ],
+        "func": [
+          0,
+          1,
+          2,
+          3,
+          4
+        ],
+        "address": [
+          -1,
+          3972,
+          6725,
+          -1,
+          -1
+        ]
+      },
+      "funcTable": {
+        "length": 5,
+        "name": [
+          0,
+          1,
+          2,
+          3,
+          13
+        ],
+        "resource": [
+          -1,
+          0,
+          0,
+          -1,
+          1
+        ],
+        "address": [
+          -1,
+          3972,
+          6725,
+          -1,
+          -1
+        ],
+        "isJS": [
+          false,
+          false,
+          false,
+          false,
+          true
+        ],
+        "fileName": [
+          null,
+          null,
+          null,
+          null,
+          12
+        ],
+        "lineNumber": [
+          null,
+          null,
+          null,
+          null,
+          34
+        ]
+      },
+      "resourceTable": {
+        "length": 2,
+        "type": [
+          1,
+          5
+        ],
+        "name": [
+          11,
+          12
+        ],
+        "lib": [
+          0
+        ],
+        "icon": [],
+        "addonId": [],
+        "host": []
+      },
+      "stackTable": {
+        "length": 5,
+        "prefix": [
+          null,
+          0,
+          1,
+          1,
+          1
+        ],
+        "frame": [
+          0,
+          1,
+          2,
+          3,
+          4
+        ]
+      },
+      "markers": {
+        "length": 7,
+        "name": [
+          4,
+          5,
+          10,
+          10,
+          5,
+          8,
+          9
+        ],
+        "time": [
+          1000,
+          1002,
+          1004,
+          1005,
+          1008,
+          1009,
+          1011
+        ],
+        "data": [
+          {
+            "category": "VsyncTimestamp",
+            "vsync": 0
+          },
+          {
+            "category": "Paint",
+            "interval": "start",
+            "stack": {
+              "markers": {
+                "schema": {
+                  "name": 0,
+                  "time": 1,
+                  "data": 2
+                },
+                "data": []
+              },
+              "name": "SyncProfile",
+              "samples": {
+                "schema": {
+                  "stack": 0,
+                  "time": 1,
+                  "responsiveness": 2,
+                  "rss": 3,
+                  "uss": 4,
+                  "frameNumber": 5,
+                  "power": 6
+                },
+                "data": [
+                  [
+                    2,
+                    1
+                  ]
+                ]
+              }
+            },
+            "type": "tracing"
+          },
+          {
+            "category": "Paint",
+            "interval": "start",
+            "type": "tracing"
+          },
+          {
+            "category": "Paint",
+            "interval": "end",
+            "type": "tracing"
+          },
+          {
+            "category": "Paint",
+            "interval": "end",
+            "type": "tracing"
+          },
+          {
+            "type": "DOMEvent",
+            "startTime": 1009,
+            "endTime": 1010,
+            "eventType": "mouseout",
+            "phase": 3
+          },
+          {
+            "startTime": 1011,
+            "endTime": 1012
+          }
+        ]
+      },
+      "samples": {
+        "length": 7,
+        "stack": [
+          1,
+          2,
+          2,
+          3,
+          0,
+          1,
+          4
+        ],
+        "time": [
+          1000,
+          1001,
+          1002,
+          1003,
+          1004,
+          1005,
+          1006
+        ],
+        "responsiveness": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0
+        ],
+        "rss": [
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ],
+        "uss": [
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ]
+      },
+      "stringArray": [
+        "(root)",
+        "0x100000f84",
+        "0x100001a45",
+        "Startup::XRE_Main",
+        "VsyncTimestamp",
+        "Reflow",
+        "baseline",
+        "frobnicate (chrome://blargh:34)",
+        "DOMEvent",
+        "MinorGC",
+        "Rasterize",
+        "firefox-webcontent",
+        "chrome://blargh",
+        "frobnicate"
+      ]
+    }
+  ],
+  "tasktracer": {
+    "taskTable": {
+      "length": 0,
+      "dispatchTime": [],
+      "sourceEventId": [],
+      "sourceEventType": [],
+      "parentTaskId": [],
+      "beginTime": [],
+      "processId": [],
+      "threadIndex": [],
+      "endTime": [],
+      "ipdlMsg": [],
+      "label": [],
+      "address": []
+    },
+    "tasksIdToTaskIndexMap": [],
+    "addressTable": {
+      "length": 0,
+      "address": [],
+      "className": [],
+      "lib": []
+    },
+    "addressIndicesByLib": [],
+    "threadTable": {
+      "length": 0,
+      "tid": [],
+      "name": [],
+      "start": []
+    },
+    "tidToThreadIndexMap": [],
+    "stringArray": []
+  }
+}

--- a/src/test/fixtures/upgrades/processed-8a.json
+++ b/src/test/fixtures/upgrades/processed-8a.json
@@ -11,7 +11,7 @@
     "startTime": 1460221352723.438,
     "toolkit": "cocoa",
     "version": 4,
-    "preprocessedProfileVersion": 7
+    "preprocessedProfileVersion": 8
   },
   "threads": [
     {
@@ -648,9 +648,9 @@
       "name": "GeckoMain",
       "processType": "tab",
       "pausedRanges": [],
-      "processStartupTime": 0,
+      "processStartupTime": 1000,
       "processShutdownTime": null,
-      "registerTime": 0,
+      "registerTime": 1000,
       "unregisterTime": null,
       "libs": [
         {
@@ -885,6 +885,7 @@
             "type": "DOMEvent",
             "startTime": 1009,
             "endTime": 1010,
+            "timeStamp": 1001,
             "eventType": "mouseout",
             "phase": 3
           },

--- a/src/test/unit/profile-data.test.js
+++ b/src/test/unit/profile-data.test.js
@@ -650,6 +650,8 @@ describe('upgrades', function() {
     );
     compareProcessedProfiles(upgradedProfile7, afterUpgradeReference);
 
+    // processed-7a to processed-8a is testing that we properly
+    // upgrade the DOMEventMarkerPayload.timeStamp field.
     const serializedOldProcessedProfile7a = require('../fixtures/upgrades/processed-7a.json');
     const afterUpgradeReference8a = unserializeProfileOfArbitraryFormat(
       require('../fixtures/upgrades/processed-8a.json')
@@ -659,6 +661,8 @@ describe('upgrades', function() {
     );
     compareProcessedProfiles(upgradedProfile7a, afterUpgradeReference8a);
 
+    // This last test is to make sure we properly upgrade the json
+    // file to same version
     const serializedOldProcessedProfile8 = require('../fixtures/upgrades/processed-8.json');
     const upgradedProfile8 = unserializeProfileOfArbitraryFormat(
       serializedOldProcessedProfile8
@@ -691,6 +695,12 @@ describe('upgrades', function() {
     const geckoProfile7 = require('../fixtures/upgrades/gecko-7.json');
     upgradeGeckoProfileToCurrentVersion(geckoProfile7);
     expect(geckoProfile7).toEqual(afterUpgradeGeckoReference);
+
+    // This last test is to make sure we properly upgrade the json
+    // file to same version
+    const geckoProfile8 = require('../fixtures/upgrades/gecko-8.json');
+    upgradeGeckoProfileToCurrentVersion(geckoProfile8);
+    expect(geckoProfile8).toEqual(afterUpgradeGeckoReference);
   });
 });
 

--- a/src/test/unit/profile-data.test.js
+++ b/src/test/unit/profile-data.test.js
@@ -589,7 +589,7 @@ describe('upgrades', function() {
     expect(serializedLhsAsObject).toEqual(serializedRhsAsObject);
   }
   const afterUpgradeReference = unserializeProfileOfArbitraryFormat(
-    require('../fixtures/upgrades/processed-7.json')
+    require('../fixtures/upgrades/processed-8.json')
   );
 
   // Uncomment this to output your next ./upgrades/processed-X.json
@@ -637,6 +637,12 @@ describe('upgrades', function() {
       serializedOldProcessedProfile6
     );
     compareProcessedProfiles(upgradedProfile6, afterUpgradeReference);
+
+    const serializedOldProcessedProfile7 = require('../fixtures/upgrades/processed-7.json');
+    const upgradedProfile7 = unserializeProfileOfArbitraryFormat(
+      serializedOldProcessedProfile7
+    );
+    compareProcessedProfiles(upgradedProfile7, afterUpgradeReference);
   });
   it('should import an old Gecko profile and upgrade it to be the same as the newest Gecko profile', function() {
     const afterUpgradeGeckoReference = require('../fixtures/upgrades/gecko-8.json');

--- a/src/test/unit/profile-data.test.js
+++ b/src/test/unit/profile-data.test.js
@@ -212,6 +212,12 @@ describe('process-profile', function() {
           ? profile.threads[2].markers.data[5].endTime
           : null
       ).toEqual(1010);
+      expect(
+        profile.threads[2].markers.data[5] &&
+        profile.threads[2].markers.data[5].type === 'DOMEvent'
+          ? profile.threads[2].markers.data[5].timeStamp
+          : null
+      ).toEqual(1001);
       // TODO: also shift the samples inside marker callstacks
     });
     it('should create one function per frame', function() {
@@ -643,6 +649,21 @@ describe('upgrades', function() {
       serializedOldProcessedProfile7
     );
     compareProcessedProfiles(upgradedProfile7, afterUpgradeReference);
+
+    const serializedOldProcessedProfile7a = require('../fixtures/upgrades/processed-7a.json');
+    const afterUpgradeReference8a = unserializeProfileOfArbitraryFormat(
+      require('../fixtures/upgrades/processed-8a.json')
+    );
+    const upgradedProfile7a = unserializeProfileOfArbitraryFormat(
+      serializedOldProcessedProfile7a
+    );
+    compareProcessedProfiles(upgradedProfile7a, afterUpgradeReference8a);
+
+    const serializedOldProcessedProfile8 = require('../fixtures/upgrades/processed-8.json');
+    const upgradedProfile8 = unserializeProfileOfArbitraryFormat(
+      serializedOldProcessedProfile8
+    );
+    compareProcessedProfiles(upgradedProfile8, afterUpgradeReference);
   });
   it('should import an old Gecko profile and upgrade it to be the same as the newest Gecko profile', function() {
     const afterUpgradeGeckoReference = require('../fixtures/upgrades/gecko-8.json');

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -102,6 +102,7 @@ export type UserTimingMarkerPayload = {
 
 export type DOMEventMarkerPayload = {
   type: 'DOMEvent',
+  timeStamp?: Milliseconds,
   startTime: Milliseconds,
   endTime: Milliseconds,
   eventType: string,


### PR DESCRIPTION
I forgot to update the website before I pushed the gecko change. So the profile recorded before the perf.html change will display wrong latency number for content processes. I'm not sure if it's fixable...