### PR TITLE
Display cause stacks in tooltips.

### DIFF
--- a/src/components/header/IntervalMarkerOverview.js
+++ b/src/components/header/IntervalMarkerOverview.js
@@ -3,15 +3,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import React, { PureComponent } from 'react';
+import * as React from 'react';
 import classNames from 'classnames';
 import { timeCode } from '../../utils/time-code';
 import { withSize } from '../shared/WithSize';
 import Tooltip from '../shared/Tooltip';
-import MarkerTooltipContents from '../shared/MarkerTooltipContents';
 
 import type { Milliseconds, CssPixels } from '../../types/units';
 import type { TracingMarker } from '../../types/profile-derived';
+import type { ThreadIndex } from '../../types/profile';
 
 type MarkerState = 'PRESSED' | 'HOVERED' | 'NONE';
 
@@ -21,8 +21,8 @@ type Props = {
   rangeEnd: Milliseconds,
   intervalMarkers: TracingMarker[],
   width: number,
-  threadIndex: number,
-  threadName: string,
+  getTooltipContents: TracingMarker => React.Node,
+  threadIndex: ThreadIndex,
   onSelect: any,
   styles: any,
   isSelected: boolean,
@@ -40,7 +40,7 @@ type State = {
   mouseY: CssPixels,
 };
 
-class IntervalMarkerOverview extends PureComponent<Props, State> {
+class IntervalMarkerOverview extends React.PureComponent<Props, State> {
   _canvas: HTMLCanvasElement | null;
   _requestedAnimationFrame: boolean | null;
 
@@ -173,7 +173,7 @@ class IntervalMarkerOverview extends PureComponent<Props, State> {
       className,
       isSelected,
       isModifyingSelection,
-      threadName,
+      getTooltipContents,
     } = this.props;
 
     const { mouseDownItem, hoveredItem, mouseX, mouseY } = this.state;
@@ -198,10 +198,7 @@ class IntervalMarkerOverview extends PureComponent<Props, State> {
         />
         {shouldShowTooltip && hoveredItem
           ? <Tooltip mouseX={mouseX} mouseY={mouseY}>
-              <MarkerTooltipContents
-                marker={hoveredItem}
-                threadName={threadName}
-              />
+              {getTooltipContents(hoveredItem)}
             </Tooltip>
           : null}
       </div>

--- a/src/components/header/ProfileThreadJankOverview.js
+++ b/src/components/header/ProfileThreadJankOverview.js
@@ -4,24 +4,43 @@
 
 // @flow
 
+import React from 'react';
 import { connect } from 'react-redux';
 import IntervalMarkerOverview from './IntervalMarkerOverview';
+import MarkerTooltipContents from '../shared/MarkerTooltipContents';
 import { selectorsForThread } from '../../reducers/profile-view';
 import {
   styles,
   overlayFills,
 } from '../../profile-logic/interval-marker-styles';
-import { getSelectedThreadIndex } from '../../reducers/url-state';
+import {
+  getSelectedThreadIndex,
+  getImplementationFilter,
+} from '../../reducers/url-state';
 
 export default connect((state, props) => {
   const { threadIndex } = props;
   const selectors = selectorsForThread(threadIndex);
   const threadName = selectors.getFriendlyThreadName(state);
+  const thread = selectors.getThread(state);
   const selectedThread = getSelectedThreadIndex(state);
+  const implementationFilter = getImplementationFilter(state);
+  const getTooltipContents = item => {
+    return (
+      <MarkerTooltipContents
+        marker={item}
+        threadName={threadName}
+        thread={thread}
+        implementationFilter={implementationFilter}
+      />
+    );
+  };
+
   return {
     intervalMarkers: selectors.getJankInstances(state),
     isSelected: threadIndex === selectedThread,
-    threadName,
+    getTooltipContents,
+    threadIndex,
     styles,
     overlayFills,
   };

--- a/src/components/header/ProfileThreadTracingMarkerOverview.js
+++ b/src/components/header/ProfileThreadTracingMarkerOverview.js
@@ -4,26 +4,45 @@
 
 // @flow
 
+import React from 'react';
 import { connect } from 'react-redux';
 import IntervalMarkerOverview from './IntervalMarkerOverview';
+import MarkerTooltipContents from '../shared/MarkerTooltipContents';
 import { selectorsForThread } from '../../reducers/profile-view';
 import {
   styles,
   overlayFills,
 } from '../../profile-logic/interval-marker-styles';
-import { getSelectedThreadIndex } from '../../reducers/url-state';
+import {
+  getSelectedThreadIndex,
+  getImplementationFilter,
+} from '../../reducers/url-state';
 
 export default connect((state, props) => {
   const { threadIndex } = props;
   const selectors = selectorsForThread(threadIndex);
   const selectedThread = getSelectedThreadIndex(state);
+  const threadName = selectors.getFriendlyThreadName(state);
+  const thread = selectors.getThread(state);
+  const implementationFilter = getImplementationFilter(state);
   const intervalMarkers = selectors.getRangeSelectionFilteredTracingMarkersForHeader(
     state
   );
+  const getTooltipContents = item => {
+    return (
+      <MarkerTooltipContents
+        marker={item}
+        threadName={threadName}
+        thread={thread}
+        implementationFilter={implementationFilter}
+      />
+    );
+  };
   return {
     intervalMarkers,
-    threadName: selectors.getFriendlyThreadName(state),
+    getTooltipContents,
     isSelected: threadIndex === selectedThread,
+    threadIndex,
     styles,
     overlayFills,
   };

--- a/src/components/marker-chart/Canvas.js
+++ b/src/components/marker-chart/Canvas.js
@@ -6,7 +6,6 @@
 import * as React from 'react';
 import withChartViewport from '../shared/chart/Viewport';
 import ChartCanvas from '../shared/chart/Canvas';
-import MarkerTooltipContents from '../shared/MarkerTooltipContents';
 import TextMeasurement from '../../utils/text-measurement';
 import { BLUE_40 } from '../../utils/colors';
 
@@ -43,6 +42,7 @@ type Props = {
   markerTimingRows: MarkerTimingRows,
   rowHeight: CssPixels,
   markers: TracingMarker[],
+  getTooltipContents: TracingMarker => React.Node,
   updateProfileSelection: ProfileSelection => Action,
   isDragging: boolean,
 };
@@ -349,13 +349,9 @@ class MarkerChartCanvas extends React.PureComponent<Props, State> {
     ctx.fillRect(x + c, bottom - c, width - 2 * c, c);
   }
 
-  /**
-   * This function currently returns `React.Element<any>` because we exactly
-   * know its return type. This needs to be a subtype of React.Node so this
-   * could be changed in the future if necessary. */
-  getHoveredMarkerInfo(hoveredItem: IndexIntoMarkerTiming): React.Element<any> {
+  getHoveredMarkerInfo(hoveredItem: IndexIntoMarkerTiming): React.Node {
     const marker = this.props.markers[hoveredItem];
-    return <MarkerTooltipContents marker={marker} />;
+    return this.props.getTooltipContents(marker);
   }
 
   render() {

--- a/src/components/marker-chart/index.js
+++ b/src/components/marker-chart/index.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import MarkerChartCanvas from './Canvas';
+import MarkerTooltipContents from '../shared/MarkerTooltipContents';
 import {
   selectedThreadSelectors,
   getDisplayRange,
@@ -9,6 +10,7 @@ import {
   getProfileViewOptions,
 } from '../../reducers/profile-view';
 import { updateProfileSelection } from '../../actions/profile-view';
+import { getImplementationFilter } from '../../reducers/url-state';
 
 import type {
   TracingMarker,
@@ -34,6 +36,7 @@ type Props = {
   updateProfileSelection: typeof updateProfileSelection,
   selection: ProfileSelection,
   threadName: string,
+  getTooltipContents: TracingMarker => React.Node,
   processDetails: string,
   markerTimingRows: MarkerTimingRows,
   markers: TracingMarker[],
@@ -62,6 +65,7 @@ class MarkerChart extends React.PureComponent<Props> {
       selection,
       threadName,
       processDetails,
+      getTooltipContents,
     } = this.props;
 
     // The viewport needs to know about the height of what it's drawing, calculate
@@ -93,6 +97,7 @@ class MarkerChart extends React.PureComponent<Props> {
           markerTimingRows={markerTimingRows}
           maxMarkerRows={maxMarkerRows}
           markers={markers}
+          getTooltipContents={getTooltipContents}
           rowHeight={ROW_HEIGHT}
         />
       </div>
@@ -109,6 +114,19 @@ export default connect(
     const { threadIndex } = ownProps;
     const markers = selectedThreadSelectors.getTracingMarkers(state);
     const markerTimingRows = selectedThreadSelectors.getMarkerTiming(state);
+    const threadName = selectedThreadSelectors.getFriendlyThreadName(state);
+    const thread = selectedThreadSelectors.getThread(state);
+    const implementationFilter = getImplementationFilter(state);
+    const getTooltipContents = item => {
+      return (
+        <MarkerTooltipContents
+          marker={item}
+          threadName={threadName}
+          thread={thread}
+          implementationFilter={implementationFilter}
+        />
+      );
+    };
 
     return {
       markers,
@@ -116,9 +134,10 @@ export default connect(
       maxMarkerRows: markerTimingRows.length,
       timeRange: getDisplayRange(state),
       interval: getProfileInterval(state),
-      threadIndex,
       selection: getProfileViewOptions(state).selection,
-      threadName: selectedThreadSelectors.getFriendlyThreadName(state),
+      threadName,
+      threadIndex,
+      getTooltipContents,
       processDetails: selectedThreadSelectors.getThreadProcessDetails(state),
     };
   },

--- a/src/components/marker-table/index.js
+++ b/src/components/marker-table/index.js
@@ -38,9 +38,13 @@ class MarkerTree {
   }
 
   hasChildren(markerIndex) {
+    // If this marker has a cause callstack, indicate it with a tree disclosure
+    // arrow. However, we don't currently support expanding those marker nodes
+    // or displaying the cause callstacks, so this is not the greatest piece
+    // of UI.
     return (
       this._markers.data[markerIndex] !== null &&
-      'stack' in this._markers.data[markerIndex]
+      'cause' in this._markers.data[markerIndex]
     );
   }
 

--- a/src/components/shared/Backtrace.css
+++ b/src/components/shared/Backtrace.css
@@ -1,0 +1,23 @@
+.backtrace {
+  margin: 5px;
+  padding: 0;
+  max-height: 25em;
+  overflow: auto;
+}
+
+.backtraceStackFrame {
+  display: block;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-width: 30em;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.backtraceStackFrameOrigin {
+  color: rgba(0,0,0,0.4);
+  margin-left: 10px;
+  font-style: normal;
+}

--- a/src/components/shared/Backtrace.js
+++ b/src/components/shared/Backtrace.js
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import React from 'react';
+import { filterCallNodePathByImplementation } from '../../profile-logic/transforms';
+import { getOriginAnnotationForFunc } from '../../profile-logic/profile-data';
+
+import type { Thread, IndexIntoStackTable } from '../../types/profile';
+import type { CallNodePath } from '../../types/profile-derived';
+import type { CauseBacktrace } from '../../types/markers';
+import type { ImplementationFilter } from '../../types/actions';
+
+require('./Backtrace.css');
+
+type Props = {|
+  +thread: Thread,
+  +cause: CauseBacktrace,
+  +implementationFilter: ImplementationFilter,
+|};
+
+function callNodePathForStack(
+  thread: Thread,
+  stack: IndexIntoStackTable
+): CallNodePath {
+  const { stackTable, frameTable } = thread;
+  const path = [];
+  for (
+    let stackIndex = stack;
+    stackIndex !== null;
+    stackIndex = stackTable.prefix[stackIndex]
+  ) {
+    path.push(frameTable.func[stackTable.frame[stackIndex]]);
+  }
+  return path;
+}
+
+function Backtrace(props: Props) {
+  const { cause, thread, implementationFilter } = props;
+  const { funcTable, stringTable } = thread;
+  const callNodePath = filterCallNodePathByImplementation(
+    thread,
+    implementationFilter,
+    callNodePathForStack(thread, cause.stack)
+  );
+
+  return (
+    <ol className="backtrace">
+      {callNodePath.length > 0
+        ? callNodePath.map((func, i) => {
+            return (
+              <li key={i} className="backtraceStackFrame">
+                {stringTable.getString(funcTable.name[func])}
+                <em className="backtraceStackFrameOrigin">
+                  {getOriginAnnotationForFunc(
+                    func,
+                    thread.funcTable,
+                    thread.resourceTable,
+                    thread.stringTable
+                  )}
+                </em>
+              </li>
+            );
+          })
+        : <li className="backtraceStackFrame">
+            (stack empty or all stack frames filtered out)
+          </li>}
+    </ol>
+  );
+}
+
+export default Backtrace;

--- a/src/components/shared/MarkerTooltipContents.js
+++ b/src/components/shared/MarkerTooltipContents.js
@@ -12,10 +12,13 @@ import {
   formatBytes,
   formatValueTotal,
 } from '../../utils/format-numbers';
+import Backtrace from './Backtrace';
+
 import { bailoutTypeInformation } from '../../profile-logic/marker-info';
 import type { TracingMarker } from '../../types/profile-derived';
-import type { MarkerPayload } from '../../types/markers';
 import type { NotVoidOrNull } from '../../types/utils';
+import type { ImplementationFilter } from '../../types/actions';
+import type { Thread } from '../../types/profile';
 
 function _markerDetail<T: NotVoidOrNull>(
   key: string,
@@ -31,7 +34,12 @@ function _markerDetail<T: NotVoidOrNull>(
   ];
 }
 
-function getMarkerDetails(data: MarkerPayload): React.Element<any> | null {
+function getMarkerDetails(
+  marker: TracingMarker,
+  thread: Thread,
+  implementationFilter: ImplementationFilter
+): React.Element<any> | null {
+  const data = marker.data;
   if (data) {
     switch (data.type) {
       case 'UserTiming': {
@@ -253,6 +261,26 @@ function getMarkerDetails(data: MarkerPayload): React.Element<any> | null {
           </div>
         );
       }
+      case 'tracing': {
+        if ('cause' in data && data.cause) {
+          const { cause } = data;
+          const causeAge = marker.start - cause.time;
+          return (
+            <div className="tooltipDetailsBackTrace">
+              <h2 className="tooltipBackTraceTitle">
+                First invalidated {formatNumber(causeAge)}ms before the flush,
+                at:
+              </h2>
+              <Backtrace
+                cause={cause}
+                thread={thread}
+                implementationFilter={implementationFilter}
+              />
+            </div>
+          );
+        }
+        break;
+      }
       default:
     }
   }
@@ -263,12 +291,20 @@ type Props = {
   marker: TracingMarker,
   className?: string,
   threadName?: string,
+  thread: Thread,
+  implementationFilter: ImplementationFilter,
 };
 
 export default class MarkerTooltipContents extends React.PureComponent<Props> {
   render() {
-    const { marker, className, threadName } = this.props;
-    const details = getMarkerDetails(marker.data);
+    const {
+      marker,
+      className,
+      threadName,
+      thread,
+      implementationFilter,
+    } = this.props;
+    const details = getMarkerDetails(marker, thread, implementationFilter);
 
     return (
       <div className={classNames('tooltipMarker', className)}>

--- a/src/components/shared/Tooltip.css
+++ b/src/components/shared/Tooltip.css
@@ -64,3 +64,14 @@
   white-space: nowrap;
   text-align: right;
 }
+
+.tooltipDetailsBackTrace {
+
+}
+
+.tooltipBackTraceTitle {
+  color: #666;
+  font-weight: normal;
+  margin: 0;
+  font-size: 100%;
+}

--- a/src/profile-logic/call-tree.js
+++ b/src/profile-logic/call-tree.js
@@ -4,7 +4,11 @@
 
 // @flow
 import { timeCode } from '../utils/time-code';
-import { getSampleCallNodes, resourceTypes } from './profile-data';
+import {
+  getSampleCallNodes,
+  resourceTypes,
+  getOriginAnnotationForFunc,
+} from './profile-data';
 import { UniqueStringArray } from '../utils/unique-string-array';
 import type {
   Thread,
@@ -175,23 +179,12 @@ export class CallTree {
   }
 
   _getOriginAnnotation(funcIndex: IndexIntoFuncTable): string {
-    const fileNameIndex = this._funcTable.fileName[funcIndex];
-    if (fileNameIndex !== null) {
-      const fileName = this._stringTable.getString(fileNameIndex);
-      const lineNumber = this._funcTable.lineNumber[funcIndex];
-      if (lineNumber !== null) {
-        return fileName + ':' + lineNumber;
-      }
-      return fileName;
-    }
-
-    const resourceIndex = this._funcTable.resource[funcIndex];
-    const resourceNameIndex = this._resourceTable.name[resourceIndex];
-    if (resourceNameIndex !== undefined) {
-      return this._stringTable.getString(resourceNameIndex);
-    }
-
-    return '';
+    return getOriginAnnotationForFunc(
+      funcIndex,
+      this._funcTable,
+      this._resourceTable,
+      this._stringTable
+    );
   }
 }
 

--- a/src/profile-logic/old-cleopatra-profile-format.js
+++ b/src/profile-logic/old-cleopatra-profile-format.js
@@ -121,22 +121,10 @@ function _convertThread(
   const frameMap = new Map();
   const stackMap = new Map();
 
-  let lastSampleTime = 0;
-
-  for (let i = 0; i < thread.samples.length; i++) {
-    const sample = thread.samples[i];
-    // sample has the shape: {
-    //   frames: [symbolicationTableIndices for the stack frames]
-    //   extraInfo: {
-    //     responsiveness,
-    //     time,
-    //   }
-    // }
-    //
+  function convertStack(frames) {
     // We map every stack frame to a frame.
     // Then we walk the stack, creating "stacks" (= (prefix stack, frame) pairs)
     // as needed, and arrive at the sample's stackIndex.
-    const frames = sample.frames;
     let prefix = null;
     for (let i = 0; i < frames.length; i++) {
       const frameSymbolicationTableIndex = frames[i];
@@ -161,8 +149,23 @@ function _convertThread(
       }
       prefix = stackIndex;
     }
+    return prefix;
+  }
+
+  let lastSampleTime = 0;
+
+  for (let i = 0; i < thread.samples.length; i++) {
+    const sample = thread.samples[i];
+    // sample has the shape: {
+    //   frames: [symbolicationTableIndices for the stack frames]
+    //   extraInfo: {
+    //     responsiveness,
+    //     time,
+    //   }
+    // }
+    const stackIndex = convertStack(sample.frames);
     const sampleIndex = samples.length++;
-    samples.stack[sampleIndex] = prefix;
+    samples.stack[sampleIndex] = stackIndex;
     const hasTime =
       'time' in sample.extraInfo && typeof sample.extraInfo.time === 'number';
     const sampleTime = hasTime
@@ -183,6 +186,29 @@ function _convertThread(
   for (let i = 0; i < thread.markers.length; i++) {
     const marker = thread.markers[i];
     const markerIndex = markers.length++;
+    const data = marker.data;
+    if (data && 'stack' in data) {
+      // data.stack is an array of strings
+      const stackIndex = convertStack(
+        data.stack.map(s => stringTable.indexForString(s))
+      );
+      data.stack = {
+        markers: { schema: { name: 0, time: 1, data: 2 }, data: [] },
+        name: 'SyncProfile',
+        samples: {
+          schema: {
+            stack: 0,
+            time: 1,
+            responsiveness: 2,
+            rss: 3,
+            uss: 4,
+            frameNumber: 5,
+            power: 6,
+          },
+          data: [[stackIndex, marker.time]],
+        },
+      };
+    }
     markers.data[markerIndex] = marker.data;
     markers.name[markerIndex] = stringTable.indexForString(marker.name);
     markers.time[markerIndex] = marker.time;

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -11,6 +11,7 @@ import type {
   FrameTable,
   FuncTable,
   MarkersTable,
+  ResourceTable,
   IndexIntoFuncTable,
   IndexIntoStringTable,
   IndexIntoSamplesTable,
@@ -34,6 +35,7 @@ import { timeCode } from '../utils/time-code';
 import { getEmptyTaskTracerData } from './task-tracer';
 import type { ImplementationFilter } from '../types/actions';
 import bisection from 'bisection';
+import type { UniqueStringArray } from '../utils/unique-string-array';
 
 /**
  * Various helpers for dealing with the profile as a data structure.
@@ -1031,4 +1033,29 @@ export function getEmptyProfile(): Profile {
     threads: [],
     tasktracer: getEmptyTaskTracerData(),
   };
+}
+
+export function getOriginAnnotationForFunc(
+  funcIndex: IndexIntoFuncTable,
+  funcTable: FuncTable,
+  resourceTable: ResourceTable,
+  stringTable: UniqueStringArray
+): string {
+  const fileNameIndex = funcTable.fileName[funcIndex];
+  if (fileNameIndex !== null) {
+    const fileName = stringTable.getString(fileNameIndex);
+    const lineNumber = funcTable.lineNumber[funcIndex];
+    if (lineNumber !== null) {
+      return fileName + ':' + lineNumber;
+    }
+    return fileName;
+  }
+
+  const resourceIndex = funcTable.resource[funcIndex];
+  const resourceNameIndex = resourceTable.name[resourceIndex];
+  if (resourceNameIndex !== undefined) {
+    return stringTable.getString(resourceNameIndex);
+  }
+
+  return '';
 }

--- a/src/test/components/MarkerTooltipContents.test.js
+++ b/src/test/components/MarkerTooltipContents.test.js
@@ -7,133 +7,205 @@ import React from 'react';
 import MarkersTooltipContents from '../../components/shared/MarkerTooltipContents';
 import renderer from 'react-test-renderer';
 import { storeWithProfile } from '../fixtures/stores';
-import { getProfileWithMarkers } from '../fixtures/profiles/make-profile';
+import {
+  addMarkersToProfileReplacingSamples,
+  getProfileFromTextSamples,
+} from '../fixtures/profiles/make-profile';
 import { selectedThreadSelectors } from '../../reducers/profile-view';
+import { getImplementationFilter } from '../../reducers/url-state';
 
 describe('MarkerTooltipContents', function() {
   it('renders tooltips for various markers', () => {
+    // First, create a profile with one stack, so that the stack table contains
+    // something that we can refer to from the CauseBacktrace of a marker.
+    const { profile, funcNames } = getProfileFromTextSamples(`
+      _main
+      XRE_main
+      XREMain::XRE_main
+      XREMain::XRE_mainRun
+      nsAppStartup::Run
+      nsAppShell::Run
+      ChildViewMouseTracker::MouseMoved
+      nsChildView::DispatchEvent
+      nsView::HandleEvent
+      nsViewManager::DispatchEvent
+      mozilla::PresShell::HandleEvent
+      mozilla::PresShell::HandlePositionedEvent
+      mozilla::PresShell::HandleEventInternal
+      mozilla::EventStateManager::PreHandleEvent
+      mozilla::EventStateManager::GenerateMouseEnterExit
+      mozilla::EventStateManager::NotifyMouseOut
+      mozilla::EventStateManager::SetContentState
+      mozilla::EventStateManager::UpdateAncestorState
+      mozilla::dom::Element::RemoveStates
+      nsDocument::ContentStateChanged
+      mozilla::PresShell::ContentStateChanged
+      mozilla::GeckoRestyleManager::ContentStateChanged
+      mozilla::GeckoRestyleManager::PostRestyleEvent
+      nsRefreshDriver::AddStyleFlushObserver
+    `);
+    // Now add some markers to the profile.
     // Enumerate through all of the switch arms of the tooltip for coverage.
-    const profile = getProfileWithMarkers([
+    addMarkersToProfileReplacingSamples(
       [
-        'DOMEvent',
-        10.5,
-        {
-          type: 'DOMEvent',
-          startTime: 10.5,
-          endTime: 11.3,
-          eventType: 'commandupdate',
-          phase: 2,
-        },
-      ],
-      [
-        'UserTiming',
-        12.5,
-        {
-          type: 'UserTiming',
-          startTime: 12.5,
-          endTime: 12.5,
-          name: 'foobar',
-          entryType: 'mark',
-        },
-      ],
-      [
-        'NotifyDidPaint',
-        14.5,
-        {
-          type: 'tracing',
-          startTime: 14.5,
-          endTime: 14.5,
-          category: 'Paint',
-          interval: 'start',
-          name: 'NotifyDidPaint',
-        },
-      ],
-      [
-        'GCMinor',
-        15.5,
-        {
-          type: 'GCMinor',
-          startTime: 15.5,
-          endTime: 15.5,
-          // nursery is only present in newer profile format.
-          nursery: {
-            reason: 'CC_WAITING',
-            status: 'complete',
-            bytes_tenured: 4 * 1024 * 1024,
-            bytes_used: 8 * 1024 * 1024,
-            new_capacity: 16 * 1024 * 1024,
-            lazy_capacity: 12 * 1024 * 1024,
-            phase_times: {},
+        [
+          'DOMEvent',
+          10.5,
+          {
+            type: 'DOMEvent',
+            startTime: 10.5,
+            endTime: 11.3,
+            eventType: 'commandupdate',
+            phase: 2,
           },
-        },
-      ],
-      [
-        'GCMajor',
-        16.5,
-        {
-          type: 'GCMajor',
-          startTime: 16.5,
-          endTime: 16.5,
-          timings: {
-            status: 'completed',
-            max_pause: 103.65,
-            total_time: 157.215,
-            reason: 'CC_WAITING',
-            zones_collected: 3,
-            total_zones: 5,
-            total_compartments: 79,
-            minor_gcs: 9,
-            store_buffer_overflows: 5,
-            slices: 13,
-            scc_sweep_total: 160,
-            scc_sweep_max_pause: 150,
-            nonincremental_reason: 'Non incremental reason',
-            allocated_bytes: 16 * 1024 * 1024,
-            added_chunks: 5,
-            removed_chunks: 2,
-            major_gc_number: 1,
-            minor_gc_number: 2,
-            slice_number: 5,
-            mmu_20ms: 0,
-            mmu_50ms: 0,
-            phase_times: {},
+        ],
+        [
+          'UserTiming',
+          12.5,
+          {
+            type: 'UserTiming',
+            startTime: 12.5,
+            endTime: 12.5,
+            name: 'foobar',
+            entryType: 'mark',
           },
-        },
-      ],
-      [
-        'GCSlice',
-        17.5,
-        {
-          type: 'GCSlice',
-          startTime: 17.5,
-          endTime: 17.5,
-          timings: {
-            reason: 'CC_WAITING',
-            slice: 1,
-            pause: 5,
-            when: 17.5,
-            budget: 11,
-            initial_state: 'Initial',
-            final_state: 'Final',
-            major_gc_number: 1,
-            page_faults: 1,
-            start_timestamp: 17,
-            end_timestamp: 17,
-            phase_times: {},
+        ],
+        [
+          'NotifyDidPaint',
+          14.5,
+          {
+            type: 'tracing',
+            startTime: 14.5,
+            endTime: 14.5,
+            category: 'Paint',
+            interval: 'start',
+            name: 'NotifyDidPaint',
           },
-        },
+        ],
+        [
+          'GCMinor',
+          15.5,
+          {
+            type: 'GCMinor',
+            startTime: 15.5,
+            endTime: 15.5,
+            // nursery is only present in newer profile format.
+            nursery: {
+              reason: 'CC_WAITING',
+              status: 'complete',
+              bytes_tenured: 4 * 1024 * 1024,
+              bytes_used: 8 * 1024 * 1024,
+              new_capacity: 16 * 1024 * 1024,
+              lazy_capacity: 12 * 1024 * 1024,
+              phase_times: {},
+            },
+          },
+        ],
+        [
+          'GCMajor',
+          16.5,
+          {
+            type: 'GCMajor',
+            startTime: 16.5,
+            endTime: 16.5,
+            timings: {
+              status: 'completed',
+              max_pause: 103.65,
+              total_time: 157.215,
+              reason: 'CC_WAITING',
+              zones_collected: 3,
+              total_zones: 5,
+              total_compartments: 79,
+              minor_gcs: 9,
+              store_buffer_overflows: 5,
+              slices: 13,
+              scc_sweep_total: 160,
+              scc_sweep_max_pause: 150,
+              nonincremental_reason: 'Non incremental reason',
+              allocated_bytes: 16 * 1024 * 1024,
+              added_chunks: 5,
+              removed_chunks: 2,
+              major_gc_number: 1,
+              minor_gc_number: 2,
+              slice_number: 5,
+              mmu_20ms: 0,
+              mmu_50ms: 0,
+              phase_times: {},
+            },
+          },
+        ],
+        [
+          'GCSlice',
+          17.5,
+          {
+            type: 'GCSlice',
+            startTime: 17.5,
+            endTime: 17.5,
+            timings: {
+              reason: 'CC_WAITING',
+              slice: 1,
+              pause: 5,
+              when: 17.5,
+              budget: 11,
+              initial_state: 'Initial',
+              final_state: 'Final',
+              major_gc_number: 1,
+              page_faults: 1,
+              start_timestamp: 17,
+              end_timestamp: 17,
+              phase_times: {},
+            },
+          },
+        ],
+        [
+          'Bailout_ShapeGuard after getelem on line 3666 of resource://foo.js -> resource://bar.js:3662',
+          10,
+          null,
+        ],
+        ['Invalidate http://mozilla.com/script.js:1234', 10, null],
+        [
+          'Styles',
+          18.5,
+          {
+            type: 'tracing',
+            category: 'Paint',
+            interval: 'start',
+            cause: {
+              time: 17.0,
+              stack: funcNames.indexOf(
+                'nsRefreshDriver::AddStyleFlushObserver'
+              ),
+            },
+            // The startTime and endTime properties are currently required by
+            // our flow type annotations, but those annotations are wrong:
+            // Actual Gecko profiles won't have these properties in their
+            // tracing markers. The flow types should really be fixed, but I had
+            // some trouble when I tried to do that so I deferred it to some
+            // later point.
+            startTime: 18.5,
+            endTime: 18.5,
+          },
+        ],
+        [
+          'Styles',
+          19,
+          {
+            type: 'tracing',
+            category: 'Paint',
+            interval: 'end',
+            // startTime and endTime should be unnecessary, see above
+            startTime: 18.5,
+            endTime: 18.5,
+          },
+        ],
       ],
-      [
-        'Bailout_ShapeGuard after getelem on line 3666 of resource://foo.js -> resource://bar.js:3662',
-        10,
-        null,
-      ],
-      ['Invalidate http://mozilla.com/script.js:1234', 10, null],
-    ]);
-    const { getState } = storeWithProfile(profile);
-    const tracingMarkers = selectedThreadSelectors.getTracingMarkers(
-      getState()
+      profile
     );
+    const { getState } = storeWithProfile(profile);
+    const state = getState();
+    const implementationFilter = getImplementationFilter(state);
+    const thread = selectedThreadSelectors.getThread(state);
+    const tracingMarkers = selectedThreadSelectors.getTracingMarkers(state);
 
     tracingMarkers.forEach(marker => {
       expect(
@@ -141,7 +213,9 @@ describe('MarkerTooltipContents', function() {
           <MarkersTooltipContents
             marker={marker}
             className="propClass"
+            thread={thread}
             threadName="Main Thread"
+            implementationFilter={implementationFilter}
           />
         )
       ).toMatchSnapshot();

--- a/src/test/components/__snapshots__/MarkerTooltipContents.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerTooltipContents.test.js.snap
@@ -489,3 +489,294 @@ exports[`MarkerTooltipContents renders tooltips for various markers 7`] = `
   </div>
 </div>
 `;
+
+exports[`MarkerTooltipContents renders tooltips for various markers 8`] = `
+<div
+  className="tooltipMarker propClass"
+>
+  <div
+    className="tooltipHeader"
+  >
+    <div
+      className="tooltipOneLine"
+    >
+      <div
+        className="tooltipTiming"
+      >
+        0.50
+        ms
+      </div>
+      <div
+        className="tooltipTitle"
+      >
+        Styles
+      </div>
+    </div>
+    <div
+      className="tooltipDetails"
+    >
+      <div
+        className="tooltipLabel"
+      >
+        Thread:
+      </div>
+      Main Thread
+    </div>
+  </div>
+  <div
+    className="tooltipDetailsBackTrace"
+  >
+    <h2
+      className="tooltipBackTraceTitle"
+    >
+      First invalidated 
+      1.5
+      ms before the flush, at:
+    </h2>
+    <ol
+      className="backtrace"
+    >
+      <li
+        className="backtraceStackFrame"
+      >
+        nsRefreshDriver::AddStyleFlushObserver
+        <em
+          className="backtraceStackFrameOrigin"
+        >
+          
+        </em>
+      </li>
+      <li
+        className="backtraceStackFrame"
+      >
+        mozilla::GeckoRestyleManager::PostRestyleEvent
+        <em
+          className="backtraceStackFrameOrigin"
+        >
+          
+        </em>
+      </li>
+      <li
+        className="backtraceStackFrame"
+      >
+        mozilla::GeckoRestyleManager::ContentStateChanged
+        <em
+          className="backtraceStackFrameOrigin"
+        >
+          
+        </em>
+      </li>
+      <li
+        className="backtraceStackFrame"
+      >
+        mozilla::PresShell::ContentStateChanged
+        <em
+          className="backtraceStackFrameOrigin"
+        >
+          
+        </em>
+      </li>
+      <li
+        className="backtraceStackFrame"
+      >
+        nsDocument::ContentStateChanged
+        <em
+          className="backtraceStackFrameOrigin"
+        >
+          
+        </em>
+      </li>
+      <li
+        className="backtraceStackFrame"
+      >
+        mozilla::dom::Element::RemoveStates
+        <em
+          className="backtraceStackFrameOrigin"
+        >
+          
+        </em>
+      </li>
+      <li
+        className="backtraceStackFrame"
+      >
+        mozilla::EventStateManager::UpdateAncestorState
+        <em
+          className="backtraceStackFrameOrigin"
+        >
+          
+        </em>
+      </li>
+      <li
+        className="backtraceStackFrame"
+      >
+        mozilla::EventStateManager::SetContentState
+        <em
+          className="backtraceStackFrameOrigin"
+        >
+          
+        </em>
+      </li>
+      <li
+        className="backtraceStackFrame"
+      >
+        mozilla::EventStateManager::NotifyMouseOut
+        <em
+          className="backtraceStackFrameOrigin"
+        >
+          
+        </em>
+      </li>
+      <li
+        className="backtraceStackFrame"
+      >
+        mozilla::EventStateManager::GenerateMouseEnterExit
+        <em
+          className="backtraceStackFrameOrigin"
+        >
+          
+        </em>
+      </li>
+      <li
+        className="backtraceStackFrame"
+      >
+        mozilla::EventStateManager::PreHandleEvent
+        <em
+          className="backtraceStackFrameOrigin"
+        >
+          
+        </em>
+      </li>
+      <li
+        className="backtraceStackFrame"
+      >
+        mozilla::PresShell::HandleEventInternal
+        <em
+          className="backtraceStackFrameOrigin"
+        >
+          
+        </em>
+      </li>
+      <li
+        className="backtraceStackFrame"
+      >
+        mozilla::PresShell::HandlePositionedEvent
+        <em
+          className="backtraceStackFrameOrigin"
+        >
+          
+        </em>
+      </li>
+      <li
+        className="backtraceStackFrame"
+      >
+        mozilla::PresShell::HandleEvent
+        <em
+          className="backtraceStackFrameOrigin"
+        >
+          
+        </em>
+      </li>
+      <li
+        className="backtraceStackFrame"
+      >
+        nsViewManager::DispatchEvent
+        <em
+          className="backtraceStackFrameOrigin"
+        >
+          
+        </em>
+      </li>
+      <li
+        className="backtraceStackFrame"
+      >
+        nsView::HandleEvent
+        <em
+          className="backtraceStackFrameOrigin"
+        >
+          
+        </em>
+      </li>
+      <li
+        className="backtraceStackFrame"
+      >
+        nsChildView::DispatchEvent
+        <em
+          className="backtraceStackFrameOrigin"
+        >
+          
+        </em>
+      </li>
+      <li
+        className="backtraceStackFrame"
+      >
+        ChildViewMouseTracker::MouseMoved
+        <em
+          className="backtraceStackFrameOrigin"
+        >
+          
+        </em>
+      </li>
+      <li
+        className="backtraceStackFrame"
+      >
+        nsAppShell::Run
+        <em
+          className="backtraceStackFrameOrigin"
+        >
+          
+        </em>
+      </li>
+      <li
+        className="backtraceStackFrame"
+      >
+        nsAppStartup::Run
+        <em
+          className="backtraceStackFrameOrigin"
+        >
+          
+        </em>
+      </li>
+      <li
+        className="backtraceStackFrame"
+      >
+        XREMain::XRE_mainRun
+        <em
+          className="backtraceStackFrameOrigin"
+        >
+          
+        </em>
+      </li>
+      <li
+        className="backtraceStackFrame"
+      >
+        XREMain::XRE_main
+        <em
+          className="backtraceStackFrameOrigin"
+        >
+          
+        </em>
+      </li>
+      <li
+        className="backtraceStackFrame"
+      >
+        XRE_main
+        <em
+          className="backtraceStackFrameOrigin"
+        >
+          
+        </em>
+      </li>
+      <li
+        className="backtraceStackFrame"
+      >
+        _main
+        <em
+          className="backtraceStackFrameOrigin"
+        >
+          
+        </em>
+      </li>
+    </ol>
+  </div>
+</div>
+`;

--- a/src/types/gecko-profile.js
+++ b/src/types/gecko-profile.js
@@ -27,6 +27,17 @@ export type GeckoMarkerStruct = {
   length: number,
 };
 
+export type GeckoMarkerStack = {
+  name: 'SyncProfile',
+  registerTime: null,
+  unregisterTime: null,
+  processType: string,
+  tid: number,
+  pid: number,
+  markers: GeckoMarkers,
+  samples: GeckoSamples,
+};
+
 export type GeckoSamples = {
   schema: {
     stack: 0,
@@ -118,8 +129,8 @@ export type GeckoStackStruct = {
 
 export type GeckoThread = {
   name: string,
-  processType: string,
   registerTime: number,
+  processType: string,
   unregisterTime: number | null,
   tid: number,
   pid: number,

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -4,6 +4,8 @@
 // @flow
 
 import type { Milliseconds, Seconds } from './units';
+import type { GeckoMarkerStack } from './gecko-profile';
+import type { IndexIntoStackTable } from './profile';
 
 /**
  * Measurement for how long draw calls take for the compositor.
@@ -16,36 +18,32 @@ export type GPUMarkerPayload = {
   cpuend: Milliseconds,
   gpustart: Milliseconds, // Always 0.
   gpuend: Milliseconds, // The time the GPU took to execute the command.
-  stack?: Object,
+};
+
+export type CauseBacktrace = {
+  time: Milliseconds,
+  stack: IndexIntoStackTable,
 };
 
 /**
  * These markers have a start and end time.
  */
-export type ProfilerMarkerTracing = {
+export type PaintProfilerMarkerTracing_Gecko = {
   type: 'tracing',
-  startTime: Milliseconds, // Same as cpustart
-  endTime: Milliseconds, // Same as cpuend
-  stack?: Object,
+  category: 'Paint',
+  startTime: Milliseconds,
+  endTime: Milliseconds,
+  stack?: GeckoMarkerStack,
   interval: 'start' | 'end',
 };
 
-export type PaintProfilerMarkerTracing = ProfilerMarkerTracing & {
+export type PaintProfilerMarkerTracing = {
+  type: 'tracing',
   category: 'Paint',
-  name:
-    | 'RefreshDriverTick'
-    | 'FireScrollEvent'
-    | 'Scripts'
-    | 'Styles'
-    | 'Reflow'
-    | 'DispatchSynthMouseMove'
-    | 'DisplayList'
-    | 'LayerBuilding'
-    | 'Rasterize'
-    | 'ForwardTransaction'
-    | 'NotifyDidPaint'
-    | 'LayerTransaction'
-    | 'Composite',
+  startTime: Milliseconds,
+  endTime: Milliseconds,
+  cause?: CauseBacktrace,
+  interval: 'start' | 'end',
 };
 
 export type PhaseTimes = { [phase: string]: Milliseconds };
@@ -307,7 +305,7 @@ export type MarkerPayload =
 export type MarkerPayload_Gecko =
   | GPUMarkerPayload
   | UserTimingMarkerPayload
-  | PaintProfilerMarkerTracing
+  | PaintProfilerMarkerTracing_Gecko
   | DOMEventMarkerPayload
   | GCMinorMarkerPayload
   | GCMajorMarkerPayload_Gecko


### PR DESCRIPTION
Fixes #64.

<img width="1552" alt="screen shot 2017-11-27 at 1 10 42 pm" src="https://user-images.githubusercontent.com/961291/33281824-8f3ddc66-d374-11e7-8b1a-e86f285841ef.png">

This is ready for review but not completely ready for landing.

Remaining work:

 * [x] Change flow type of the `getTooltipContents` to something more specific than `Function`
 * [ ] Try to reduce the duplication of the `getTooltipContents` implementations
 * [x] Add a snapshot test
 * [x] Should probably move the `GeckoSyncProfile` type definition to the gecko-profile type file.
 * [ ] Implement printing the stack to the console when a marker is clicked (could also be a follow-up)