### PR TITLE
Add shared empty arrays to reducers to help with memoization

### DIFF
--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -47,12 +47,6 @@ import type {
 } from '../types/reducers';
 import type { TransformStack } from '../types/transforms';
 
-// Pre-allocate arrays to help with strict equality tests in memoized functions. Flow
-// will coerce these into types, so have one array per type.
-const EMPTY_THREAD_VIEW_OPTIONS = [];
-const EMPTY_CALL_NODE_PATH = [];
-const EMPTY_CALL_NODE_PATH_LIST = [];
-
 function profile(
   state: Profile = ProfileData.getEmptyProfile(),
   action: Action
@@ -116,18 +110,15 @@ function symbolicationStatus(
   }
 }
 
-function viewOptionsPerThread(
-  state: ThreadViewOptions[] = EMPTY_THREAD_VIEW_OPTIONS,
-  action: Action
-) {
+function viewOptionsPerThread(state: ThreadViewOptions[] = [], action: Action) {
   switch (action.type) {
     case 'RECEIVE_PROFILE_FROM_ADDON':
     case 'RECEIVE_PROFILE_FROM_STORE':
     case 'RECEIVE_PROFILE_FROM_URL':
     case 'RECEIVE_PROFILE_FROM_FILE':
       return action.profile.threads.map(() => ({
-        selectedCallNodePath: EMPTY_CALL_NODE_PATH,
-        expandedCallNodePaths: EMPTY_CALL_NODE_PATH_LIST,
+        selectedCallNodePath: [],
+        expandedCallNodePaths: [],
         selectedMarker: -1,
       }));
     case 'COALESCED_FUNCTIONS_UPDATE': {

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -47,6 +47,12 @@ import type {
 } from '../types/reducers';
 import type { TransformStack } from '../types/transforms';
 
+// Pre-allocate arrays to help with strict equality tests in memoized functions. Flow
+// will coerce these into types, so have one array per type.
+const EMPTY_THREAD_VIEW_OPTIONS = [];
+const EMPTY_CALL_NODE_PATH = [];
+const EMPTY_CALL_NODE_PATH_LIST = [];
+
 function profile(
   state: Profile = ProfileData.getEmptyProfile(),
   action: Action
@@ -110,15 +116,18 @@ function symbolicationStatus(
   }
 }
 
-function viewOptionsPerThread(state: ThreadViewOptions[] = [], action: Action) {
+function viewOptionsPerThread(
+  state: ThreadViewOptions[] = EMPTY_THREAD_VIEW_OPTIONS,
+  action: Action
+) {
   switch (action.type) {
     case 'RECEIVE_PROFILE_FROM_ADDON':
     case 'RECEIVE_PROFILE_FROM_STORE':
     case 'RECEIVE_PROFILE_FROM_URL':
     case 'RECEIVE_PROFILE_FROM_FILE':
       return action.profile.threads.map(() => ({
-        selectedCallNodePath: [],
-        expandedCallNodePaths: [],
+        selectedCallNodePath: EMPTY_CALL_NODE_PATH,
+        expandedCallNodePaths: EMPTY_CALL_NODE_PATH_LIST,
         selectedMarker: -1,
       }));
     case 'COALESCED_FUNCTIONS_UPDATE': {

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -22,6 +22,12 @@ import type {
 } from '../types/actions';
 import type { State, URLState, Reducer } from '../types/reducers';
 
+// Pre-allocate arrays to help with strict equality tests in memoized functions. Flow
+// will coerce these into types, so have one array per type.
+const EMPTY_TRANSFORM_STACK = [];
+const EMPTY_THREAD_LIST = [];
+const EMPTY_START_END_RANGES = [];
+
 function dataSource(state: DataSource = 'none', action: Action) {
   switch (action.type) {
     case 'WAITING_FOR_PROFILE_FROM_FILE':
@@ -58,7 +64,10 @@ function selectedTab(state: string = 'calltree', action: Action) {
   }
 }
 
-function rangeFilters(state: StartEndRange[] = [], action: Action) {
+function rangeFilters(
+  state: StartEndRange[] = EMPTY_START_END_RANGES,
+  action: Action
+) {
   switch (action.type) {
     case 'ADD_RANGE_FILTER': {
       const { start, end } = action;
@@ -142,14 +151,14 @@ function transforms(state: TransformStacksPerThread = {}, action: Action) {
   switch (action.type) {
     case 'ADD_TRANSFORM_TO_STACK': {
       const { threadIndex, transform } = action;
-      const transforms = state[threadIndex] || [];
+      const transforms = state[threadIndex] || EMPTY_TRANSFORM_STACK;
       return Object.assign({}, state, {
         [threadIndex]: [...transforms, transform],
       });
     }
     case 'POP_TRANSFORMS_FROM_STACK': {
       const { threadIndex, firstRemovedFilterIndex } = action;
-      const transforms = state[threadIndex] || [];
+      const transforms = state[threadIndex] || EMPTY_TRANSFORM_STACK;
       return Object.assign({}, state, {
         [threadIndex]: transforms.slice(0, firstRemovedFilterIndex),
       });
@@ -193,7 +202,7 @@ function hidePlatformDetails(state: boolean = false, action: Action) {
   }
 }
 
-function threadOrder(state: ThreadIndex[] = [], action: Action) {
+function threadOrder(state: ThreadIndex[] = EMPTY_THREAD_LIST, action: Action) {
   switch (action.type) {
     case 'RECEIVE_PROFILE_FROM_ADDON':
     case 'RECEIVE_PROFILE_FROM_STORE':
@@ -213,7 +222,10 @@ function threadOrder(state: ThreadIndex[] = [], action: Action) {
   }
 }
 
-function hiddenThreads(state: ThreadIndex[] = [], action: Action) {
+function hiddenThreads(
+  state: ThreadIndex[] = EMPTY_THREAD_LIST,
+  action: Action
+) {
   switch (action.type) {
     case 'RECEIVE_PROFILE_FROM_ADDON':
     case 'RECEIVE_PROFILE_FROM_STORE':
@@ -292,7 +304,7 @@ export const getTransformStack = (
   state: State,
   threadIndex: ThreadIndex
 ): TransformStack => {
-  return getURLState(state).transforms[threadIndex] || [];
+  return getURLState(state).transforms[threadIndex] || EMPTY_TRANSFORM_STACK;
 };
 export const getThreadOrder = (state: State) => getURLState(state).threadOrder;
 export const getHiddenThreads = (state: State) =>

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -22,11 +22,8 @@ import type {
 } from '../types/actions';
 import type { State, URLState, Reducer } from '../types/reducers';
 
-// Pre-allocate arrays to help with strict equality tests in memoized functions. Flow
-// will coerce these into types, so have one array per type.
+// Pre-allocate an array to help with strict equality tests in the selectors.
 const EMPTY_TRANSFORM_STACK = [];
-const EMPTY_THREAD_LIST = [];
-const EMPTY_START_END_RANGES = [];
 
 function dataSource(state: DataSource = 'none', action: Action) {
   switch (action.type) {
@@ -64,10 +61,7 @@ function selectedTab(state: string = 'calltree', action: Action) {
   }
 }
 
-function rangeFilters(
-  state: StartEndRange[] = EMPTY_START_END_RANGES,
-  action: Action
-) {
+function rangeFilters(state: StartEndRange[] = [], action: Action) {
   switch (action.type) {
     case 'ADD_RANGE_FILTER': {
       const { start, end } = action;
@@ -151,14 +145,14 @@ function transforms(state: TransformStacksPerThread = {}, action: Action) {
   switch (action.type) {
     case 'ADD_TRANSFORM_TO_STACK': {
       const { threadIndex, transform } = action;
-      const transforms = state[threadIndex] || EMPTY_TRANSFORM_STACK;
+      const transforms = state[threadIndex] || [];
       return Object.assign({}, state, {
         [threadIndex]: [...transforms, transform],
       });
     }
     case 'POP_TRANSFORMS_FROM_STACK': {
       const { threadIndex, firstRemovedFilterIndex } = action;
-      const transforms = state[threadIndex] || EMPTY_TRANSFORM_STACK;
+      const transforms = state[threadIndex] || [];
       return Object.assign({}, state, {
         [threadIndex]: transforms.slice(0, firstRemovedFilterIndex),
       });
@@ -202,7 +196,7 @@ function hidePlatformDetails(state: boolean = false, action: Action) {
   }
 }
 
-function threadOrder(state: ThreadIndex[] = EMPTY_THREAD_LIST, action: Action) {
+function threadOrder(state: ThreadIndex[] = [], action: Action) {
   switch (action.type) {
     case 'RECEIVE_PROFILE_FROM_ADDON':
     case 'RECEIVE_PROFILE_FROM_STORE':
@@ -222,10 +216,7 @@ function threadOrder(state: ThreadIndex[] = EMPTY_THREAD_LIST, action: Action) {
   }
 }
 
-function hiddenThreads(
-  state: ThreadIndex[] = EMPTY_THREAD_LIST,
-  action: Action
-) {
+function hiddenThreads(state: ThreadIndex[] = [], action: Action) {
   switch (action.type) {
     case 'RECEIVE_PROFILE_FROM_ADDON':
     case 'RECEIVE_PROFILE_FROM_STORE':


### PR DESCRIPTION
I noticed that the selectors were sometime re-running when they shouldn't. This was due to creating blank arrays on the fly, so strict equality checking does not work. I changed up all the reducers to only use pre-allocated blank arrays. There were places I didn't strictly need to do it for correct memoization, but doing it everywhere made it easy to mechanically check the reducers so that we won't have issues.