### PR TITLE
Fix time units in GC markers

### DIFF
--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
-import type { Milliseconds, Seconds } from './units';
+import type { Milliseconds, Microseconds, Seconds } from './units';
 
 /**
  * Measurement for how long draw calls take for the compositor.
@@ -48,7 +48,7 @@ export type PaintProfilerMarkerTracing = ProfilerMarkerTracing & {
     | 'Composite',
 };
 
-export type PhaseTimes = { [phase: string]: Milliseconds };
+export type PhaseTimes = { [phase: string]: Microseconds };
 
 type GCSliceData_Shared = {
   // Slice number within the GCMajor collection.

--- a/src/types/units.js
+++ b/src/types/units.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
+export type Microseconds = number;
 export type Milliseconds = number;
 export type Seconds = number;
 


### PR DESCRIPTION
In an earlier patch I used milliseconds when the data is in microseconds.
This patch fixes that error.