### PR TITLE
Add the new time in chunk alloc GCMinor marker field

### DIFF
--- a/src/components/shared/MarkerTooltipContents.js
+++ b/src/components/shared/MarkerTooltipContents.js
@@ -99,6 +99,13 @@ function getMarkerDetails(data: MarkerPayload): React.Element<any> | null {
                         nursery.lazy_capacity,
                         formatBytes
                       )}
+                  {nursery.chunk_alloc_us === undefined
+                    ? null
+                    : _markerDetail(
+                        'gctimeinchunkalloc',
+                        'Time spent allocating chunks in mutator',
+                        formatNumber(nursery.chunk_alloc_us) + 'μs'
+                      )}
                 </div>
               );
             }

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -201,6 +201,8 @@ export type GCMinorCompletedData = {
   // actually allocated.
   lazy_capacity?: number,
 
+  chunk_alloc_us?: Microseconds,
+
   phase_times: PhaseTimes<Microseconds>,
 };
 


### PR DESCRIPTION
A new field was introduced to the GCMinor marker here:
https://bugzilla.mozilla.org/show_bug.cgi?id=1409324

This change adds the field to perf.html.