### PR TITLE
Drop function transform

### DIFF
--- a/res/drop-icon.svg
+++ b/res/drop-icon.svg
@@ -1,0 +1,14 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <circle fill="#000000" cx="8" cy="2" r="2"></circle>
+    <circle fill="#000000" cx="11" cy="8" r="2"></circle>
+    <circle fill="#000000" cx="14" cy="14" r="2"></circle>
+    <path d="M6.5,14.5 L1.5,9.5" stroke="#000000" stroke-width="1.5" stroke-linecap="round"></path>
+    <path d="M1.5,14.5 L6.5,9.5" stroke="#000000" stroke-width="1.5" stroke-linecap="round"></path>
+    <path d="M10.5,6.5 L8.5,3.5" stroke="#000000" stroke-linecap="square"></path>
+    <path d="M13.5,12.5 L11.5,9.5" stroke="#000000" stroke-linecap="square"></path>
+  </g>
+</svg>

--- a/src/components/calltree/ProfileCallTreeContextMenu.css
+++ b/src/components/calltree/ProfileCallTreeContextMenu.css
@@ -23,6 +23,10 @@
   background: url(../../../res/focus-icon.svg) center center no-repeat;
 }
 
+.profileCallTreeContextMenuIconDrop {
+  background: url(../../../res/drop-icon.svg) center center no-repeat;
+}
+
 .profileCallTreeContextMenuLabel {
   color: #555;
   font-weight: bold;

--- a/src/components/calltree/ProfileCallTreeContextMenu.js
+++ b/src/components/calltree/ProfileCallTreeContextMenu.js
@@ -108,11 +108,11 @@ class ProfileCallTreeContextMenu extends PureComponent<Props> {
         break;
       case 'merge-call-node':
       case 'merge-function':
-      case 'merge-subtree':
       case 'focus-subtree':
       case 'focus-function':
       case 'collapse-resource':
       case 'collapse-direct-recursion':
+      case 'drop-function':
         this.addTransformToStack(type);
         break;
       default:
@@ -146,14 +146,6 @@ class ProfileCallTreeContextMenu extends PureComponent<Props> {
           funcIndex: selectedFunc,
         });
         break;
-      case 'merge-subtree':
-        addTransformToStack(threadIndex, {
-          type: 'merge-subtree',
-          callNodePath: selectedCallNodePath,
-          implementation,
-          inverted,
-        });
-        break;
       case 'merge-call-node':
         addTransformToStack(threadIndex, {
           type: 'merge-call-node',
@@ -164,6 +156,12 @@ class ProfileCallTreeContextMenu extends PureComponent<Props> {
       case 'merge-function':
         addTransformToStack(threadIndex, {
           type: 'merge-function',
+          funcIndex: selectedFunc,
+        });
+        break;
+      case 'drop-function':
+        addTransformToStack(threadIndex, {
+          type: 'drop-function',
           funcIndex: selectedFunc,
         });
         break;
@@ -268,9 +266,6 @@ class ProfileCallTreeContextMenu extends PureComponent<Props> {
           <span className="profileCallTreeContextMenuIcon profileCallTreeContextMenuIconMerge" />
           Merge function into caller across the entire tree
         </MenuItem>
-        {/* <MenuItem onClick={this.handleClick} data={{ type: 'mergeSubtree' }}>
-          Merge subtree into calling function
-        </MenuItem> */}
         <MenuItem onClick={this.handleClick} data={{ type: 'focus-subtree' }}>
           <span className="profileCallTreeContextMenuIcon profileCallTreeContextMenuIconFocus" />
           Focus on subtree
@@ -302,6 +297,10 @@ class ProfileCallTreeContextMenu extends PureComponent<Props> {
               Collapse direct recursion
             </MenuItem>
           : null}
+        <MenuItem onClick={this.handleClick} data={{ type: 'drop-function' }}>
+          <span className="profileCallTreeContextMenuIcon profileCallTreeContextMenuIconDrop" />
+          Drop samples with this function
+        </MenuItem>
         <div className="react-contextmenu-separator" />
         <MenuItem
           onClick={this.handleClick}

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -513,9 +513,6 @@ export const selectorsForThread = (
                 transform.callNodePath,
                 transform.implementation
               );
-        case 'merge-subtree':
-          // TODO - Implement this transform.
-          return thread;
         case 'merge-call-node':
           return Transforms.mergeCallNode(
             thread,
@@ -524,6 +521,8 @@ export const selectorsForThread = (
           );
         case 'merge-function':
           return Transforms.mergeFunction(thread, transform.funcIndex);
+        case 'drop-function':
+          return Transforms.dropFunction(thread, transform.funcIndex);
         case 'focus-function':
           return Transforms.focusFunction(thread, transform.funcIndex);
         case 'collapse-resource':

--- a/src/test/url-handling.test.js
+++ b/src/test/url-handling.test.js
@@ -236,7 +236,7 @@ describe('url upgrading', function() {
 
 describe('URL serialization of the transform stack', function() {
   const transformString =
-    'f-combined-012~ms-js-123~mcn-combined-234~f-js-345-i~mf-6~ff-7~cr-combined-8-9~rec-combined-10';
+    'f-combined-012~mcn-combined-234~f-js-345-i~mf-6~ff-7~cr-combined-8-9~rec-combined-10~df-11';
   const { getState } = _getStoreWithURL({
     search: '?transforms=' + transformString,
   });
@@ -252,12 +252,6 @@ describe('URL serialization of the transform stack', function() {
         type: 'focus-subtree',
         callNodePath: [0, 1, 2],
         implementation: 'combined',
-        inverted: false,
-      },
-      {
-        type: 'merge-subtree',
-        callNodePath: [1, 2, 3],
-        implementation: 'js',
         inverted: false,
       },
       {
@@ -289,6 +283,10 @@ describe('URL serialization of the transform stack', function() {
         type: 'collapse-direct-recursion',
         funcIndex: 10,
         implementation: 'combined',
+      },
+      {
+        type: 'drop-function',
+        funcIndex: 11,
       },
     ]);
   });

--- a/src/types/transforms.js
+++ b/src/types/transforms.js
@@ -115,7 +115,7 @@ export type FocusFunctionSubtree = {|
 |};
 
 /**
- * The MergeSubtree transform represents merging a CallNode into the parent CallNode. The
+ * The MergeCallNode transform represents merging a CallNode into the parent CallNode. The
  * CallNode must match the given CallNodePath. In the call tree below, if the CallNode
  * at path [A, B, C] is removed, then the `D` and `F` CallNodes are re-assigned to `B`.
  * No self time in this case would change, as `C` was not a leaf CallNode, but the
@@ -188,6 +188,26 @@ export type MergeFunction = {|
 |};
 
 /**
+ * The DropFunction transform removes samples from the thread that have a function
+ * somewhere in its stack.
+ *
+ *                 A:4,0                              A:1,0
+ *                 /    \        Drop Func C            |
+ *                v      v           -->                v
+ *            B:3,0     C:1,0                         B:1,0
+ *           /      \                                   |
+ *          v        v                                  v
+ *        C:2,1     D:1,1                             D:1,1
+ *        |
+ *        v
+ *      D:1,1
+ */
+export type DropFunction = {|
+  type: 'drop-function',
+  funcIndex: IndexIntoFuncTable,
+|};
+
+/**
  * Collapse resource takes CallNodes that are of a consecutive library, and collapses
  * them into a new collapsed pseudo-stack. Given a call tree like below, where each node
  * is defined by either "function_name" or "function_name:library_name":
@@ -233,22 +253,12 @@ export type CollapseDirectRecursion = {|
   implementation: ImplementationFilter,
 |};
 
-/**
- * TODO - Once implemented.
- */
-export type MergeSubtree = {|
-  type: 'merge-subtree',
-  callNodePath: CallNodePath,
-  implementation: ImplementationFilter,
-  inverted: boolean,
-|};
-
 export type Transform =
   | FocusSubtree
   | FocusFunctionSubtree
-  | MergeSubtree
   | MergeCallNode
   | MergeFunction
+  | DropFunction
   | CollapseResource
   | CollapseDirectRecursion;
 


### PR DESCRIPTION
```
                 A:4,0                              A:1,0
                 /    \        Drop Func C            |
                v      v           -->                v
            B:3,0     C:1,0                         B:1,0
           /      \                                   |
          v        v                                  v
        C:2,1     D:1,1                             D:1,1
        |
        v
      D:1,1
```
Resolves #220 

This came out of discussions in #435.

This adds the ability to remove samples from the call tree. I called it "Drop functions".

Here I dropped idling from the compositor thread:
<img width="1024" alt="image" src="https://user-images.githubusercontent.com/1588648/34538452-0e43b9ec-f092-11e7-8be7-7f7a52931a86.png">


Here is the icon I created for "drop":
<img width="510" alt="image" src="https://user-images.githubusercontent.com/1588648/34538484-28293d8c-f092-11e7-88eb-85f975a100ff.png">

  