### PR TITLE
Allow users to access profile information via the webconsole; Resolves #706

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,10 @@ import Root from './components/app/Root';
 import createStore from './create-store';
 import 'photon-colors/colors.css';
 import '../res/style.css';
+import {
+  addDataToWindowObject,
+  logFriendlyPreamble,
+} from './utils/window-console';
 
 // Mock out Google Analytics for anything that's not production so that we have run-time
 // code coverage in development and testing.
@@ -43,3 +47,6 @@ const store = createStore();
 render(<Root store={store} />, document.getElementById('root'));
 
 window.Perf = Perf;
+
+addDataToWindowObject(store.getState);
+logFriendlyPreamble();

--- a/src/test/unit/__snapshots__/window-console.test.js.snap
+++ b/src/test/unit/__snapshots__/window-console.test.js.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`console-accessible values on the window object logs a friendly message 1`] = `
+Array [
+  Array [
+    "%c                  __ _     _             _ 
+                 / _| |   | |           | |
+ _ __   ___ _ __| |_| |__ | |_ _ __ ___ | |
+| '_ \\\\ / _ \\\\ '__|  _| '_ \\\\| __| '_ \` _ \\\\| |
+| |_) |  __/ |  | |_| | | | |_| | | | | | |
+| .__/ \\\\___|_|  |_(_)_| |_|\\\\__|_| |_| |_|_|
+| |                                        
+|_|                                        ",
+    "font-family: monospace;",
+  ],
+  Array [
+    "%cThe following profiler information is available via the console:%c
+
+%cwindow.profile%c - The currently loaded profile
+%cwindow.filteredThread%c - The current filtered thread
+%cwindow.callTree%c - The call tree of the current filtered thread
+
+The profile format is document here:
+%chttps://github.com/devtools-html/perf.html/blob/master/docs/processed-profile-format.md%c
+
+The CallTree class's source code is available here:
+%chttps://github.com/devtools-html/perf.html/blob/master/src/profile-logic/call-tree.js%c",
+    "font-size: 130%;",
+    "",
+    "font-weight: bold;",
+    "",
+    "font-weight: bold;",
+    "",
+    "font-weight: bold;",
+    "",
+    "font-style: italic; text-decoration: underline;",
+    "",
+    "font-style: italic; text-decoration: underline;",
+    "",
+  ],
+]
+`;

--- a/src/test/unit/window-console.test.js
+++ b/src/test/unit/window-console.test.js
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+import {
+  addDataToWindowObject,
+  logFriendlyPreamble,
+} from '../../utils/window-console';
+import { storeWithSimpleProfile } from '../fixtures/stores';
+
+describe('console-accessible values on the window object', function() {
+  // Coerce the window into a generic object, as these values aren't defined
+  // in the flow type definition.
+
+  it('does not have the values initially', function() {
+    expect((window: any).profile).toBeUndefined();
+    expect((window: any).filteredProfile).toBeUndefined();
+    expect((window: any).callTree).toBeUndefined();
+  });
+
+  it('adds values to the console', function() {
+    const store = storeWithSimpleProfile();
+    const target = {};
+    addDataToWindowObject(store.getState, target);
+    expect(target.profile).toBeTruthy();
+    expect(target.filteredThread).toBeTruthy();
+    expect(target.callTree).toBeTruthy();
+  });
+
+  it('logs a friendly message', function() {
+    const log = console.log;
+    (console: Object).log = jest.fn();
+    logFriendlyPreamble();
+    expect(console.log.mock.calls.length).toEqual(2);
+    expect(console.log.mock.calls).toMatchSnapshot();
+    (console: Object).log = log;
+  });
+});

--- a/src/types/libdef/npm-custom/common-tags_v1.x.x.js
+++ b/src/types/libdef/npm-custom/common-tags_v1.x.x.js
@@ -8,4 +8,9 @@ declare module 'common-tags' {
     template: string[],
     ...expressions: string[]
   ): string;
