### PR TITLE
Focus the call tree when clicking a stack in the header

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -45,6 +45,12 @@ export function changeSelectedThread(selectedThread: ThreadIndex): Action {
   };
 }
 
+export function focusCallTree(): Action {
+  return {
+    type: 'FOCUS_CALL_TREE',
+  };
+}
+
 export function changeThreadOrder(threadOrder: ThreadIndex[]): Action {
   sendAnalytics({
     hitType: 'event',

--- a/src/components/app/TabBar.js
+++ b/src/components/app/TabBar.js
@@ -33,6 +33,9 @@ class TabBar extends PureComponent<Props> {
 
   _mouseDownListener(e: SyntheticMouseEvent<HTMLElement>) {
     this.props.onSelectTab(e.currentTarget.dataset.name);
+    // Prevent focusing the tab so that actual content like the
+    // calltree can perform its own focusing.
+    e.preventDefault();
   }
 
   render() {

--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -18,6 +18,7 @@ import {
 import {
   selectedThreadSelectors,
   getScrollToSelectionGeneration,
+  getFocusCallTreeGeneration,
   getProfileViewOptions,
 } from '../../reducers/profile-view';
 import { getIconsWithClassNames } from '../../reducers/icons';
@@ -41,6 +42,7 @@ import type { Column } from '../shared/TreeView';
 type Props = {
   threadIndex: ThreadIndex,
   scrollToSelectionGeneration: number,
+  focusCallTreeGeneration: number,
   tree: CallTree,
   callNodeInfo: CallNodeInfo,
   selectedCallNodeIndex: IndexIntoCallNodeTable | null,
@@ -100,6 +102,12 @@ class CallTreeComponent extends PureComponent<Props> {
       if (this._treeView) {
         this._treeView.scrollSelectionIntoView();
       }
+    }
+
+    if (
+      this.props.focusCallTreeGeneration > prevProps.focusCallTreeGeneration
+    ) {
+      this.focus();
     }
   }
 
@@ -205,6 +213,7 @@ export default connect(
   (state: State) => ({
     threadIndex: getSelectedThreadIndex(state),
     scrollToSelectionGeneration: getScrollToSelectionGeneration(state),
+    focusCallTreeGeneration: getFocusCallTreeGeneration(state),
     tree: selectedThreadSelectors.getCallTree(state),
     callNodeInfo: selectedThreadSelectors.getCallNodeInfo(state),
     selectedCallNodeIndex: selectedThreadSelectors.getSelectedCallNodeIndex(

--- a/src/components/header/ProfileThreadHeaderBar.js
+++ b/src/components/header/ProfileThreadHeaderBar.js
@@ -46,6 +46,7 @@ type Props = {
   changeSelectedThread: ThreadIndex => void,
   updateProfileSelection: typeof updateProfileSelection,
   changeSelectedCallNode: (IndexIntoCallNodeTable, CallNodePath) => void,
+  focusCallTree: () => void,
 };
 
 class ProfileThreadHeaderBar extends PureComponent<Props> {
@@ -76,7 +77,12 @@ class ProfileThreadHeaderBar extends PureComponent<Props> {
 
   _onStackClick(time: number) {
     const { threadIndex, interval } = this.props;
-    const { thread, callNodeInfo, changeSelectedCallNode } = this.props;
+    const {
+      thread,
+      callNodeInfo,
+      changeSelectedCallNode,
+      focusCallTree,
+    } = this.props;
     const sampleIndex = getSampleIndexClosestToTime(
       thread.samples,
       time,
@@ -91,6 +97,7 @@ class ProfileThreadHeaderBar extends PureComponent<Props> {
       threadIndex,
       getCallNodePath(newSelectedCallNode, callNodeInfo.callNodeTable)
     );
+    focusCallTree();
   }
 
   _onIntervalMarkerSelect(

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -316,6 +316,15 @@ function scrollToSelectionGeneration(state: number = 0, action: Action) {
   }
 }
 
+function focusCallTreeGeneration(state: number = 0, action: Action) {
+  switch (action.type) {
+    case 'FOCUS_CALL_TREE':
+      return state + 1;
+    default:
+      return state;
+  }
+}
+
 function rootRange(
   state: StartEndRange = { start: 0, end: 1 },
   action: Action
@@ -359,6 +368,7 @@ const profileViewReducer: Reducer<ProfileViewState> = combineReducers({
     waitingForLibs,
     selection,
     scrollToSelectionGeneration,
+    focusCallTreeGeneration,
     rootRange,
     zeroAt,
     tabOrder,
@@ -381,6 +391,11 @@ export const getProfileRootRange = (state: State) =>
 export const getScrollToSelectionGeneration = createSelector(
   getProfileViewOptions,
   viewOptions => viewOptions.scrollToSelectionGeneration
+);
+
+export const getFocusCallTreeGeneration = createSelector(
+  getProfileViewOptions,
+  viewOptions => viewOptions.focusCallTreeGeneration
 );
 
 export const getZeroAt = createSelector(

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -69,6 +69,9 @@ type ProfileAction =
       selectedCallNodePath: CallNodePath,
     }
   | {
+      type: 'FOCUS_CALL_TREE',
+    }
+  | {
       type: 'CHANGE_EXPANDED_CALL_NODES',
       threadIndex: ThreadIndex,
       expandedCallNodePaths: Array<CallNodePath>,

--- a/src/types/reducers.js
+++ b/src/types/reducers.js
@@ -35,6 +35,7 @@ export type ProfileViewState = {
     waitingForLibs: Set<RequestedLib>,
     selection: ProfileSelection,
     scrollToSelectionGeneration: number,
+    focusCallTreeGeneration: number,
     rootRange: StartEndRange,
     zeroAt: Milliseconds,
     tabOrder: number[],


### PR DESCRIPTION
Fixes #621 