### PR TITLE
Merge to caller

### DIFF
--- a/res/style.css
+++ b/res/style.css
@@ -834,7 +834,7 @@ body {
 
 .react-contextmenu {
   min-width: 160px;
-  padding: 3px 0;
+  padding: 5px 0;
   margin: 2px 0 0;
   font-size: 12px;
   color: #000;
@@ -848,13 +848,17 @@ body {
   -moz-user-select: none;
   user-select: none;
 }
+.react-contextmenu-separator {
+  border-bottom: 1px solid #ddd;
+  margin: 6px 0;
+}
 
 .react-contextmenu.react-contextmenu--visible {
   display: block;
 }
 
 .react-contextmenu-item {
-  padding: 2px 8px;
+  padding: 2px 12px;
   line-height: 1.5;
   white-space: nowrap;
   cursor: default;

--- a/src/components/calltree/ProfileCallTreeContextMenu.js
+++ b/src/components/calltree/ProfileCallTreeContextMenu.js
@@ -4,23 +4,38 @@
 
 // @flow
 import React, { PureComponent } from 'react';
-import { ContextMenu, MenuItem, SubMenu } from 'react-contextmenu';
-import actions from '../../actions';
+import { ContextMenu, MenuItem } from 'react-contextmenu';
 import { connect } from 'react-redux';
 import { selectedThreadSelectors } from '../../reducers/profile-view';
 import { stripFunctionArguments } from '../../profile-logic/function-info';
 import copy from 'copy-to-clipboard';
+import { addTransformToStack } from '../../actions/profile-view';
+import {
+  getSelectedThreadIndex,
+  getImplementationFilter,
+  getInvertCallstack,
+} from '../../reducers/url-state';
 
+import type { ImplementationFilter } from '../../types/actions';
 import type {
   IndexIntoCallNodeTable,
   CallNodeInfo,
 } from '../../types/profile-derived';
-import type { Thread } from '../../types/profile';
+import type {
+  Thread,
+  IndexIntoFuncTable,
+  ThreadIndex,
+} from '../../types/profile';
 
 type Props = {
   thread: Thread,
+  threadIndex: ThreadIndex,
   callNodeInfo: CallNodeInfo,
+  implementation: ImplementationFilter,
+  selectedCallNodePath: IndexIntoFuncTable[],
   selectedCallNodeIndex: IndexIntoCallNodeTable,
+  inverted: boolean,
+  addTransformToStack: typeof addTransformToStack,
 };
 
 class ProfileCallTreeContextMenu extends PureComponent {
@@ -93,8 +108,60 @@ class ProfileCallTreeContextMenu extends PureComponent {
       case 'copyStack':
         this.copyStack();
         break;
+      case 'mergeCallNode':
+        this.addTransformToStack('merge-call-node');
+        break;
+      case 'mergeSubtree':
+        this.addTransformToStack('merge-subtree');
+        break;
+      case 'focusSubtree':
+        this.addTransformToStack('focus-subtree');
+        break;
       default:
         throw new Error(`Unknown type ${data.type}`);
+    }
+  }
+
+  addTransformToStack(
+    type: 'focus-subtree' | 'merge-subtree' | 'merge-call-node'
+  ): void {
+    const {
+      addTransformToStack,
+      threadIndex,
+      implementation,
+      selectedCallNodePath,
+      inverted,
+    } = this.props;
+
+    // Flow just isn't working for me here. I resorted to a switch statement. This really
+    // shouldn't be necessary.
+    switch (type) {
+      case 'focus-subtree':
+        addTransformToStack(threadIndex, {
+          type: 'focus-subtree',
+          callNodePath: selectedCallNodePath,
+          implementation,
+          inverted,
+        });
+        break;
+      case 'merge-subtree':
+        addTransformToStack(threadIndex, {
+          type: 'merge-subtree',
+          callNodePath: selectedCallNodePath,
+          implementation,
+          inverted,
+        });
+        break;
+      case 'merge-call-node':
+        addTransformToStack(threadIndex, {
+          type: 'merge-call-node',
+          callNodePath: selectedCallNodePath,
+          implementation,
+          inverted,
+        });
+        break;
+      default:
+        throw new Error('Type not found.');
     }
   }
 
@@ -109,22 +176,30 @@ class ProfileCallTreeContextMenu extends PureComponent {
 
     return (
       <ContextMenu id={'ProfileCallTreeContextMenu'}>
-        <SubMenu title="Copy" hoverDelay={200}>
-          <MenuItem
-            onClick={this.handleClick}
-            data={{ type: 'copyFunctionName' }}
-          >
-            Function Name
-          </MenuItem>
-          {isJS
-            ? <MenuItem onClick={this.handleClick} data={{ type: 'copyUrl' }}>
-                Script URL
-              </MenuItem>
-            : null}
-          <MenuItem onClick={this.handleClick} data={{ type: 'copyStack' }}>
-            Stack
-          </MenuItem>
-        </SubMenu>
+        <MenuItem onClick={this.handleClick} data={{ type: 'mergeCallNode' }}>
+          Merge node into calling function
+        </MenuItem>
+        {/* <MenuItem onClick={this.handleClick} data={{ type: 'mergeSubtree' }}>
+          Merge subtree into calling function
+        </MenuItem> */}
+        <MenuItem onClick={this.handleClick} data={{ type: 'focusSubtree' }}>
+          Focus on subtree
+        </MenuItem>
+        <div className="react-contextmenu-separator" />
+        <MenuItem
+          onClick={this.handleClick}
+          data={{ type: 'copyFunctionName' }}
+        >
+          Copy function name
+        </MenuItem>
+        {isJS
+          ? <MenuItem onClick={this.handleClick} data={{ type: 'copyUrl' }}>
+              Copy script URL
+            </MenuItem>
+          : null}
+        <MenuItem onClick={this.handleClick} data={{ type: 'copyStack' }}>
+          Copy stack
+        </MenuItem>
       </ContextMenu>
     );
   }
@@ -133,10 +208,16 @@ class ProfileCallTreeContextMenu extends PureComponent {
 export default connect(
   state => ({
     thread: selectedThreadSelectors.getFilteredThread(state),
+    threadIndex: getSelectedThreadIndex(state),
     callNodeInfo: selectedThreadSelectors.getCallNodeInfo(state),
+    implementation: getImplementationFilter(state),
+    inverted: getInvertCallstack(state),
+    selectedCallNodePath: selectedThreadSelectors.getSelectedCallNodePath(
+      state
+    ),
     selectedCallNodeIndex: selectedThreadSelectors.getSelectedCallNodeIndex(
       state
     ),
   }),
-  actions
+  { addTransformToStack }
 )(ProfileCallTreeContextMenu);

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -592,6 +592,8 @@ export function mergeCallNode(
       prefix: [],
       frame: [],
     };
+    // Provide two arrays to efficiently cache values for the algorithm. This probably
+    // could be refactored to use only one array here.
     const stackDepths = [];
     const stackMatches = [];
     const funcMatchesImplementation = FUNC_MATCHES[implementation];

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -569,6 +569,234 @@ export function filterThreadToPrefixCallNodePath(
 }
 
 /**
+ * Transform a thread's stacks to merge stacks that match the `prefixCallNodePath` into
+ * the calling stack. See `src/types/transforms.js` for more information about the
+ * "merge-call-node" transform.
+ */
+export function mergeCallNode(
+  thread: Thread,
+  prefixCallNodePath: IndexIntoFuncTable[],
+  implementation: ImplementationFilter
+): Thread {
+  return timeCode('mergeCallNode', () => {
+    const { stackTable, frameTable, samples } = thread;
+    // Depth here is 0 indexed.
+    const depthAtCallNodePathLeaf = prefixCallNodePath.length - 1;
+    const oldStackToNewStack: Map<
+      IndexIntoStackTable | null,
+      IndexIntoStackTable | null
+    > = new Map();
+    oldStackToNewStack.set(null, null);
+    const newStackTable = {
+      length: 0,
+      prefix: [],
+      frame: [],
+    };
+    const stackDepths = [];
+    const stackMatches = [];
+    const funcMatchesImplementation = FUNC_MATCHES[implementation];
+    for (let stackIndex = 0; stackIndex < stackTable.length; stackIndex++) {
+      const prefix = stackTable.prefix[stackIndex];
+      const frameIndex = stackTable.frame[stackIndex];
+      const funcIndex = frameTable.func[frameIndex];
+
+      const doesPrefixMatch = prefix === null ? true : stackMatches[prefix];
+      const prefixDepth = prefix === null ? -1 : stackDepths[prefix];
+      const currentFuncOnPath = prefixCallNodePath[prefixDepth + 1];
+
+      let doMerge = false;
+      let stackDepth = prefixDepth;
+      let doesMatchCallNodePath;
+      if (doesPrefixMatch && stackDepth < depthAtCallNodePathLeaf) {
+        // This stack's prefixes were in our CallNodePath.
+        if (currentFuncOnPath === funcIndex) {
+          // This stack's function matches too!
+          doesMatchCallNodePath = true;
+          if (stackDepth + 1 === depthAtCallNodePathLeaf) {
+            // Holy cow, we found a match for our merge operation and can merge this stack.
+            doMerge = true;
+          } else {
+            // Since we found a match, increase the stack depth. This should match
+            // the depth of the implementation filtered stacks.
+            stackDepth++;
+          }
+        } else if (!funcMatchesImplementation(thread, funcIndex)) {
+          // This stack's function does not match the CallNodePath, however it's not part
+          // of the CallNodePath's implementation filter. Go ahead and keep it.
+          doesMatchCallNodePath = true;
+        } else {
+          // While all of the predecessors matched, this stack's function does not :(
+          doesMatchCallNodePath = false;
+        }
+      } else {
+        // This stack is not part of a matching branch of the tree.
+        doesMatchCallNodePath = false;
+      }
+      stackMatches[stackIndex] = doesMatchCallNodePath;
+      stackDepths[stackIndex] = stackDepth;
+
+      // Map the oldStackToNewStack, and only push on the stacks that aren't merged.
+      if (doMerge) {
+        const newStackPrefix = oldStackToNewStack.get(prefix);
+        oldStackToNewStack.set(
+          stackIndex,
+          newStackPrefix === undefined ? null : newStackPrefix
+        );
+      } else {
+        const newStackIndex = newStackTable.length++;
+        const newStackPrefix = oldStackToNewStack.get(prefix);
+        newStackTable.prefix[newStackIndex] =
+          newStackPrefix === undefined ? null : newStackPrefix;
+        newStackTable.frame[newStackIndex] = frameIndex;
+        oldStackToNewStack.set(stackIndex, newStackIndex);
+      }
+    }
+    const newSamples = Object.assign({}, samples, {
+      stack: samples.stack.map(oldStack => {
+        const newStack = oldStackToNewStack.get(oldStack);
+        if (newStack === undefined) {
+          throw new Error(
+            'Converting from the old stack to a new stack cannot be undefined'
+          );
+        }
+        return newStack;
+      }),
+    });
+    return Object.assign({}, thread, {
+      stackTable: newStackTable,
+      samples: newSamples,
+    });
+  });
+}
+
+/**
+ * Transform a thread to merge stacks that match the `postfixCallNodePath` into
+ * the caller. See `src/types/transforms.js` for more information about the
+ * "merge-call-node" transform.
+ */
+export function mergeInvertedCallNode(
+  thread: Thread,
+  postfixCallNodePath: IndexIntoFuncTable[],
+  implementation: ImplementationFilter
+): Thread {
+  return timeCode('mergeCallNode', () => {
+    const { stackTable, frameTable, samples } = thread;
+    const postfixDepth = postfixCallNodePath.length;
+    const funcMatchesImplementation = FUNC_MATCHES[implementation];
+
+    const stackNeedsMerging: Array<void | true> = [];
+    const stacksChecked: Array<void | true> = [];
+
+    // Go through each sample and determine if it contains a stack that needs to be
+    // merged.
+    for (let i = 0; i < samples.stack.length; i++) {
+      const leafStackIndex = samples.stack[i];
+      if (leafStackIndex === null || stacksChecked[leafStackIndex]) {
+        continue;
+      }
+      stacksChecked[leafStackIndex] = true;
+
+      let matchesUpToDepth = 0; // counted from the leaf
+      for (
+        let stackIndex = leafStackIndex;
+        stackIndex !== null;
+        stackIndex = stackTable.prefix[stackIndex]
+      ) {
+        const frameIndex = stackTable.frame[stackIndex];
+        const funcIndex = frameTable.func[frameIndex];
+
+        if (funcIndex === postfixCallNodePath[matchesUpToDepth]) {
+          // The CallNodePath matches up to this depth.
+          matchesUpToDepth++;
+          if (matchesUpToDepth === postfixDepth) {
+            // This matches the CallNodePath.
+            stackNeedsMerging[stackIndex] = true;
+            break;
+          }
+        } else if (funcMatchesImplementation(thread, funcIndex)) {
+          // This function didn't match the CallNodePath, and it can't be ignored
+          // because it matches the implementation.
+          break;
+        }
+      }
+    }
+
+    const oldStackToNewStack: Map<
+      IndexIntoStackTable | null,
+      IndexIntoStackTable | null
+    > = new Map();
+    oldStackToNewStack.set(null, null);
+    const newStackTable = {
+      length: 0,
+      prefix: [],
+      frame: [],
+    };
+
+    // We have determined which stacks need to be merged, now do the merging in
+    // one pass across all the stacks.
+    for (
+      let oldStackIndex = 0;
+      oldStackIndex < stackTable.length;
+      oldStackIndex++
+    ) {
+      const oldPrefix = stackTable.prefix[oldStackIndex];
+      const newPrefix = oldStackToNewStack.get(oldPrefix);
+      if (newPrefix === undefined) {
+        throw new Error('The stack must not have an undefined prefix.');
+      }
+      // Skip over this stack, since we are merging it.
+      if (stackNeedsMerging[oldStackIndex]) {
+        oldStackToNewStack.set(oldStackIndex, newPrefix);
+        continue;
+      }
+
+      const newStackIndex = newStackTable.length++;
+      newStackTable.prefix.push(newPrefix);
+      newStackTable.frame.push(stackTable.frame[oldStackIndex]);
+      oldStackToNewStack.set(oldStackIndex, newStackIndex);
+    }
+
+    const newSamplesTable = Object.assign({}, samples, {
+      stack: samples.stack.map(oldStack => {
+        const newStack = oldStackToNewStack.get(oldStack);
+        if (newStack === undefined) {
+          throw new Error('The stack must not convert to undefined.');
+        }
+        return newStack;
+      }),
+    });
+
+    return Object.assign({}, thread, {
+      stackTable: newStackTable,
+      samples: newSamplesTable,
+    });
+  });
+}
+
+const FUNC_MATCHES = {
+  combined: (_thread: Thread, _funcIndex: IndexIntoFuncTable) => true,
+  cpp: (thread: Thread, funcIndex: IndexIntoFuncTable): boolean => {
+    const { funcTable, stringTable } = thread;
+    // Return quickly if this is a JS frame.
+    if (thread.funcTable.isJS[funcIndex]) {
+      return false;
+    }
+
+    // Regular C++ functions are associated with a resource that describes the
+    // shared library that these C++ functions were loaded from. Jitcode is not
+    // loaded from shared libraries but instead generated at runtime, so Jitcode
+    // frames are not associated with a shared library and thus have no resource
+    const locationString = stringTable.getString(funcTable.name[funcIndex]);
+    const isProbablyJitCode =
+      funcTable.resource[funcIndex] === -1 && locationString.startsWith('0x');
+    return !isProbablyJitCode;
+  },
+  js: (thread: Thread, funcIndex: IndexIntoFuncTable): boolean => {
+    return thread.funcTable.isJS[funcIndex];
+  },
+};
+
+/**
  * Filter thread to only contain stacks which end with |postfixCallNodePath|, and
  * only samples witth those stacks. The new stacks' leaf frames will be
  * frames whose func is the last element of the postfix func array.

--- a/src/profile-logic/transforms.js
+++ b/src/profile-logic/transforms.js
@@ -79,10 +79,10 @@ export function stringifyTransforms(transforms: TransformStack = []): string {
 export function getTransformLabels(
   thread: Thread,
   threadName: string,
-  tranforms: Transform[]
+  transforms: Transform[]
 ) {
   const { funcTable, stringTable } = thread;
-  const labels = tranforms.map(transform => {
+  const labels = transforms.map(transform => {
     function lastFuncString(callNodePath) {
       const lastFunc = callNodePath[callNodePath.length - 1];
       const nameIndex = funcTable.name[lastFunc];

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -44,10 +44,7 @@ import type {
   SymbolicationStatus,
   ThreadViewOptions,
 } from '../types/reducers';
-import type {
-  TransformStack,
-  FocusSubtreeTransform,
-} from '../types/transforms';
+import type { TransformStack, Transform } from '../types/transforms';
 
 function profile(
   state: Profile = ProfileData.getEmptyProfile(),
@@ -100,7 +97,7 @@ function profile(
 
 function callNodePathAfterNewTransform(
   callNodePath: IndexIntoFuncTable[],
-  transform: FocusSubtreeTransform
+  transform: Transform
 ): IndexIntoFuncTable[] {
   if (!transform.inverted && transform.implementation !== 'js') {
     return removePrefixFromCallNodePath(transform.callNodePath, callNodePath);
@@ -394,6 +391,7 @@ export type SelectorsForThread = {
   getFilteredThread: State => Thread,
   getRangeSelectionFilteredThread: State => Thread,
   getCallNodeInfo: State => CallNodeInfo,
+  getSelectedCallNodePath: State => IndexIntoFuncTable[],
   getSelectedCallNodeIndex: State => IndexIntoCallNodeTable | null,
   getExpandedCallNodeIndexes: State => Array<IndexIntoCallNodeTable | null>,
   getCallTree: State => CallTree.CallTree,
@@ -469,25 +467,39 @@ export const selectorsForThread = (
     const _getRangeAndTransformFilteredThread = createSelector(
       getRangeFilteredThread,
       getTransformStack,
-      (thread, transforms): Thread => {
-        const result = transforms.reduce((t, transform) => {
+      (startingThread, transforms): Thread => {
+        const result = transforms.reduce((thread, transform) => {
           switch (transform.type) {
             case 'focus-subtree':
               return transform.inverted
                 ? ProfileData.filterThreadToPostfixCallNodePath(
-                    t,
+                    thread,
                     transform.callNodePath,
                     transform.implementation
                   )
                 : ProfileData.filterThreadToPrefixCallNodePath(
-                    t,
+                    thread,
+                    transform.callNodePath,
+                    transform.implementation
+                  );
+            case 'merge-subtree':
+              return thread;
+            case 'merge-call-node':
+              return transform.inverted
+                ? ProfileData.mergeInvertedCallNode(
+                    thread,
+                    transform.callNodePath,
+                    transform.implementation
+                  )
+                : ProfileData.mergeCallNode(
+                    thread,
                     transform.callNodePath,
                     transform.implementation
                   );
             default:
               throw new Error('Unhandled transform.');
           }
-        }, thread);
+        }, startingThread);
         return result;
       }
     );
@@ -533,14 +545,14 @@ export const selectorsForThread = (
         return ProfileData.getCallNodeInfo(stackTable, frameTable, funcTable);
       }
     );
-    const _getSelectedCallNodeAsPath = createSelector(
+    const getSelectedCallNodePath = createSelector(
       getViewOptions,
       (threadViewOptions): IndexIntoFuncTable[] =>
         threadViewOptions.selectedCallNodePath
     );
     const getSelectedCallNodeIndex = createSelector(
       getCallNodeInfo,
-      _getSelectedCallNodeAsPath,
+      getSelectedCallNodePath,
       (callNodeInfo, callNodePath): IndexIntoCallNodeTable | null => {
         return ProfileData.getCallNodeFromPath(
           callNodePath,
@@ -652,6 +664,7 @@ export const selectorsForThread = (
       getFilteredThread,
       getRangeSelectionFilteredThread,
       getCallNodeInfo,
+      getSelectedCallNodePath,
       getSelectedCallNodeIndex,
       getExpandedCallNodeIndexes,
       getCallTree,

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -483,6 +483,7 @@ export const selectorsForThread = (
                     transform.implementation
                   );
             case 'merge-subtree':
+              // TODO - Implement this transform.
               return thread;
             case 'merge-call-node':
               return transform.inverted

--- a/src/test/fixtures/profiles/profiles-for-call-trees.js
+++ b/src/test/fixtures/profiles/profiles-for-call-trees.js
@@ -257,3 +257,70 @@ function _addToStackTable(
   stackTable.prefix.push(prefix);
   stackTable.length++;
 }
+
+export function getProfileWithMixedJSImplementation(): Profile {
+  // These first indexes for funcs, frames, and stacks all share the same values as there
+  // is a one to one relationship between them.
+  const RUN_SCRIPT = 0;
+  const ON_LOAD = 1;
+  const A = 2;
+  const B = 3;
+  const ION_CANNON = 4;
+  // These two indexes are valid for the Ion frames and stacks. The func indexes are from
+  // the previous list.
+  const A_ION = 5;
+  const B_ION = 6;
+
+  const sampleStacks = [B, B_ION, B_ION];
+  const profile = getEmptyProfile();
+  const thread = getEmptyThread();
+  const { stackTable, stringTable } = thread;
+
+  const blankStringIndex = stringTable.indexForString('');
+  const funcNames = ['JS::RunScript', 'onLoad', 'a', 'b', 'js::jit::IonCannon'];
+  const funcNameIndices = funcNames.map(name =>
+    stringTable.indexForString(name)
+  );
+
+  thread.funcTable = {
+    name: funcNameIndices,
+    address: Array(funcNames.length).fill(blankStringIndex),
+    isJS: [false, true, true, true, false],
+    resource: Array(funcNames.length).fill(-1),
+    fileName: Array(funcNames.length).fill(blankStringIndex),
+    lineNumber: Array(funcNames.length).fill(null),
+    length: funcNames.length,
+  };
+
+  const frameFuncs = [RUN_SCRIPT, ON_LOAD, A, B, ION_CANNON, A, B];
+  thread.frameTable = {
+    func: frameFuncs,
+    address: Array(frameFuncs.length).fill(-1),
+    category: Array(frameFuncs.length).fill(null),
+    implementation: Array(frameFuncs.length).fill(null),
+    line: Array(frameFuncs.length).fill(null),
+    optimizations: Array(frameFuncs.length).fill(null),
+    length: frameFuncs.length,
+  };
+
+  _addToStackTable(stackTable, RUN_SCRIPT, null); // 0
+  _addToStackTable(stackTable, ON_LOAD, RUN_SCRIPT); // 1
+  _addToStackTable(stackTable, A, ON_LOAD); // 2
+  _addToStackTable(stackTable, B, A); // 3
+  _addToStackTable(stackTable, ION_CANNON, ON_LOAD); // 4
+  _addToStackTable(stackTable, A, ION_CANNON); // 5
+  _addToStackTable(stackTable, B, A_ION); // 6
+
+  thread.samples = {
+    responsiveness: Array(sampleStacks.length).fill(0),
+    stack: sampleStacks,
+    time: sampleStacks.map((_, i) => i),
+    rss: Array(sampleStacks.length).fill(0),
+    uss: Array(sampleStacks.length).fill(0),
+    length: sampleStacks.length,
+  };
+
+  profile.threads.push(thread);
+
+  return profile;
+}

--- a/src/test/store/__snapshots__/transforms.test.js.snap
+++ b/src/test/store/__snapshots__/transforms.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`focus subtree transform on a call tree can be filtered to a subtree 1`] = `
+exports[`"focus-subtree" transform on a call tree can be filtered to a subtree 1`] = `
 "
 - C (total: 2, self:—)
  - D (total: 1, self:—)
@@ -9,7 +9,7 @@ exports[`focus subtree transform on a call tree can be filtered to a subtree 1`]
    - G (total: 1, self:1)"
 `;
 
-exports[`focus subtree transform on a call tree can remove the transform 1`] = `
+exports[`"focus-subtree" transform on a call tree can remove the transform 1`] = `
 "
 - A (total: 3, self:—)
  - B (total: 3, self:—)
@@ -22,7 +22,7 @@ exports[`focus subtree transform on a call tree can remove the transform 1`] = `
      - I (total: 1, self:1)"
 `;
 
-exports[`focus subtree transform on a call tree starts as an unfiltered call tree 1`] = `
+exports[`"focus-subtree" transform on a call tree starts as an unfiltered call tree 1`] = `
 "
 - A (total: 3, self:—)
  - B (total: 3, self:—)
@@ -35,7 +35,7 @@ exports[`focus subtree transform on a call tree starts as an unfiltered call tre
      - I (total: 1, self:1)"
 `;
 
-exports[`focus subtree transform on an inverted call tree can be filtered to a subtree 1`] = `
+exports[`"focus-subtree" transform on an inverted call tree can be filtered to a subtree 1`] = `
 "
 - X (total: 2, self:2)
  - B (total: 1, self:—)
@@ -45,7 +45,7 @@ exports[`focus subtree transform on an inverted call tree can be filtered to a s
      - A (total: 1, self:—)"
 `;
 
-exports[`focus subtree transform on an inverted call tree can be un-inverted and keep the transform 1`] = `
+exports[`"focus-subtree" transform on an inverted call tree can be un-inverted and keep the transform 1`] = `
 "
 - A (total: 2, self:—)
  - B (total: 2, self:—)
@@ -54,7 +54,7 @@ exports[`focus subtree transform on an inverted call tree can be un-inverted and
    - X (total: 1, self:1)"
 `;
 
-exports[`focus subtree transform on an inverted call tree starts as an inverted call tree 1`] = `
+exports[`"focus-subtree" transform on an inverted call tree starts as an inverted call tree 1`] = `
 "
 - Z (total: 2, self:2)
  - Y (total: 2, self:—)
@@ -69,4 +69,98 @@ exports[`focus subtree transform on an inverted call tree starts as an inverted 
    - C (total: 1, self:—)
      - B (total: 1, self:—)
        - A (total: 1, self:—)"
+`;
+
+exports[`"merge-call-node" transform on a JS call tree can merge a combined CallNodePath, and display a correct JS call tree 1`] = `
+"
+- onLoad (total: 3.0ms, self:0.0ms)
+ - a (total: 2.0ms, self:0.0ms)
+   - b (total: 2.0ms, self:2.0ms)
+ - b (total: 1.0ms, self:1.0ms)"
+`;
+
+exports[`"merge-call-node" transform on a JS call tree can merge path [b, a, js::jit::IonCannon] on an inverted call tree 1`] = `
+"
+- b (total: 3.0ms, self:3.0ms)
+ - a (total: 3.0ms, self:0.0ms)
+   - onLoad (total: 3.0ms, self:0.0ms)
+     - JS::RunScript (total: 3.0ms, self:0.0ms)"
+`;
+
+exports[`"merge-call-node" transform on a JS call tree can merge path [b, a, onLoad] on an inverted JS call tree 1`] = `
+"
+- b (total: 3.0ms, self:3.0ms)
+ - a (total: 3.0ms, self:0.0ms)
+   - js::jit::IonCannon (total: 2.0ms, self:0.0ms)
+     - JS::RunScript (total: 2.0ms, self:0.0ms)
+   - JS::RunScript (total: 1.0ms, self:0.0ms)"
+`;
+
+exports[`"merge-call-node" transform on a JS call tree can merge the node at JS path "onLoad" -> "A" 1`] = `
+"
+- onLoad (total: 3.0ms, self:0.0ms)
+ - b (total: 3.0ms, self:3.0ms)"
+`;
+
+exports[`"merge-call-node" transform on a JS call tree can merge the node at JS path "onLoad" -> "A" on an combined call tree 1`] = `
+"
+- JS::RunScript (total: 3.0ms, self:0.0ms)
+ - onLoad (total: 3.0ms, self:0.0ms)
+   - js::jit::IonCannon (total: 2.0ms, self:0.0ms)
+     - b (total: 2.0ms, self:2.0ms)
+   - b (total: 1.0ms, self:1.0ms)"
+`;
+
+exports[`"merge-call-node" transform on a JS call tree has an untransformed JS only view 1`] = `
+"
+- onLoad (total: 3.0ms, self:0.0ms)
+ - a (total: 3.0ms, self:0.0ms)
+   - b (total: 3.0ms, self:3.0ms)"
+`;
+
+exports[`"merge-call-node" transform on a JS call tree starts as an inverted call tree 1`] = `
+"
+- b (total: 3.0ms, self:3.0ms)
+ - a (total: 3.0ms, self:0.0ms)
+   - js::jit::IonCannon (total: 2.0ms, self:0.0ms)
+     - onLoad (total: 2.0ms, self:0.0ms)
+       - JS::RunScript (total: 2.0ms, self:0.0ms)
+   - onLoad (total: 1.0ms, self:0.0ms)
+     - JS::RunScript (total: 1.0ms, self:0.0ms)"
+`;
+
+exports[`"merge-call-node" transform on a JS call tree starts as an untransformed call tree 1`] = `
+"
+- JS::RunScript (total: 3.0ms, self:0.0ms)
+ - onLoad (total: 3.0ms, self:0.0ms)
+   - js::jit::IonCannon (total: 2.0ms, self:0.0ms)
+     - a (total: 2.0ms, self:0.0ms)
+       - b (total: 2.0ms, self:2.0ms)
+   - a (total: 1.0ms, self:0.0ms)
+     - b (total: 1.0ms, self:1.0ms)"
+`;
+
+exports[`"merge-call-node" transform on a call tree call node [A, B, C] can be merged into [A, B] 1`] = `
+"
+- A (total: 3.0ms, self:0.0ms)
+ - B (total: 3.0ms, self:0.0ms)
+   - D (total: 1.0ms, self:0.0ms)
+     - E (total: 1.0ms, self:1.0ms)
+   - F (total: 1.0ms, self:0.0ms)
+     - G (total: 1.0ms, self:1.0ms)
+   - H (total: 1.0ms, self:0.0ms)
+     - I (total: 1.0ms, self:1.0ms)"
+`;
+
+exports[`"merge-call-node" transform on a call tree starts as an unfiltered call tree 1`] = `
+"
+- A (total: 3.0ms, self:0.0ms)
+ - B (total: 3.0ms, self:0.0ms)
+   - C (total: 2.0ms, self:0.0ms)
+     - D (total: 1.0ms, self:0.0ms)
+       - E (total: 1.0ms, self:1.0ms)
+     - F (total: 1.0ms, self:0.0ms)
+       - G (total: 1.0ms, self:1.0ms)
+   - H (total: 1.0ms, self:0.0ms)
+     - I (total: 1.0ms, self:1.0ms)"
 `;

--- a/src/test/store/__snapshots__/transforms.test.js.snap
+++ b/src/test/store/__snapshots__/transforms.test.js.snap
@@ -73,94 +73,94 @@ exports[`"focus-subtree" transform on an inverted call tree starts as an inverte
 
 exports[`"merge-call-node" transform on a JS call tree can merge a combined CallNodePath, and display a correct JS call tree 1`] = `
 "
-- onLoad (total: 3.0ms, self:0.0ms)
- - a (total: 2.0ms, self:0.0ms)
-   - b (total: 2.0ms, self:2.0ms)
- - b (total: 1.0ms, self:1.0ms)"
+- onLoad (total: 3, self:—)
+ - a (total: 2, self:—)
+   - b (total: 2, self:2)
+ - b (total: 1, self:1)"
 `;
 
 exports[`"merge-call-node" transform on a JS call tree can merge path [b, a, js::jit::IonCannon] on an inverted call tree 1`] = `
 "
-- b (total: 3.0ms, self:3.0ms)
- - a (total: 3.0ms, self:0.0ms)
-   - onLoad (total: 3.0ms, self:0.0ms)
-     - JS::RunScript (total: 3.0ms, self:0.0ms)"
+- b (total: 3, self:3)
+ - a (total: 3, self:—)
+   - onLoad (total: 3, self:—)
+     - JS::RunScript (total: 3, self:—)"
 `;
 
 exports[`"merge-call-node" transform on a JS call tree can merge path [b, a, onLoad] on an inverted JS call tree 1`] = `
 "
-- b (total: 3.0ms, self:3.0ms)
- - a (total: 3.0ms, self:0.0ms)
-   - js::jit::IonCannon (total: 2.0ms, self:0.0ms)
-     - JS::RunScript (total: 2.0ms, self:0.0ms)
-   - JS::RunScript (total: 1.0ms, self:0.0ms)"
+- b (total: 3, self:3)
+ - a (total: 3, self:—)
+   - js::jit::IonCannon (total: 2, self:—)
+     - JS::RunScript (total: 2, self:—)
+   - JS::RunScript (total: 1, self:—)"
 `;
 
 exports[`"merge-call-node" transform on a JS call tree can merge the node at JS path "onLoad" -> "A" 1`] = `
 "
-- onLoad (total: 3.0ms, self:0.0ms)
- - b (total: 3.0ms, self:3.0ms)"
+- onLoad (total: 3, self:—)
+ - b (total: 3, self:3)"
 `;
 
 exports[`"merge-call-node" transform on a JS call tree can merge the node at JS path "onLoad" -> "A" on an combined call tree 1`] = `
 "
-- JS::RunScript (total: 3.0ms, self:0.0ms)
- - onLoad (total: 3.0ms, self:0.0ms)
-   - js::jit::IonCannon (total: 2.0ms, self:0.0ms)
-     - b (total: 2.0ms, self:2.0ms)
-   - b (total: 1.0ms, self:1.0ms)"
+- JS::RunScript (total: 3, self:—)
+ - onLoad (total: 3, self:—)
+   - js::jit::IonCannon (total: 2, self:—)
+     - b (total: 2, self:2)
+   - b (total: 1, self:1)"
 `;
 
 exports[`"merge-call-node" transform on a JS call tree has an untransformed JS only view 1`] = `
 "
-- onLoad (total: 3.0ms, self:0.0ms)
- - a (total: 3.0ms, self:0.0ms)
-   - b (total: 3.0ms, self:3.0ms)"
+- onLoad (total: 3, self:—)
+ - a (total: 3, self:—)
+   - b (total: 3, self:3)"
 `;
 
 exports[`"merge-call-node" transform on a JS call tree starts as an inverted call tree 1`] = `
 "
-- b (total: 3.0ms, self:3.0ms)
- - a (total: 3.0ms, self:0.0ms)
-   - js::jit::IonCannon (total: 2.0ms, self:0.0ms)
-     - onLoad (total: 2.0ms, self:0.0ms)
-       - JS::RunScript (total: 2.0ms, self:0.0ms)
-   - onLoad (total: 1.0ms, self:0.0ms)
-     - JS::RunScript (total: 1.0ms, self:0.0ms)"
+- b (total: 3, self:3)
+ - a (total: 3, self:—)
+   - js::jit::IonCannon (total: 2, self:—)
+     - onLoad (total: 2, self:—)
+       - JS::RunScript (total: 2, self:—)
+   - onLoad (total: 1, self:—)
+     - JS::RunScript (total: 1, self:—)"
 `;
 
 exports[`"merge-call-node" transform on a JS call tree starts as an untransformed call tree 1`] = `
 "
-- JS::RunScript (total: 3.0ms, self:0.0ms)
- - onLoad (total: 3.0ms, self:0.0ms)
-   - js::jit::IonCannon (total: 2.0ms, self:0.0ms)
-     - a (total: 2.0ms, self:0.0ms)
-       - b (total: 2.0ms, self:2.0ms)
-   - a (total: 1.0ms, self:0.0ms)
-     - b (total: 1.0ms, self:1.0ms)"
+- JS::RunScript (total: 3, self:—)
+ - onLoad (total: 3, self:—)
+   - js::jit::IonCannon (total: 2, self:—)
+     - a (total: 2, self:—)
+       - b (total: 2, self:2)
+   - a (total: 1, self:—)
+     - b (total: 1, self:1)"
 `;
 
 exports[`"merge-call-node" transform on a call tree call node [A, B, C] can be merged into [A, B] 1`] = `
 "
-- A (total: 3.0ms, self:0.0ms)
- - B (total: 3.0ms, self:0.0ms)
-   - D (total: 1.0ms, self:0.0ms)
-     - E (total: 1.0ms, self:1.0ms)
-   - F (total: 1.0ms, self:0.0ms)
-     - G (total: 1.0ms, self:1.0ms)
-   - H (total: 1.0ms, self:0.0ms)
-     - I (total: 1.0ms, self:1.0ms)"
+- A (total: 3, self:—)
+ - B (total: 3, self:—)
+   - D (total: 1, self:—)
+     - E (total: 1, self:1)
+   - F (total: 1, self:—)
+     - G (total: 1, self:1)
+   - H (total: 1, self:—)
+     - I (total: 1, self:1)"
 `;
 
 exports[`"merge-call-node" transform on a call tree starts as an unfiltered call tree 1`] = `
 "
-- A (total: 3.0ms, self:0.0ms)
- - B (total: 3.0ms, self:0.0ms)
-   - C (total: 2.0ms, self:0.0ms)
-     - D (total: 1.0ms, self:0.0ms)
-       - E (total: 1.0ms, self:1.0ms)
-     - F (total: 1.0ms, self:0.0ms)
-       - G (total: 1.0ms, self:1.0ms)
-   - H (total: 1.0ms, self:0.0ms)
-     - I (total: 1.0ms, self:1.0ms)"
+- A (total: 3, self:—)
+ - B (total: 3, self:—)
+   - C (total: 2, self:—)
+     - D (total: 1, self:—)
+       - E (total: 1, self:1)
+     - F (total: 1, self:—)
+       - G (total: 1, self:1)
+   - H (total: 1, self:—)
+     - I (total: 1, self:1)"
 `;

--- a/src/test/store/fixtures/profiles.js
+++ b/src/test/store/fixtures/profiles.js
@@ -110,7 +110,7 @@ export function getEmptyThread(overrides: ?Object): Thread {
       libs: [],
       funcTable: {
         address: [],
-        isJS: false,
+        isJS: [],
         name: [],
         resource: [],
         fileName: [],


### PR DESCRIPTION
This adds merging to caller to the transform stack. My original implementation of merge subtree was much simpler, so I started with the intent of adding that as well. However I ended up only stubbing out the transform for merge subtree, but not implementing or surfacing it in the UI. I hope that it is ok that I left that in here.