+
+  declare function stripIndent(
+    template: string[],
+    ...expressions: string[]
+  ): string;
 }

--- a/src/utils/window-console.js
+++ b/src/utils/window-console.js
@@ -1,0 +1,107 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+import { stripIndent } from 'common-tags';
+import type { GetState } from '../types/store';
+import { getProfile, selectedThreadSelectors } from '../reducers/profile-view';
+
+// Provide a bit of typing hinting. Flow doesn't understand the dynamic nature of
+// Object.defineProperty and has no definitions around it.
+type DefineGetProperty<T> = (
+  object: Object,
+  key: string,
+  {
+    +get: () => T,
+  }
+) => void;
+
+/**
+ * This function adds various values from the Redux Store to the window object so that
+ * people can access useful things.
+ */
+export function addDataToWindowObject(
+  getState: GetState,
+  target: Object = window
+) {
+  (Object.defineProperty: DefineGetProperty<*>)(target, 'profile', {
+    enumerable: true,
+    get() {
+      return getProfile(getState());
+    },
+  });
+
+  (Object.defineProperty: DefineGetProperty<*>)(target, 'filteredThread', {
+    enumerable: true,
+    get() {
+      return selectedThreadSelectors.getRangeSelectionFilteredThread(
+        getState()
+      );
+    },
+  });
+
+  (Object.defineProperty: DefineGetProperty<*>)(target, 'callTree', {
+    enumerable: true,
+    get() {
+      return selectedThreadSelectors.getCallTree(getState());
+    },
+  });
+}
+
+export function logFriendlyPreamble() {
+  /**
+   * Provide a friendly message to the end user to notify them that they can access certain
+   * values from the global window object. These variables are set in an ad-hoc fashion
+   * throughout the code.
+   */
+  const intro = `font-size: 130%;`;
+  const bold = `font-weight: bold;`;
+  const link = `font-style: italic; text-decoration: underline;`;
+  const reset = '';
+  console.log(
+    // This is gratuitous, I know:
+    [
+      // Prettier breaks this formatting, but newer versions don't.
+      // https://github.com/devtools-html/perf.html/issues/776
+      /* eslint-disable prettier/prettier */
+      "%c                  __ _     _             _ ",
+      "                 / _| |   | |           | |",
+      " _ __   ___ _ __| |_| |__ | |_ _ __ ___ | |",
+      "| '_ \\ / _ \\ '__|  _| '_ \\| __| '_ ` _ \\| |",
+      "| |_) |  __/ |  | |_| | | | |_| | | | | | |",
+      "| .__/ \\___|_|  |_(_)_| |_|\\__|_| |_| |_|_|",
+      "| |                                        ",
+      "|_|                                        ",
+      /* eslint-enable prettier/prettier */
+    ].join('\n'),
+    'font-family: monospace;'
+  );
+
+  console.log(
+    stripIndent`
+      %cThe following profiler information is available via the console:%c
+
+      %cwindow.profile%c - The currently loaded profile
+      %cwindow.filteredThread%c - The current filtered thread
+      %cwindow.callTree%c - The call tree of the current filtered thread
+
+      The profile format is document here:
+      %chttps://github.com/devtools-html/perf.html/blob/master/docs/processed-profile-format.md%c
+
+      The CallTree class's source code is available here:
+      %chttps://github.com/devtools-html/perf.html/blob/master/src/profile-logic/call-tree.js%c
+    `,
+    intro,
+    reset,
+    bold,
+    reset,
+    bold,
+    reset,
+    bold,
+    reset,
+    link,
+    reset,
+    link,
+    reset
+  );
+}


### PR DESCRIPTION
I added some ASCII art. At first I did it as a joke, but I think it actually legitimizes the console message a bit and makes it feel more friendly. It lets the users know they are welcome to mess around. The `%c` spacing is a tad weird due to a bug in the web console code that adds a space.

<img width="783" alt="image" src="https://user-images.githubusercontent.com/1588648/35939283-4cfa1baa-0c11-11e8-97c9-bfe6051dd751.png">
