### PR TITLE
Fix #761: fix the search input's label's height so that the hint does…

### DIFF
--- a/src/components/shared/StackSearchField.css
+++ b/src/components/shared/StackSearchField.css
@@ -5,6 +5,12 @@
   z-index: 1;
 }
 
+.stackSearchFieldLabel {
+  /* We fix the height so that the stackSearchFieldIntroduction doesn't increase it */
+  display: block;
+  height: 100%;
+}
+
 .stackSearchFieldInput {
   width: 300px;
 }


### PR DESCRIPTION
…n't contribute to it

With this fix the stack chart receives mouse event again at that
location.