### PR TITLE
Make maxDepth one-based instead of zero-based

### DIFF
--- a/src/profile-logic/stack-timing.js
+++ b/src/profile-logic/stack-timing.js
@@ -78,7 +78,7 @@ export function getStackTimingByDepth(
   interval: number
 ): StackTimingByDepth {
   const { callNodeTable, stackIndexToCallNodeIndex } = callNodeInfo;
-  const stackTimingByDepth = Array.from({ length: maxDepth + 1 }, () => ({
+  const stackTimingByDepth = Array.from({ length: maxDepth }, () => ({
     start: [],
     end: [],
     stack: [],
@@ -196,6 +196,18 @@ function _pushStacks(
   }
 }
 
+/**
+ * Compute maximum depth of call stack for a given thread.
+ *
+ * Returns the depth of the deepest call node, but with a one-based
+ * depth instead of a zero-based.
+ *
+ * If no samples are found, 0 is returned.
+ *
+ * @param {object} thread
+ * @param {object} callNodeInfo
+ * @return {number} maxDepth
+ */
 export function computeCallNodeMaxDepth(
   rangedThread: Thread,
   callNodeInfo: CallNodeInfo
@@ -203,11 +215,12 @@ export function computeCallNodeMaxDepth(
   let maxDepth = 0;
   const { samples } = rangedThread;
   const { callNodeTable, stackIndexToCallNodeIndex } = callNodeInfo;
-  for (let i = 0; i < rangedThread.samples.length; i++) {
+  for (let i = 0; i < samples.length; i++) {
     const stackIndex = samples.stack[i];
     if (stackIndex !== null) {
       const callNodeIndex = stackIndexToCallNodeIndex[stackIndex];
-      const depth = callNodeTable.depth[callNodeIndex];
+      // Change to one-based depth
+      const depth = callNodeTable.depth[callNodeIndex] + 1;
       if (depth > maxDepth) {
         maxDepth = depth;
       }

--- a/src/profile-logic/stack-timing.js
+++ b/src/profile-logic/stack-timing.js
@@ -203,17 +203,13 @@ function _pushStacks(
  * depth instead of a zero-based.
  *
  * If no samples are found, 0 is returned.
- *
- * @param {object} thread
- * @param {object} callNodeInfo
- * @return {number} maxDepth
  */
 export function computeCallNodeMaxDepth(
-  rangedThread: Thread,
+  thread: Thread,
   callNodeInfo: CallNodeInfo
 ): number {
   let maxDepth = 0;
-  const { samples } = rangedThread;
+  const { samples } = thread;
   const { callNodeTable, stackIndexToCallNodeIndex } = callNodeInfo;
   for (let i = 0; i < samples.length; i++) {
     const stackIndex = samples.stack[i];

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
@@ -873,7 +873,7 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
             style={
               Object {
                 "height": "304px",
-                "width": 3120,
+                "width": 3130,
               }
             }
           >

--- a/src/test/store/actions.test.js
+++ b/src/test/store/actions.test.js
@@ -146,12 +146,12 @@ describe('selectors/getCallNodeMaxDepthForStackChart', function() {
     const allSamplesMaxDepth = selectedThreadSelectors.getCallNodeMaxDepthForStackChart(
       store.getState()
     );
-    expect(allSamplesMaxDepth).toEqual(6);
+    expect(allSamplesMaxDepth).toEqual(7);
     store.dispatch(changeHidePlatformDetails(true));
     const jsOnlySamplesMaxDepth = selectedThreadSelectors.getCallNodeMaxDepthForStackChart(
       store.getState()
     );
-    expect(jsOnlySamplesMaxDepth).toEqual(4);
+    expect(jsOnlySamplesMaxDepth).toEqual(5);
   });
 
   it('acts upon the current range', function() {
@@ -160,12 +160,21 @@ describe('selectors/getCallNodeMaxDepthForStackChart', function() {
     const allSamplesMaxDepth = selectedThreadSelectors.getCallNodeMaxDepthForStackChart(
       store.getState()
     );
-    expect(allSamplesMaxDepth).toEqual(2);
+    expect(allSamplesMaxDepth).toEqual(3);
     store.dispatch(changeHidePlatformDetails(true));
     const jsOnlySamplesMaxDepth = selectedThreadSelectors.getCallNodeMaxDepthForStackChart(
       store.getState()
     );
-    expect(jsOnlySamplesMaxDepth).toEqual(0);
+    expect(jsOnlySamplesMaxDepth).toEqual(1);
+  });
+
+  it('returns zero if no samples are in range', function() {
+    const store = storeWithProfile();
+    store.dispatch(addRangeFilter(0, 0));
+    const noSamplesMaxDepth = selectedThreadSelectors.getCallNodeMaxDepthForStackChart(
+      store.getState()
+    );
+    expect(noSamplesMaxDepth).toEqual(0);
   });
 });
 

--- a/src/test/store/actions.test.js
+++ b/src/test/store/actions.test.js
@@ -17,6 +17,7 @@ import {
 } from '../../actions/profile-view';
 import { changeStackChartColorStrategy } from '../../actions/stack-chart';
 import { getCategoryByImplementation } from '../../profile-logic/color-categories';
+import { getProfileFromTextSamples } from '../fixtures/profiles/make-profile';
 
 const { selectedThreadSelectors } = ProfileViewSelectors;
 
@@ -168,9 +169,9 @@ describe('selectors/getCallNodeMaxDepthForStackChart', function() {
     expect(jsOnlySamplesMaxDepth).toEqual(1);
   });
 
-  it('returns zero if no samples are in range', function() {
-    const store = storeWithProfile();
-    store.dispatch(addRangeFilter(0, 0));
+  it('returns zero if there are no samples', function() {
+    const { profile } = getProfileFromTextSamples(` `);
+    const store = storeWithProfile(profile);
     const noSamplesMaxDepth = selectedThreadSelectors.getCallNodeMaxDepthForStackChart(
       store.getState()
     );


### PR DESCRIPTION
An off by one error makes the last row of stack frames in the stack
chart hidden.  By changing computeCallNodeMaxDepth in stack-timing.js
to be one-based this problem is fixed, and also better reflects how
max depths are used.