### PR TITLE
React.PropTypes to prop-types module

### DIFF
--- a/src/components/app/Initializing.js
+++ b/src/components/app/Initializing.js
@@ -3,7 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 type Props = {

--- a/src/components/app/ProfileViewer.js
+++ b/src/components/app/ProfileViewer.js
@@ -4,7 +4,8 @@
 
 // @flow
 
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import TabBar from './TabBar';
 import classNames from 'classnames';

--- a/src/components/app/TabBar.js
+++ b/src/components/app/TabBar.js
@@ -4,7 +4,8 @@
 
 // @flow
 
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Reorderable from '../shared/Reorderable';
 

--- a/src/components/app/UrlManager.js
+++ b/src/components/app/UrlManager.js
@@ -4,7 +4,8 @@
 
 // @flow
 
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { getIsUrlSetupDone } from '../../reducers/app';
 

--- a/src/components/calltree/FilterNavigatorBar.js
+++ b/src/components/calltree/FilterNavigatorBar.js
@@ -4,7 +4,8 @@
 
 // @flow
 
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import './FilterNavigatorBar.css';

--- a/src/components/calltree/NodeIcon.js
+++ b/src/components/calltree/NodeIcon.js
@@ -4,7 +4,8 @@
 
 // @flow
 
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import { getIconClassNameForNode } from '../../reducers/icons';

--- a/src/components/header/SelectionScrubberOverlay.js
+++ b/src/components/header/SelectionScrubberOverlay.js
@@ -4,7 +4,8 @@
 
 // @flow
 
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import clamp from 'clamp';
 import Draggable from '../shared/Draggable';

--- a/src/components/header/ThreadStackGraph.js
+++ b/src/components/header/ThreadStackGraph.js
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { timeCode } from '../../utils/time-code';
 import { getSampleCallNodes } from '../../profile-logic/profile-data';

--- a/src/components/header/TimeRuler.js
+++ b/src/components/header/TimeRuler.js
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 
 class TimeRuler extends PureComponent {
   _findNiceNumberGreaterOrEqualTo(uglyNumber) {

--- a/src/components/header/TimeSelectionScrubber.js
+++ b/src/components/header/TimeSelectionScrubber.js
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import TimeRuler from './TimeRuler';
 import SelectionScrubberOverlay from './SelectionScrubberOverlay';
 import clamp from 'clamp';

--- a/src/components/marker-table/index.js
+++ b/src/components/marker-table/index.js
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import TreeView from '../shared/TreeView';
 import {

--- a/src/components/shared/IdleSearchField.js
+++ b/src/components/shared/IdleSearchField.js
@@ -3,7 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import './IdleSearchField.css';

--- a/src/components/shared/StyleDef.js
+++ b/src/components/shared/StyleDef.js
@@ -11,7 +11,8 @@
 // needed with some simple logic than having a complex code to detect
 // duplication.
 
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 
 export class StyleDef extends PureComponent {
   componentDidMount() {

--- a/src/components/shared/VirtualList.js
+++ b/src/components/shared/VirtualList.js
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import range from 'array-range';
 

--- a/src/components/stack-chart/Settings.js
+++ b/src/components/stack-chart/Settings.js
@@ -4,7 +4,8 @@
 
 // @flow
 
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import actions from '../../actions';
 import {

--- a/src/components/summary/ProfileSummaryView.js
+++ b/src/components/summary/ProfileSummaryView.js
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { getProfile } from '../../reducers/profile-view';
 import {

--- a/src/components/summary/SummarizeLineGraph.js
+++ b/src/components/summary/SummarizeLineGraph.js
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 
 const HEIGHT = 30;
 const STROKE = 3;

--- a/src/components/summary/SummarizeProfileExpand.js
+++ b/src/components/summary/SummarizeProfileExpand.js
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import SummarizeLineGraph from './SummarizeLineGraph';
 
 class SummarizeProfileExpand extends PureComponent {

--- a/src/components/summary/SummarizeProfileHeader.js
+++ b/src/components/summary/SummarizeProfileHeader.js
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 
 const LINE_GRAPH_TITLE =
   'The line graph represents the number of samples that were in ' +

--- a/src/components/summary/SummarizeProfileThread.js
+++ b/src/components/summary/SummarizeProfileThread.js
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import SummarizeLineGraph from './SummarizeLineGraph';
 
 class SummarizeProfileThread extends PureComponent {

--- a/src/components/tasktracer/ProfileTaskTracerView.js
+++ b/src/components/tasktracer/ProfileTaskTracerView.js
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import actions from '../../actions';
 import {


### PR DESCRIPTION
This addresses issue #627.

Please note that the following warning is displayed when running tests:

```
Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs
```

This happens because we use:

```
import * as React from 'react';
```

This triggers all the getters in the react module and displays the warnings. Because we are no longer using e.g. React.PropTypes or React.DOM these warnings can be safely ignored.