### PR TITLE
Hide overflow indicator when header stops being scrollable

### DIFF
--- a/src/components/header/OverflowEdgeIndicator.js
+++ b/src/components/header/OverflowEdgeIndicator.js
@@ -54,6 +54,10 @@ class OverflowEdgeIndicator extends React.PureComponent<Props, State> {
     this._updateIndicatorStatus();
   }
 
+  componentDidUpdate() {
+    this._updateIndicatorStatus();
+  }
+
   _updateIndicatorStatus() {
     const container = this._container;
     const contentsWrapper = this._contentsWrapper;


### PR DESCRIPTION
Fixes #686