### PR TITLE
Only expand/collapse nodes on double left click

### DIFF
--- a/src/components/shared/TreeView.js
+++ b/src/components/shared/TreeView.js
@@ -426,7 +426,7 @@ class TreeView extends PureComponent {
 
   _onRowClicked(nodeId: IndexIntoCallNodeTable, event: MouseEvent) {
     this._select(nodeId);
-    if (event.detail === 2) {
+    if (event.detail === 2 && event.button === 0) {
       // double click
       this._toggle(nodeId);
     }


### PR DESCRIPTION
The context menu is making call tree nodes expand and collapse.