### PR TITLE
When inverting call trees, create a new selectedCallNodePath

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -252,15 +252,23 @@ export function changeImplementationFilter(
   };
 }
 
-export function changeInvertCallstack(invertCallstack: boolean): Action {
-  sendAnalytics({
-    hitType: 'event',
-    eventCategory: 'profile',
-    eventAction: 'change invert callstack',
-  });
-  return {
-    type: 'CHANGE_INVERT_CALLSTACK',
-    invertCallstack,
+export function changeInvertCallstack(
+  invertCallstack: boolean
+): ThunkAction<void> {
+  return (dispatch, getState) => {
+    sendAnalytics({
+      hitType: 'event',
+      eventCategory: 'profile',
+      eventAction: 'change invert callstack',
+    });
+    dispatch({
+      type: 'CHANGE_INVERT_CALLSTACK',
+      invertCallstack,
+      selectedThreadIndex: getSelectedThreadIndex(getState()),
+      callTree: selectedThreadSelectors.getCallTree(getState()),
+      callNodeTable: selectedThreadSelectors.getCallNodeInfo(getState())
+        .callNodeTable,
+    });
   };
 }
 

--- a/src/components/calltree/ProfileCallTreeContextMenu.js
+++ b/src/components/calltree/ProfileCallTreeContextMenu.js
@@ -312,9 +312,7 @@ class ProfileCallTreeContextMenu extends PureComponent<Props> {
     } = this.props;
 
     if (selectedCallNodeIndex === null) {
-      throw new Error(
-        "The context menu assumes there is a selected call node and there wasn't one."
-      );
+      return null;
     }
 
     const funcIndex = callNodeTable.func[selectedCallNodeIndex];

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -611,7 +611,10 @@ export function getCallNodeFromPath(
     }
     fs = nextFS;
   }
-  return fs;
+
+  // The fs could still be -1 here, which we want to interpret as null to follow
+  // the function's type signature.
+  return fs === -1 ? null : fs;
 }
 
 export function getCallNodePath(

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -612,8 +612,7 @@ export function getCallNodeFromPath(
     fs = nextFS;
   }
 
-  // The fs could still be -1 here, which we want to interpret as null to follow
-  // the function's type signature.
+  // The fs could still be -1 here, so ensure we return null if that is the case.
   return fs === -1 ? null : fs;
 }
 

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -170,6 +170,31 @@ function viewOptionsPerThread(state: ThreadViewOptions[] = [], action: Action) {
         ...state.slice(threadIndex + 1),
       ];
     }
+    case 'CHANGE_INVERT_CALLSTACK': {
+      const { callTree, callNodeTable, selectedThreadIndex } = action;
+      return state.map((viewOptions, threadIndex) => {
+        if (selectedThreadIndex === threadIndex) {
+          // Only attempt this on the current thread, as we need the transformed thread
+          // There is no guarantee that this has been calculated on all the other threads,
+          // and we shouldn't attempt to expect it, as that could be quite a perf cost.
+          const selectedCallNodePath = Transforms.invertCallNodePath(
+            viewOptions.selectedCallNodePath,
+            callTree,
+            callNodeTable
+          );
+
+          const expandedCallNodePaths = [];
+          for (let i = 1; i < selectedCallNodePath.length; i++) {
+            expandedCallNodePaths.push(selectedCallNodePath.slice(0, i));
+          }
+          return Object.assign({}, viewOptions, {
+            selectedCallNodePath,
+            expandedCallNodePaths,
+          });
+        }
+        return viewOptions;
+      });
+    }
     case 'CHANGE_EXPANDED_CALL_NODES': {
       const { threadIndex, expandedCallNodePaths } = action;
       return [

--- a/src/test/store/transforms.test.js
+++ b/src/test/store/transforms.test.js
@@ -1198,8 +1198,8 @@ describe('expanded and selected CallNodePaths on inverted trees', function() {
   it('can update call node references for focusing a subtree', function() {
     const { dispatch, getState } = storeWithProfile(profile);
     // This opens expands the call nodes up to this point.
-    dispatch(changeSelectedCallNode(threadIndex, selectedCallNodePath));
     dispatch(changeInvertCallstack(true));
+    dispatch(changeSelectedCallNode(threadIndex, selectedCallNodePath));
     dispatch(
       addTransformToStack(threadIndex, {
         type: 'focus-subtree',
@@ -1224,8 +1224,8 @@ describe('expanded and selected CallNodePaths on inverted trees', function() {
   it('can update call node references for merging a call node', function() {
     const { dispatch, getState } = storeWithProfile(profile);
     // This opens expands the call nodes up to this point.
-    dispatch(changeSelectedCallNode(threadIndex, selectedCallNodePath));
     dispatch(changeInvertCallstack(true));
+    dispatch(changeSelectedCallNode(threadIndex, selectedCallNodePath));
     dispatch(
       addTransformToStack(threadIndex, {
         type: 'merge-call-node',

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
+import { CallTree } from '../profile-logic/call-tree';
 import type {
   Profile,
   Thread,
@@ -10,7 +11,7 @@ import type {
   IndexIntoMarkersTable,
   IndexIntoFuncTable,
 } from './profile';
-import type { CallNodePath } from './profile-derived';
+import type { CallNodePath, CallNodeTable } from './profile-derived';
 import type { GetLabel } from '../profile-logic/labeling-strategies';
 import type { GetCategory } from '../profile-logic/color-categories';
 import type { TemporaryError } from '../utils/errors';
@@ -159,7 +160,13 @@ type UrlStateAction =
       previousImplementation: ImplementationFilter,
       implementation: ImplementationFilter,
     }
-  | { type: 'CHANGE_INVERT_CALLSTACK', invertCallstack: boolean }
+  | {|
+      type: 'CHANGE_INVERT_CALLSTACK',
+      invertCallstack: boolean,
+      callTree: CallTree,
+      callNodeTable: CallNodeTable,
+      selectedThreadIndex: ThreadIndex,
+    |}
   | { type: 'CHANGE_HIDE_PLATFORM_DETAILS', hidePlatformDetails: boolean }
   | { type: 'CHANGE_MARKER_SEARCH_STRING', searchString: string };
 


### PR DESCRIPTION
This resolves #344. I split out two small existing errors in the codebase into 2 separate commits with explanations before the one that actually makes the change.