### PR TITLE
Fix url upgrading

### DIFF
--- a/flow-typed/npm/jest_v20.x.x.js
+++ b/flow-typed/npm/jest_v20.x.x.js
@@ -214,7 +214,7 @@ type JestExpectType = {
   /**
    * Use .toMatch to check that a string matches a regular expression.
    */
-  toMatch(regexp: RegExp): void,
+  toMatch(regexp: RegExp | string): void,
   /**
    * Use .toMatchObject to check that a javascript object matches a subset of the properties of an object.
    */

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -184,18 +184,23 @@ describe('url upgrading', function() {
     });
   });
 
-  describe('general checks', function() {
-    it("won't run if the version is specified", function() {
-      const { getState } = _getStoreWithURL({
-        pathname: '/public/e71ce9584da34298627fb66ac7f2f245ba5edbf5/markers/',
-        search: `?v=${CURRENT_URL_VERSION}`,
-      });
-
-      // The conversion process shouldn't run
-      expect(urlStateReducers.getSelectedTab(getState())).not.toBe(
-        'markers-table'
-      );
+  // More general checks
+  it("won't run if the version is specified", function() {
+    const { getState } = _getStoreWithURL({
+      pathname: '/public/e71ce9584da34298627fb66ac7f2f245ba5edbf5/markers/',
+      search: `?v=${CURRENT_URL_VERSION}`,
     });
+
+    // The conversion process shouldn't run.
+    // This is somewhat hacky: because we specified the last version, we expect
+    // the v2 converter to not run, and so the selected tab shouldn't be
+    // 'marker-table'. Note also that a 'markers' tab is invalid for the current
+    // state of the application, so we won't have 'markers' as result.
+    // We should change this to something more meaningful when we have eg
+    // converters that reuse query names.
+    expect(urlStateReducers.getSelectedTab(getState())).not.toBe(
+      'marker-table'
+    );
   });
 });
 

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -7,7 +7,12 @@
  * @jest-environment jsdom
  */
 import * as urlStateReducers from '../reducers/url-state';
-import { stateFromLocation, urlStateToUrlObject } from '../url-handling';
+import {
+  stateFromLocation,
+  urlStateToUrlObject,
+  urlFromState,
+  CURRENT_URL_VERSION,
+} from '../url-handling';
 import { blankStore } from './fixtures/stores';
 import getGeckoProfile from './fixtures/profiles/gecko-profile';
 import { processProfile } from '../profile-logic/process-profile';
@@ -178,6 +183,20 @@ describe('url upgrading', function() {
       expect(urlStateReducers.getSelectedTab(getState())).toBe('marker-table');
     });
   });
+
+  describe('general checks', function() {
+    it("won't run if the version is specified", function() {
+      const { getState } = _getStoreWithURL({
+        pathname: '/public/e71ce9584da34298627fb66ac7f2f245ba5edbf5/markers/',
+        search: `?v=${CURRENT_URL_VERSION}`,
+      });
+
+      // The conversion process shouldn't run
+      expect(urlStateReducers.getSelectedTab(getState())).not.toBe(
+        'markers-table'
+      );
+    });
+  });
 });
 
 describe('URL serialization of the transform stack', function() {
@@ -239,5 +258,16 @@ describe('URL serialization of the transform stack', function() {
       urlStateReducers.getUrlState(getState())
     );
     expect(query.transforms).toBe(transformString);
+  });
+});
+
+describe('urlFromState', function() {
+  it('outputs the current URL version', function() {
+    const urlState = stateFromLocation({
+      pathname: '/public/1ecd7a421948995171a4bb483b7bcc8e1868cc57/calltree/',
+      search: '',
+      hash: '',
+    });
+    expect(urlFromState(urlState)).toMatch(`v=${CURRENT_URL_VERSION}`);
   });
 });

--- a/src/url-handling.js
+++ b/src/url-handling.js
@@ -16,6 +16,8 @@ import { unexpectedCase } from './utils/flow';
 import type { UrlState } from './types/reducers';
 import type { DataSource, TabSlug } from './types/actions';
 
+export const CURRENT_URL_VERSION = 2;
+
 function dataSourceDirs(urlState: UrlState) {
   const { dataSource } = urlState;
   switch (dataSource) {
@@ -88,6 +90,7 @@ export function urlStateToUrlObject(urlState: UrlState): UrlObject {
     thread: `${urlState.selectedThread}`,
     threadOrder: urlState.threadOrder.join('-'),
     hiddenThreads: urlState.hiddenThreads.join('-'),
+    v: CURRENT_URL_VERSION,
   };
 
   if (process.env.NODE_ENV === 'development') {
@@ -242,14 +245,12 @@ function toValidTabSlug(slug: ?string): TabSlug {
   }
 }
 
-export const CURRENT_URL_VERSION = 2;
-
 type ProcessedLocation = { pathname: string, hash: string, query: Object };
 
 export function upgradeLocationToCurrentVersion(
   processedLocation: ProcessedLocation
 ): ProcessedLocation {
-  const urlVersion = processedLocation.query.v || 0;
+  const urlVersion = +processedLocation.query.v || 0;
   if (urlVersion === CURRENT_URL_VERSION) {
     return processedLocation;
   }


### PR DESCRIPTION
I realized this wasn't working for the following use cases:
* reloading the page after the upgrade has been done
* and generally the version wasn't properly compared so it always ran the upgrade -- which wasn't an issue with the current upgrades but is with an upcoming patch I'm working on.