### PR TITLE
Fix clicking on thread

### DIFF
--- a/src/components/header/ProfileThreadHeaderBar.js
+++ b/src/components/header/ProfileThreadHeaderBar.js
@@ -55,6 +55,7 @@ class ProfileThreadHeaderBar extends PureComponent {
     super(props);
     (this: any)._onLabelMouseDown = this._onLabelMouseDown.bind(this);
     (this: any)._onGraphClick = this._onGraphClick.bind(this);
+    (this: any)._onLineClick = this._onLineClick.bind(this);
     (this: any)._onMarkerSelect = this._onMarkerSelect.bind(this);
     (this: any)._onIntervalMarkerSelect = this._onIntervalMarkerSelect.bind(
       this
@@ -71,9 +72,13 @@ class ProfileThreadHeaderBar extends PureComponent {
     }
   }
 
-  _onGraphClick(time: number) {
+  _onLineClick() {
     const { threadIndex, changeSelectedThread } = this.props;
     changeSelectedThread(threadIndex);
+  }
+
+  _onGraphClick(time: number) {
+    const { threadIndex } = this.props;
     if (time !== undefined) {
       const { thread, callNodeInfo, changeSelectedCallNode } = this.props;
       const sampleIndex = getSampleIndexClosestToTime(thread.samples, time);
@@ -146,6 +151,7 @@ class ProfileThreadHeaderBar extends PureComponent {
     return (
       <li
         className={'profileThreadHeaderBar' + (isSelected ? ' selected' : '')}
+        onClick={this._onLineClick}
         style={style}
       >
         <ContextMenuTrigger

--- a/src/test/components/__snapshots__/ProfileViewerHeader.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileViewerHeader.test.js.snap
@@ -98,6 +98,7 @@ exports[`calltree/ProfileViewerHeader renders the header 1`] = `
         >
           <li
             className="profileThreadHeaderBar selected"
+            onClick={[Function]}
             style={undefined}
           >
             <div


### PR DESCRIPTION
After #514 the click behavior on the header is awkward: clicking on the
"marker" and "jank" parts on a line won't select the thread.

This patch fixes this by handling the click on the whole line.