### PR TITLE
Add the ability to only show one thread

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -51,6 +51,13 @@ export function focusCallTree(): Action {
   };
 }
 
+export function changeRightClickedThread(selectedThread: ThreadIndex): Action {
+  return {
+    type: 'CHANGE_RIGHT_CLICKED_THREAD',
+    selectedThread,
+  };
+}
+
 export function changeThreadOrder(threadOrder: ThreadIndex[]): Action {
   sendAnalytics({
     hitType: 'event',
@@ -107,6 +114,30 @@ export function showThread(threadIndex: ThreadIndex): ThunkAction<void> {
     dispatch({
       type: 'SHOW_THREAD',
       threadIndex,
+    });
+  };
+}
+
+export function isolateThread(
+  isolatedThreadIndex: ThreadIndex
+): ThunkAction<void> {
+  return (dispatch, getState) => {
+    const threads = getThreads(getState());
+    const thread = threads[isolatedThreadIndex];
+    const threadIndexes = threads.map((_, index) => index);
+    sendAnalytics({
+      hitType: 'event',
+      eventCategory: 'threads',
+      eventAction: 'isolate',
+      eventLabel: getFriendlyThreadName(threads, thread),
+    });
+
+    dispatch({
+      type: 'ISOLATE_THREAD',
+      hiddenThreadIndexes: threadIndexes.filter(
+        index => index !== isolatedThreadIndex
+      ),
+      isolatedThreadIndex,
     });
   };
 }

--- a/src/components/header/ProfileThreadHeaderContextMenu.js
+++ b/src/components/header/ProfileThreadHeaderContextMenu.js
@@ -5,9 +5,16 @@
 // @flow
 import React, { PureComponent } from 'react';
 import { ContextMenu, MenuItem } from 'react-contextmenu';
-import { hideThread, showThread } from '../../actions/profile-view';
+import {
+  hideThread,
+  showThread,
+  isolateThread,
+} from '../../actions/profile-view';
 import { connect } from 'react-redux';
-import { getThreads } from '../../reducers/profile-view';
+import {
+  getThreads,
+  getRightClickedThreadIndex,
+} from '../../reducers/profile-view';
 import { getThreadOrder, getHiddenThreads } from '../../reducers/url-state';
 import { getFriendlyThreadName } from '../../profile-logic/profile-data';
 import classNames from 'classnames';
@@ -19,8 +26,10 @@ type Props = {|
   threads: Thread[],
   threadOrder: ThreadIndex[],
   hiddenThreads: ThreadIndex[],
+  rightClickedThreadIndex: ThreadIndex,
   hideThread: typeof hideThread,
   showThread: typeof showThread,
+  isolateThread: typeof isolateThread,
 |};
 
 class ProfileThreadHeaderContextMenu extends PureComponent<Props> {
@@ -47,11 +56,34 @@ class ProfileThreadHeaderContextMenu extends PureComponent<Props> {
     }
   }
 
+  _isolateThread = () => {
+    const { isolateThread, rightClickedThreadIndex } = this.props;
+    isolateThread(rightClickedThreadIndex);
+  };
+
   render() {
-    const { threads, threadOrder, hiddenThreads } = this.props;
+    const {
+      threads,
+      threadOrder,
+      hiddenThreads,
+      rightClickedThreadIndex,
+    } = this.props;
+
+    const clickedThreadName = getFriendlyThreadName(
+      threads,
+      threads[rightClickedThreadIndex]
+    );
 
     return (
       <ContextMenu id={'ProfileThreadHeaderContextMenu'}>
+        {hiddenThreads.length === threads.length - 1
+          ? null
+          : <div>
+              <MenuItem onClick={this._isolateThread}>
+                Only show: {`"${clickedThreadName}"`}
+              </MenuItem>
+              <div className="react-contextmenu-separator" />
+            </div>}
         {threadOrder.map(threadIndex => {
           const isHidden = hiddenThreads.includes(threadIndex);
           return (
@@ -78,6 +110,7 @@ export default connect(
     threads: getThreads(state),
     threadOrder: getThreadOrder(state),
     hiddenThreads: getHiddenThreads(state),
+    rightClickedThreadIndex: getRightClickedThreadIndex(state),
   }),
-  { hideThread, showThread }
+  { hideThread, showThread, isolateThread }
 )(ProfileThreadHeaderContextMenu);

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -362,6 +362,15 @@ function tabOrder(state: number[] = [0, 1, 2, 3], action: Action) {
   }
 }
 
+function rightClickedThread(state: ThreadIndex = 0, action: Action) {
+  switch (action.type) {
+    case 'CHANGE_RIGHT_CLICKED_THREAD':
+      return action.selectedThread;
+    default:
+      return state;
+  }
+}
+
 const profileViewReducer: Reducer<ProfileViewState> = combineReducers({
   viewOptions: combineReducers({
     perThread: viewOptionsPerThread,
@@ -373,6 +382,7 @@ const profileViewReducer: Reducer<ProfileViewState> = combineReducers({
     rootRange,
     zeroAt,
     tabOrder,
+    rightClickedThread,
   }),
   profile,
 });
@@ -437,6 +447,8 @@ export const getThreadNames = (state: State): string[] =>
   getProfile(state).threads.map(t => t.name);
 export const getProfileTaskTracerData = (state: State): TaskTracer =>
   getProfile(state).tasktracer;
+export const getRightClickedThreadIndex = (state: State) =>
+  getProfileViewOptions(state).rightClickedThread;
 
 export type SelectorsForThread = {
   getThread: State => Thread,

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -107,6 +107,8 @@ function selectedThread(state: ThreadIndex = 0, action: Action) {
       }
       return findDefaultThreadIndex(action.profile.threads);
     }
+    case 'ISOLATE_THREAD':
+      return action.isolatedThreadIndex;
     case 'HIDE_THREAD': {
       const { threadIndex, hiddenThreads, threadOrder } = action;
       // If the currently selected thread is being hidden, then re-select a new one.
@@ -237,6 +239,9 @@ function hiddenThreads(state: ThreadIndex[] = [], action: Action) {
     case 'SHOW_THREAD': {
       const { threadIndex } = action;
       return state.filter(index => index !== threadIndex);
+    }
+    case 'ISOLATE_THREAD': {
+      return action.hiddenThreadIndexes;
     }
     default:
       return state;

--- a/src/test/store/thread-ordering-toggling.test.js
+++ b/src/test/store/thread-ordering-toggling.test.js
@@ -50,6 +50,10 @@ describe('thread ordering and toggling', function() {
       showThread: threadIndex => {
         dispatch(ProfileViewActions.showThread(threadIndex));
       },
+
+      isolateThread: threadIndex => {
+        dispatch(ProfileViewActions.isolateThread(threadIndex));
+      },
     };
   }
 
@@ -168,6 +172,43 @@ describe('thread ordering and toggling', function() {
 
     it('will select another thread when hidden', function() {
       hideThread(A);
+      expect(getSelectedThreadIndex()).toEqual(B);
+    });
+  });
+
+  describe('isolate a thread', function() {
+    function setup() {
+      const store = storeWithProfile(
+        getProfileWithNamedThreads(['A', 'B', 'C', 'D'])
+      );
+      return setupHelpers(store);
+    }
+
+    it('starts out with the initial sorting', function() {
+      const { getOrderedThreadNames, getHiddenThreadNames } = setup();
+      expect(getOrderedThreadNames()).toEqual(['A', 'B', 'C', 'D']);
+      expect(getHiddenThreadNames()).toEqual([]);
+    });
+
+    it('has the first thread selected', function() {
+      const { getSelectedThreadIndex } = setup();
+      expect(getSelectedThreadIndex()).toEqual(A);
+    });
+
+    it('isolates a thread', function() {
+      const {
+        getOrderedThreadNames,
+        getHiddenThreadNames,
+        isolateThread,
+      } = setup();
+      isolateThread(B);
+      expect(getOrderedThreadNames()).toEqual(['A', 'B', 'C', 'D']);
+      expect(getHiddenThreadNames()).toEqual(['A', 'C', 'D']);
+    });
+
+    it('selects the isolated thread', function() {
+      const { getSelectedThreadIndex, isolateThread } = setup();
+      isolateThread(B);
       expect(getSelectedThreadIndex()).toEqual(B);
     });
   });

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -59,6 +59,11 @@ type ProfileAction =
     }
   | { type: 'SHOW_THREAD', threadIndex: ThreadIndex }
   | {
+      type: 'ISOLATE_THREAD',
+      hiddenThreadIndexes: ThreadIndex[],
+      isolatedThreadIndex: ThreadIndex,
+    }
+  | {
       type: 'ASSIGN_TASK_TRACER_NAMES',
       addressIndices: number[],
       symbolNames: string[],
@@ -132,6 +137,7 @@ type UrlStateAction =
   | { type: 'ADD_RANGE_FILTER', start: number, end: number }
   | { type: 'POP_RANGE_FILTERS', firstRemovedFilterIndex: number }
   | { type: 'CHANGE_SELECTED_THREAD', selectedThread: ThreadIndex }
+  | { type: 'CHANGE_RIGHT_CLICKED_THREAD', selectedThread: ThreadIndex }
   | { type: 'CHANGE_CALL_TREE_SEARCH_STRING', searchString: string }
   | {
       type: 'ADD_TRANSFORM_TO_STACK',

--- a/src/types/reducers.js
+++ b/src/types/reducers.js
@@ -39,6 +39,7 @@ export type ProfileViewState = {
     rootRange: StartEndRange,
     zeroAt: Milliseconds,
     tabOrder: number[],
+    rightClickedThread: ThreadIndex,
   },
   profile: Profile,
 };


### PR DESCRIPTION
This adds an option to the thread context menu to only show the right-clicked thread. This was a major source of annoyance for me doing demos during the Y'All Hands.