### PR TITLE
Collapse recursion of a function

### DIFF
--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -513,6 +513,12 @@ export const selectorsForThread = (
             transform.resourceIndex,
             transform.implementation
           );
+        case 'collapse-direct-recursion':
+          return Transforms.collapseDirectRecursion(
+            thread,
+            transform.funcIndex,
+            transform.implementation
+          );
         default:
           throw new Error('Unhandled transform.');
       }

--- a/src/test/store/__snapshots__/transforms.test.js.snap
+++ b/src/test/store/__snapshots__/transforms.test.js.snap
@@ -1,5 +1,50 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`"collapse-direct-recursion" transform combined implementation can collapse the B function 1`] = `
+"
+- A (total: 4, self:—)
+ - B (total: 3, self:—)
+   - C (total: 1, self:1)
+   - D (total: 1, self:1)
+   - E (total: 1, self:1)
+ - F (total: 1, self:1)"
+`;
+
+exports[`"collapse-direct-recursion" transform combined implementation starts as an unfiltered call tree 1`] = `
+"
+- A (total: 4, self:—)
+ - B (total: 3, self:—)
+   - B (total: 2, self:—)
+     - B (total: 1, self:—)
+       - C (total: 1, self:1)
+     - D (total: 1, self:1)
+   - E (total: 1, self:1)
+ - F (total: 1, self:1)"
+`;
+
+exports[`"collapse-direct-recursion" transform filtered implementation can collapse the B function 1`] = `
+"
+- A.js (total: 5, self:—)
+ - B.js (total: 4, self:1)
+   - D.js (total: 1, self:1)
+   - E.js (total: 1, self:1)
+   - F.js (total: 1, self:1)
+ - G.js (total: 1, self:1)"
+`;
+
+exports[`"collapse-direct-recursion" transform filtered implementation starts as an unfiltered call tree 1`] = `
+"
+- A.js (total: 5, self:—)
+ - B.js (total: 4, self:—)
+   - B.js (total: 3, self:—)
+     - C.cpp (total: 3, self:1)
+       - B.js (total: 1, self:—)
+         - D.js (total: 1, self:1)
+       - E.js (total: 1, self:1)
+   - F.js (total: 1, self:1)
+ - G.js (total: 1, self:1)"
+`;
+
 exports[`"collapse-resource" transform combined implementation can collapse the "firefox" library 1`] = `
 "
 - A (total: 2, self:—)

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -206,7 +206,7 @@ describe('url upgrading', function() {
 
 describe('URL serialization of the transform stack', function() {
   const transformString =
-    'f-combined-012~ms-js-123~mcn-combined-234~f-js-345-i~mf-6~ff-7~cr-combined-8-9';
+    'f-combined-012~ms-js-123~mcn-combined-234~f-js-345-i~mf-6~ff-7~cr-combined-8-9~rec-combined-10';
   const { getState } = _getStoreWithURL({
     search: '?v=1&transforms=' + transformString,
   });
@@ -253,6 +253,11 @@ describe('URL serialization of the transform stack', function() {
         type: 'collapse-resource',
         resourceIndex: 8,
         collapsedFuncIndex: 9,
+        implementation: 'combined',
+      },
+      {
+        type: 'collapse-direct-recursion',
+        funcIndex: 10,
         implementation: 'combined',
       },
     ]);

--- a/src/types/transforms.js
+++ b/src/types/transforms.js
@@ -212,6 +212,28 @@ export type CollapseResource = {|
 |};
 
 /**
+ * Collapse direct recursion takes a function that calls itself recursively and collapses
+ * it into a single stack.
+ *
+ *      A                                 A
+ *      ↓    Collapse direct recursion    ↓
+ *      B          function B             B
+ *      ↓              ->                 ↓
+ *      B                                 C
+ *      ↓
+ *      B
+ *      ↓
+ *      B
+ *      ↓
+ *      C
+ */
+export type CollapseDirectRecursion = {|
+  type: 'collapse-direct-recursion',
+  funcIndex: IndexIntoFuncTable,
+  implementation: ImplementationFilter,
+|};
+
+/**
  * TODO - Once implemented.
  */
 export type MergeSubtree = {|
@@ -227,7 +249,8 @@ export type Transform =
   | MergeSubtree
   | MergeCallNode
   | MergeFunction
-  | CollapseResource;
+  | CollapseResource
+  | CollapseDirectRecursion;
 
 export type TransformStack = Transform[];
 export type TransformStacksPerThread = { [id: ThreadIndex]: TransformStack };


### PR DESCRIPTION
This includes work from other patches. Please look at only the last commit "Collapse recursion transform".