### PR TITLE
Add lazy_capacity property to GCMinor markers

### DIFF
--- a/src/components/shared/MarkerTooltipContents.js
+++ b/src/components/shared/MarkerTooltipContents.js
@@ -86,6 +86,13 @@ function getMarkerDetails(data: MarkerPayload): React.Element<any> | null {
                     nursery.new_capacity,
                     formatBytes
                   )}
+                  {nursery.lazy_capacity &&
+                    _markerDetail(
+                      'gclazynurserysize',
+                      'Lazy-allocated size',
+                      nursery.lazy_capacity,
+                      formatBytes
+                    )}
                 </div>
               );
             }

--- a/src/test/components/MarkerTooltipContents.test.js
+++ b/src/test/components/MarkerTooltipContents.test.js
@@ -62,6 +62,7 @@ describe('MarkerTooltipContents', function() {
             bytes_tenured: 4 * 1024 * 1024,
             bytes_used: 8 * 1024 * 1024,
             new_capacity: 16 * 1024 * 1024,
+            lazy_capacity: 12 * 1024 * 1024,
             phase_times: {},
           },
         },

--- a/src/test/components/__snapshots__/MarkerTooltipContents.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerTooltipContents.test.js.snap
@@ -294,6 +294,13 @@ exports[`MarkerTooltipContents renders tooltips for various markers 5`] = `
       :
     </div>
     16MB
+    <div
+      className="tooltipLabel"
+    >
+      Lazy-allocated size
+      :
+    </div>
+    12MB
   </div>
 </div>
 `;

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -188,6 +188,12 @@ export type GCMinorCompletedData = {
   cur_capacity?: number,
   new_capacity: number,
 
+  // The nursery may be dynamically resized (since version 58)
+  // this field is the lazy-allocated size.  It is not present in older
+  // versions.
+  // In the future it may be omitted if it matches cur_capacity.
+  lazy_capacity?: number,
+
   phase_times: PhaseTimes,
 };
 


### PR DESCRIPTION
Recently I added the lazy_capacity property to SpiderMonkey.  This change adds it to perf.html.