### PR TITLE
Use bit-ly's CORS-based API to shorten URL (instead of the JSONP-base…

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "classnames": "^2.2.5",
     "common-tags": "^1.4.0",
     "copy-to-clipboard": "^3.0.8",
-    "fetch-jsonp": "^1.1.3",
     "lodash.uniqwith": "^4.5.0",
     "memoize-immutable": "^3.0.0",
     "offline-plugin": "^4.8.3",

--- a/res/.htaccess
+++ b/res/.htaccess
@@ -37,13 +37,13 @@ Header set Referrer-Policy same-origin
 #   You can generate these hashes using the website
 #   https://report-uri.io/home/hash after grabbing the script from the Inspector.
 #   NOTE: you can't use the script file directly as the API modifies it before injecting.
-#   c. When shortening URLs witn JSONP, we insert a script from bitly.
+#   c. We use Google Analytics to track the usage of the application.
 # 2. `unsafe-inline` in `style-src` is necessary to support favicons.
 # 3. Same for `*` in `img-src`.
 # 4. `object-src` is for plugins, we don't need them.
-# 5. `connect-src` is `*` to support `from-url`
+# 5. `connect-src` is `*` to support `from-url`. We also do requests to bitly to shorten URLs.
 # 6. `frame-ancestors` is the same purpose as `X-Frame-Options` above.
 # 7. `form-action`prevents forms, we don't need this.`
 # 8. `upgrade-insecure-requests` instructs the browser to upgrade all insecure
 #     requests to HTTPS, but only the ones to the same hostname.
-Header always add Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-eRTCQnd2fhPykpATDzCv4gdVk/EOdDq+6yzFXaWgGEw=' 'sha256-AdiT28wTL5FNaRVHWQVFC0ic3E20Gu4/PiC9xukS9+E=' https://api-ssl.bitly.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src *; object-src 'none'; connect-src *; frame-ancestors 'self'; form-action 'none'; upgrade-insecure-requests"
+Header always add Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-eRTCQnd2fhPykpATDzCv4gdVk/EOdDq+6yzFXaWgGEw=' 'sha256-AdiT28wTL5FNaRVHWQVFC0ic3E20Gu4/PiC9xukS9+E=' https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src *; object-src 'none'; connect-src *; frame-ancestors 'self'; form-action 'none'; upgrade-insecure-requests"

--- a/server.js
+++ b/server.js
@@ -25,7 +25,6 @@ new WebpackDevServer(webpack(config), {
         'self'
         'sha256-eRTCQnd2fhPykpATDzCv4gdVk/EOdDq+6yzFXaWgGEw='
         'sha256-AdiT28wTL5FNaRVHWQVFC0ic3E20Gu4/PiC9xukS9+E='
-        https://api-ssl.bitly.com
         https://www.google-analytics.com;
       style-src 'self' 'unsafe-inline';
       img-src *;

--- a/src/utils/shorten-url.js
+++ b/src/utils/shorten-url.js
@@ -4,7 +4,6 @@
 
 // @flow
 
-import fetchJsonP from 'fetch-jsonp';
 import queryString from 'query-string';
 import url from 'url';
 
@@ -27,7 +26,7 @@ export default function shortenUrl(urlToShorten: string): Promise<string> {
       format: 'json',
       access_token: 'b177b00a130faf3ecda6960e8b59fde73e902422',
     });
-  return fetchJsonP(bitlyQueryUrl)
+  return fetch(bitlyQueryUrl)
     .then(response => response.json())
     .then(json => json.data.url);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2681,10 +2681,6 @@ fbjs@^0.8.4, fbjs@^0.8.9:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
-fetch-jsonp@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/fetch-jsonp/-/fetch-jsonp-1.1.3.tgz#9eb9e585ba08aaf700563538d17bbebbcd5a3db2"
-
 figures@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"


### PR DESCRIPTION
…d API)

This improves privacy by not inserting 3rd-party scripts from bitly.

Fixes: #645