### PR TITLE
Proposal: Add new loggers

### DIFF
--- a/src/create-store.js
+++ b/src/create-store.js
@@ -21,7 +21,12 @@ export default function initializeStore(): Store {
   if (process.env.NODE_ENV === 'development') {
     middlewares.push(
       createLogger({
-        titleFormatter: action => `content action ${action.type}`,
+        collapsed: true,
+        titleFormatter: (action, time, duration) =>
+          `[action]    ${action.type} (in ${duration} ms)`,
+        logErrors: false,
+        diff: true,
+        duration: true,
       })
     );
   }

--- a/src/index.js
+++ b/src/index.js
@@ -17,12 +17,8 @@ import {
 // code coverage in development and testing.
 if (process.env.NODE_ENV === 'development') {
   window.ga = (event, ...payload) => {
-    console.log(
-      `%cAnalytics:%c"${event}"`,
-      'color: #FF6D00; font-weight: bold',
-      'color: #FF6D00;',
-      ...payload
-    );
+    const style = 'color: #FF6D00; font-weight: bold';
+    console.log(`[analytics] %c"${event}"`, style, ...payload);
   };
 } else if (process.env.NODE_ENV !== 'production') {
   window.ga = () => {};

--- a/src/utils/time-code.js
+++ b/src/utils/time-code.js
@@ -20,7 +20,12 @@ export function timeCode<T>(label: string, codeAsACallback: () => T): T {
 
     // Only log timing information in development mode.
     if (process.env.NODE_ENV === 'development') {
-      console.log(`${label} took ${elapsed}ms to execute.`);
+      const style = 'font-weight: bold; color: #f0a';
+      console.log(
+        `[timing]    %c"${label}"`,
+        style,
+        `took ${elapsed}ms to execute.`
+      );
     }
 
     // Some portion of users will have timing information sent. Limit this further to


### PR DESCRIPTION
Our current logging has been pretty painful due to:

1. Very verbose multiline style.
2. Console filtering doesn't work well as it still shows the console group message
3. The logger does a try/catch on the code
  • This leads to the error and action being logged in non-intuitive orders
  • The error location is then the console.error from the logger script, not the script location where it was actually called.
4. The messages are not scannable.

This patch creates a custom logger that does minimal formatting.

1. Error locations are preserved, and are clickable to source code.
2. Logging order is preserved (no action log is emitted on error)
3. The logger includes callstacks for each action creator.
4. Everything starts with a tag like `[analytics]` so that it is easy to filter on.
5. The tags are aligned to be scannable.

## Image of the error location being preserved and clickable:

<img width="775" alt="image" src="https://user-images.githubusercontent.com/1588648/36285818-ba38c98e-1272-11e8-9141-a87ec2e4d2bf.png">

## Filtering:

<img width="1022" alt="image" src="https://user-images.githubusercontent.com/1588648/36285844-d6c13c3a-1272-11e8-8d83-b0f71785987c.png">

## Better scannability:

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/1588648/36285881-f04d0f8a-1272-11e8-897d-b65116a3a46f.png">
