### PR TITLE
Webpack local config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 public_html/
 flow-coverage
 coverage
+webpack.local-config.js

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "publish": "rimraf public_html && cp -r dist public_html",
     "serve-static": "ws -d dist/ -s index.html -p 4242",
     "start": "yarn build:clean && env NODE_ENV=development node server.js",
-    "start-no-hot": "yarn start",
     "start-prod": "yarn build-prod && yarn serve-static",
     "start-prod-readable": "yarn build-prod-readable && yarn serve-static",
     "start-examples": "ws -d examples/ -s index.html -p 4242",


### PR DESCRIPTION
This PR adds a local config option for webpack, so I can configure reloading how I want without bothering anyone else.

In addition it removes the unused command `yarn start-hot`, and also `yarn start` no longer needs to run build first once. This was done due to a hack to get our old worker into the build correctly.