### PR TITLE
Handle -1 libIndex values; Resolves #623

### DIFF
--- a/src/components/calltree/ProfileCallTreeContextMenu.js
+++ b/src/components/calltree/ProfileCallTreeContextMenu.js
@@ -217,7 +217,7 @@ class ProfileCallTreeContextMenu extends PureComponent<Props> {
       return null;
     }
     const libIndex = resourceTable.lib[resourceIndex];
-    if (libIndex === undefined || libIndex === null) {
+    if (libIndex === undefined || libIndex === null || libIndex === -1) {
       return null;
     }
     return libs[libIndex].name;

--- a/src/profile-logic/symbolication.js
+++ b/src/profile-logic/symbolication.js
@@ -106,7 +106,7 @@ function gatherFuncsInThread(thread: Thread): Map<Lib, IndexIntoFuncTable[]> {
     }
 
     const libIndex = resourceTable.lib[resourceIndex];
-    if (libIndex === null || libIndex === undefined) {
+    if (libIndex === null || libIndex === undefined || libIndex === -1) {
       throw new Error('libIndex must be a valid index.');
     }
     const lib = libs[libIndex];

--- a/src/profile-logic/transforms.js
+++ b/src/profile-logic/transforms.js
@@ -236,7 +236,7 @@ export function getTransformLabels(
     if (transform.type === 'collapse-resource') {
       const libIndex = resourceTable.lib[transform.resourceIndex];
       let resourceName;
-      if (libIndex === undefined || libIndex === null) {
+      if (libIndex === undefined || libIndex === null || libIndex === -1) {
         const nameIndex = resourceTable.name[transform.resourceIndex];
         if (nameIndex === -1) {
           throw new Error('Attempting to collapse a resource without a name');

--- a/src/test/unit/process-profile.test.js
+++ b/src/test/unit/process-profile.test.js
@@ -86,7 +86,7 @@ describe('extract functions and resource from location strings', function() {
           resourceType = resourceTable.type[resourceIndex];
         }
         const lib =
-          libIndex === undefined || libIndex === null
+          libIndex === undefined || libIndex === null || libIndex === -1
             ? undefined
             : libs[libIndex];
 

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -109,9 +109,10 @@ export type FuncTable = {
  */
 export type ResourceTable = {
   length: number,
-  // lib SHOULD be void in this case, but some profiles in the store seem to have
-  // null here. We should probably investigate and provide an upgrader.
-  lib: Array<IndexIntoLibs | void | null>,
+  // lib SHOULD be void in this case, but some profiles in the store have null or -1
+  // here. We should investigate and provide an upgrader.
+  // See https://github.com/devtools-html/perf.html/issues/652
+  lib: Array<IndexIntoLibs | void | null | -1>,
   name: Array<IndexIntoStringTable | -1>,
   host: Array<IndexIntoStringTable | void>,
   type: resourceTypeEnum[],


### PR DESCRIPTION
The libIndex for `profile.thread.resourceTable.lib` is inconsistent in its historical use. This is a quick patch to ensure we don't have runtime errors.