### PR TITLE
Increase maxViewportHeight for stack chart

### DIFF
--- a/src/components/stack-chart/index.js
+++ b/src/components/stack-chart/index.js
@@ -71,7 +71,7 @@ class StackChartGraph extends React.PureComponent<Props> {
       processDetails,
     } = this.props;
 
-    const maxViewportHeight = maxStackDepth * STACK_FRAME_HEIGHT;
+    const maxViewportHeight = (maxStackDepth + 1) * STACK_FRAME_HEIGHT;
 
     return (
       <div className="stackChart">


### PR DESCRIPTION
An off by one error makes the last row of stack frames in the stack
chart hidden. Increase maxViewportHeight so that all frames can be
seen in the canvas.