### PR TITLE
Create CallNodePath type

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -5,11 +5,8 @@
 // @flow
 import type { ProfileSelection, ImplementationFilter } from '../types/actions';
 import type { Action, ThunkAction } from '../types/store';
-import type {
-  ThreadIndex,
-  IndexIntoFuncTable,
-  IndexIntoMarkersTable,
-} from '../types/profile';
+import type { ThreadIndex, IndexIntoMarkersTable } from '../types/profile';
+import type { CallNodePath } from '../types/profile-derived';
 import type { Transform } from '../types/transforms';
 
 /**
@@ -19,7 +16,7 @@ import type { Transform } from '../types/transforms';
  */
 export function changeSelectedCallNode(
   threadIndex: ThreadIndex,
-  selectedCallNodePath: IndexIntoFuncTable[]
+  selectedCallNodePath: CallNodePath
 ): Action {
   return {
     type: 'CHANGE_SELECTED_CALL_NODE',
@@ -80,7 +77,7 @@ export function changeCallTreeSearchString(searchString: string): Action {
 
 export function changeExpandedCallNodes(
   threadIndex: ThreadIndex,
-  expandedCallNodePaths: Array<IndexIntoFuncTable[]>
+  expandedCallNodePaths: Array<CallNodePath>
 ): Action {
   return {
     type: 'CHANGE_EXPANDED_CALL_NODES',

--- a/src/components/calltree/ProfileCallTreeContextMenu.js
+++ b/src/components/calltree/ProfileCallTreeContextMenu.js
@@ -20,19 +20,16 @@ import type { ImplementationFilter } from '../../types/actions';
 import type {
   IndexIntoCallNodeTable,
   CallNodeInfo,
+  CallNodePath,
 } from '../../types/profile-derived';
-import type {
-  Thread,
-  IndexIntoFuncTable,
-  ThreadIndex,
-} from '../../types/profile';
+import type { Thread, ThreadIndex } from '../../types/profile';
 
 type Props = {
   thread: Thread,
   threadIndex: ThreadIndex,
   callNodeInfo: CallNodeInfo,
   implementation: ImplementationFilter,
-  selectedCallNodePath: IndexIntoFuncTable[],
+  selectedCallNodePath: CallNodePath,
   selectedCallNodeIndex: IndexIntoCallNodeTable,
   inverted: boolean,
   addTransformToStack: typeof addTransformToStack,

--- a/src/components/header/ProfileThreadHeaderBar.js
+++ b/src/components/header/ProfileThreadHeaderBar.js
@@ -16,14 +16,11 @@ import {
 import actions from '../../actions';
 import ContextMenuTrigger from '../shared/ContextMenuTrigger';
 
-import type {
-  IndexIntoFuncTable,
-  Thread,
-  ThreadIndex,
-} from '../../types/profile';
+import type { Thread, ThreadIndex } from '../../types/profile';
 import type { Milliseconds } from '../../types/units';
 import type {
   CallNodeInfo,
+  CallNodePath,
   IndexIntoCallNodeTable,
 } from '../../types/profile-derived';
 import type { State } from '../../types/reducers';
@@ -42,10 +39,7 @@ type Props = {
   threadName: string,
   processDetails: string,
   changeSelectedThread: ThreadIndex => void,
-  changeSelectedCallNode: (
-    IndexIntoCallNodeTable,
-    IndexIntoFuncTable[]
-  ) => void,
+  changeSelectedCallNode: (IndexIntoCallNodeTable, CallNodePath) => void,
 };
 
 class ProfileThreadHeaderBar extends PureComponent {

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -21,6 +21,7 @@ import type {
 import type {
   CallNodeInfo,
   CallNodeTable,
+  CallNodePath,
   IndexIntoCallNodeTable,
   TracingMarker,
 } from '../types/profile-derived';
@@ -501,7 +502,7 @@ export function filterThreadToSearchString(
  */
 export function filterThreadToPrefixCallNodePath(
   thread: Thread,
-  prefixCallNodePath: IndexIntoFuncTable[],
+  prefixCallNodePath: CallNodePath,
   implementation: ImplementationFilter
 ): Thread {
   return timeCode('filterThreadToPrefixCallNodePath', () => {
@@ -575,7 +576,7 @@ export function filterThreadToPrefixCallNodePath(
  */
 export function mergeCallNode(
   thread: Thread,
-  prefixCallNodePath: IndexIntoFuncTable[],
+  prefixCallNodePath: CallNodePath,
   implementation: ImplementationFilter
 ): Thread {
   return timeCode('mergeCallNode', () => {
@@ -678,7 +679,7 @@ export function mergeCallNode(
  */
 export function mergeInvertedCallNode(
   thread: Thread,
-  postfixCallNodePath: IndexIntoFuncTable[],
+  postfixCallNodePath: CallNodePath,
   implementation: ImplementationFilter
 ): Thread {
   return timeCode('mergeCallNode', () => {
@@ -805,7 +806,7 @@ const FUNC_MATCHES = {
  */
 export function filterThreadToPostfixCallNodePath(
   thread: Thread,
-  postfixCallNodePath: IndexIntoFuncTable[],
+  postfixCallNodePath: CallNodePath,
   implementation: ImplementationFilter
 ): Thread {
   return timeCode('filterThreadToPostfixCallNodePath', () => {
@@ -923,7 +924,7 @@ export function filterThreadToRange(
 }
 
 export function getCallNodeFromPath(
-  callNodePath: IndexIntoFuncTable[],
+  callNodePath: CallNodePath,
   callNodeTable: CallNodeTable
 ): IndexIntoCallNodeTable | null {
   let fs = -1;
@@ -954,7 +955,7 @@ export function getCallNodeFromPath(
 export function getCallNodePath(
   callNodeIndex: IndexIntoCallNodeTable | null,
   callNodeTable: CallNodeTable
-): IndexIntoFuncTable[] {
+): CallNodePath {
   if (callNodeIndex === null) {
     return [];
   }

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -23,7 +23,6 @@ import type {
   Profile,
   Thread,
   ThreadIndex,
-  IndexIntoFuncTable,
   SamplesTable,
   TaskTracer,
   MarkersTable,
@@ -31,6 +30,7 @@ import type {
 import type {
   TracingMarker,
   CallNodeInfo,
+  CallNodePath,
   IndexIntoCallNodeTable,
   MarkerTimingRows,
 } from '../types/profile-derived';
@@ -96,9 +96,9 @@ function profile(
 }
 
 function callNodePathAfterNewTransform(
-  callNodePath: IndexIntoFuncTable[],
+  callNodePath: CallNodePath,
   transform: Transform
-): IndexIntoFuncTable[] {
+): CallNodePath {
   if (!transform.inverted && transform.implementation !== 'js') {
     return removePrefixFromCallNodePath(transform.callNodePath, callNodePath);
   }
@@ -106,8 +106,8 @@ function callNodePathAfterNewTransform(
 }
 
 function removePrefixFromCallNodePath(
-  prefixFuncsPath: IndexIntoFuncTable[],
-  callNodePath: IndexIntoFuncTable[]
+  prefixFuncsPath: CallNodePath,
+  callNodePath: CallNodePath
 ) {
   if (
     prefixFuncsPath.length > callNodePath.length ||
@@ -391,7 +391,7 @@ export type SelectorsForThread = {
   getFilteredThread: State => Thread,
   getRangeSelectionFilteredThread: State => Thread,
   getCallNodeInfo: State => CallNodeInfo,
-  getSelectedCallNodePath: State => IndexIntoFuncTable[],
+  getSelectedCallNodePath: State => CallNodePath,
   getSelectedCallNodeIndex: State => IndexIntoCallNodeTable | null,
   getExpandedCallNodeIndexes: State => Array<IndexIntoCallNodeTable | null>,
   getCallTree: State => CallTree.CallTree,
@@ -548,7 +548,7 @@ export const selectorsForThread = (
     );
     const getSelectedCallNodePath = createSelector(
       getViewOptions,
-      (threadViewOptions): IndexIntoFuncTable[] =>
+      (threadViewOptions): CallNodePath =>
         threadViewOptions.selectedCallNodePath
     );
     const getSelectedCallNodeIndex = createSelector(
@@ -563,7 +563,7 @@ export const selectorsForThread = (
     );
     const _getExpandedCallNodePaths = createSelector(
       getViewOptions,
-      (threadViewOptions): Array<IndexIntoFuncTable[]> =>
+      (threadViewOptions): Array<CallNodePath> =>
         threadViewOptions.expandedCallNodePaths
     );
     const getExpandedCallNodeIndexes = createSelector(

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -10,6 +10,7 @@ import type {
   IndexIntoMarkersTable,
   IndexIntoFuncTable,
 } from './profile';
+import type { CallNodePath } from './profile-derived';
 import type { GetLabel } from '../profile-logic/labeling-strategies';
 import type { GetCategory } from '../profile-logic/color-categories';
 import type { TemporaryError } from '../utils/errors';
@@ -66,12 +67,12 @@ type ProfileAction =
   | {
       type: 'CHANGE_SELECTED_CALL_NODE',
       threadIndex: ThreadIndex,
-      selectedCallNodePath: IndexIntoFuncTable[],
+      selectedCallNodePath: CallNodePath,
     }
   | {
       type: 'CHANGE_EXPANDED_CALL_NODES',
       threadIndex: ThreadIndex,
-      expandedCallNodePaths: Array<IndexIntoFuncTable[]>,
+      expandedCallNodePaths: Array<CallNodePath>,
     }
   | {
       type: 'CHANGE_SELECTED_MARKER',

--- a/src/types/profile-derived.js
+++ b/src/types/profile-derived.js
@@ -5,7 +5,7 @@
 // @flow
 import type { Milliseconds } from './units';
 import type { MarkerPayload } from './markers';
-
+import type { IndexIntoFuncTable } from './profile';
 export type IndexIntoCallNodeTable = number;
 
 /**
@@ -49,6 +49,16 @@ export type CallNodeInfo = {
   // IndexIntoStackTable -> IndexIntoCallNodeTable
   stackIndexToCallNodeIndex: Uint32Array,
 };
+
+/**
+ * When working with call trees, individual nodes in the tree are not stable across
+ * different types of transformations and filtering operations. In order to refer
+ * to some place in the call tree we use a list of functions that either go from
+ * root to tip for normal call trees, or from tip to root for inverted call trees.
+ * These paths are then stored along with the implementation filter, and the whether
+ * or not the tree is inverted for a stable reference into a call tree.
+ */
+export type CallNodePath = IndexIntoFuncTable[];
 
 export type TracingMarker = {
   start: Milliseconds,

--- a/src/types/reducers.js
+++ b/src/types/reducers.js
@@ -13,12 +13,8 @@ import type {
   ImplementationFilter,
 } from './actions';
 import type { Milliseconds, StartEndRange } from './units';
-import type {
-  IndexIntoMarkersTable,
-  IndexIntoFuncTable,
-  Profile,
-  ThreadIndex,
-} from './profile';
+import type { IndexIntoMarkersTable, Profile, ThreadIndex } from './profile';
+import type { CallNodePath } from './profile-derived';
 import type { Attempt } from '../utils/errors';
 import type { GetLabel } from '../profile-logic/labeling-strategies';
 import type { GetCategory } from '../profile-logic/color-categories';
@@ -29,8 +25,8 @@ export type Reducer<T> = (T, Action) => T;
 export type RequestedLib = { debugName: string, breakpadId: string };
 export type SymbolicationStatus = 'DONE' | 'SYMBOLICATING';
 export type ThreadViewOptions = {
-  selectedCallNodePath: IndexIntoFuncTable[],
-  expandedCallNodePaths: Array<IndexIntoFuncTable[]>,
+  selectedCallNodePath: CallNodePath,
+  expandedCallNodePaths: Array<CallNodePath>,
   selectedMarker: IndexIntoMarkersTable | -1,
 };
 export type ProfileViewState = {

--- a/src/types/transforms.js
+++ b/src/types/transforms.js
@@ -8,7 +8,8 @@
  * that is used to transform the sample and stack information of a profile. They are
  * applied in a stack.
  */
-import type { ThreadIndex, IndexIntoFuncTable } from './profile';
+import type { ThreadIndex } from './profile';
+import type { CallNodePath } from './profile-derived';
 import type { ImplementationFilter } from './actions';
 
 /**
@@ -22,7 +23,7 @@ import type { ImplementationFilter } from './actions';
  * provide a stable reference to a call node for a given view into a call tree.
  */
 export type CallNodeReference = {
-  callNodePath: IndexIntoFuncTable[],
+  callNodePath: CallNodePath,
   implementation: ImplementationFilter,
   inverted: boolean,
 };


### PR DESCRIPTION
This makes our paths much more explicit. I held off from doing this in my earlier patches to reduce the blast radius. Pinging whoever gets to it first, I'm going to do follow up work off of this change.