### PR TITLE
Fix tooltip regression for contexts

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "offline-plugin": "^4.9.0",
     "photon-colors": "2.0.1",
     "pretty-bytes": "^4.0.2",
+    "prop-types": "^15.6.0",
     "query-string": "^5.1.0",
     "react": "^16.2.0",
     "react-contextmenu": "^2.9.2",

--- a/src/components/shared/Tooltip.js
+++ b/src/components/shared/Tooltip.js
@@ -6,6 +6,7 @@
 import * as React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
+import PropTypes from 'prop-types';
 import type { CssPixels } from '../../types/units';
 
 require('./Tooltip.css');
@@ -30,6 +31,7 @@ export default class Tooltip extends React.PureComponent<Props, State> {
   // This allows to get the store so that we can pass it along to the tooltip
   // children with a react-redux Provider. We can safely remove it once we use
   // React 16's portals.
+  static contextTypes = { store: PropTypes.object.isRequired };
 
   constructor(props: Props) {
     super(props);


### PR DESCRIPTION
Looks like we need the proptypes module still :-/

I didn't take the time to add portals, but fixed the regression with minimal effort.