### PR TITLE
Memoize transforms

### DIFF
--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -416,41 +416,42 @@ export const selectorsForThread = (
     );
     const getTransformStack = (state: State): TransformStack =>
       URLState.getTransformStack(state, threadIndex);
+
     const _getRangeAndTransformFilteredThread = createSelector(
       getRangeFilteredThread,
       getTransformStack,
-      (startingThread, transforms): Thread => {
-        const result = transforms.reduce((thread, transform) => {
-          switch (transform.type) {
-            case 'focus-subtree':
-              return transform.inverted
-                ? Transforms.focusInvertedSubtree(
-                    thread,
-                    transform.callNodePath,
-                    transform.implementation
-                  )
-                : Transforms.focusSubtree(
-                    thread,
-                    transform.callNodePath,
-                    transform.implementation
-                  );
-            case 'merge-subtree':
-              // TODO - Implement this transform.
-              return thread;
-            case 'merge-call-node':
-              return Transforms.mergeCallNode(
-                thread,
-                transform.callNodePath,
-                transform.implementation
-              );
-            case 'merge-function':
-              return Transforms.mergeFunction(thread, transform.funcIndex);
-            default:
-              throw new Error('Unhandled transform.');
-          }
-        }, startingThread);
-        return result;
-      }
+      Transforms.memoizeTransformedThread(
+        (startingThread, transforms): Thread =>
+          transforms.reduce((thread, transform) => {
+            switch (transform.type) {
+              case 'focus-subtree':
+                return transform.inverted
+                  ? Transforms.focusInvertedSubtree(
+                      thread,
+                      transform.callNodePath,
+                      transform.implementation
+                    )
+                  : Transforms.focusSubtree(
+                      thread,
+                      transform.callNodePath,
+                      transform.implementation
+                    );
+              case 'merge-subtree':
+                // TODO - Implement this transform.
+                return thread;
+              case 'merge-call-node':
+                return Transforms.mergeCallNode(
+                  thread,
+                  transform.callNodePath,
+                  transform.implementation
+                );
+              case 'merge-function':
+                return Transforms.mergeFunction(thread, transform.funcIndex);
+              default:
+                throw new Error('Unhandled transform.');
+            }
+          }, startingThread)
+      )
     );
     const _getImplementationFilteredThread = createSelector(
       _getRangeAndTransformFilteredThread,


### PR DESCRIPTION
@mstange This PR only memoizes the latest transform applied. This makes adding transforms to the stack fast, but popping them is still really bad. Should I do a follow-up where I memoize every step of the way? This would consume more memory but would guarantee that we don't spend a long time unnecessarily re-computing transforms.

I didn't write a test for this function, but it lights up the existing tests when it is wrong.