### PR TITLE
Replace isMounted with animation

### DIFF
--- a/res/style.css
+++ b/res/style.css
@@ -28,16 +28,6 @@ body, #root, .profileViewer {
   z-index: 0;
 }
 
-.profileViewer {
-  background-color: #fff;
-  opacity: 0;
-  transition: opacity 200ms;
-}
-
-.profileViewerIsMounted {
-  opacity: 1;
-}
-
 .treeView {
   display: flex;
   flex-flow: column nowrap;

--- a/src/components/app/ProfileViewer.css
+++ b/src/components/app/ProfileViewer.css
@@ -1,0 +1,14 @@
+@keyframes profileViewerFadeIn {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+.profileViewer {
+  background-color: #fff;
+  animation-name: profileViewerFadeIn;
+  animation-duration: 200ms;
+}

--- a/src/components/app/ProfileViewer.js
+++ b/src/components/app/ProfileViewer.js
@@ -43,11 +43,7 @@ type Props = {
   changeTabOrder: (number[]) => Action,
 };
 
-type State = {
-  isMounted: boolean,
-};
-
-class ProfileViewer extends PureComponent<Props, State> {
+class ProfileViewer extends PureComponent<Props> {
   _tabs: Tab[];
 
   constructor(props) {

--- a/src/components/app/ProfileViewer.js
+++ b/src/components/app/ProfileViewer.js
@@ -8,7 +8,6 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import TabBar from './TabBar';
-import classNames from 'classnames';
 import ProfileCallTreeView from '../calltree/ProfileCallTreeView';
 import MarkerTable from '../marker-table';
 import ProfileTaskTracerView from '../tasktracer/ProfileTaskTracerView';
@@ -33,6 +32,8 @@ import type { StartEndRange } from '../../types/units';
 import type { Tab } from './TabBar';
 import type { Action } from '../../types/actions';
 
+require('./ProfileViewer.css');
+
 type Props = {
   className: string,
   tabOrder: number[],
@@ -52,7 +53,6 @@ class ProfileViewer extends PureComponent<Props, State> {
   constructor(props) {
     super(props);
     (this: any)._onSelectTab = this._onSelectTab.bind(this);
-    this.state = { isMounted: false };
     // If updating this list, make sure and update the tabOrder reducer with another index.
     this._tabs = [
       {
@@ -79,12 +79,6 @@ class ProfileViewer extends PureComponent<Props, State> {
     changeSelectedTab(selectedTab);
   }
 
-  componentDidMount() {
-    // TODO use ReactCSSTransition instead of this hack. https://github.com/devtools-html/perf.html/issues/648
-    // eslint-disable-next-line react/no-did-mount-set-state
-    this.setState({ isMounted: true });
-  }
-
   render() {
     const {
       className,
@@ -93,15 +87,9 @@ class ProfileViewer extends PureComponent<Props, State> {
       changeTabOrder,
       selectedTab,
     } = this.props;
-    const { isMounted } = this.state;
 
     return (
-      <div
-        className={classNames(
-          className,
-          isMounted ? `${className}IsMounted` : null
-        )}
-      >
+      <div className={className}>
         <div className={`${className}TopBar`}>
           <ProfileFilterNavigator />
           <ProfileSharing />


### PR DESCRIPTION
Possible solution for #648 

I tried to replace the `isMounted` with `CSSTransition` but it doesn't work. I think the `PageViewer` dom tree is so big that the `react-transition-group` library delay between applying `appear` and `appear-active` classes are still not enough to trigger a transition.

But there is still a solution to the problem, we can use animations 😸 The `ProfileViewer` component animates on the mount, so animations would trigger properly every time you insert the `ProfileViewer` to the DOM tree.

I also moved the `profileViewer` styles to a separate file.

