### PR TITLE
Makes computing visible rows faster

### DIFF
--- a/src/components/shared/TreeView.js
+++ b/src/components/shared/TreeView.js
@@ -316,6 +316,7 @@ class TreeView<
 > extends React.PureComponent<TreeViewProps<NodeIndex, DisplayData>> {
   _specialItems: (NodeIndex | null)[];
   _visibleRows: NodeIndex[];
+  _expandedNodes: Set<NodeIndex | null>;
   _list: VirtualList | null;
   _takeListRef = (list: VirtualList | null) => (this._list = list);
 
@@ -327,6 +328,7 @@ class TreeView<
     (this: any)._onCopy = this._onCopy.bind(this);
     (this: any)._onRowClicked = this._onRowClicked.bind(this);
     this._specialItems = [props.selectedNodeId];
+    this._expandedNodes = new Set(props.expandedNodeIds);
     this._visibleRows = this._getAllVisibleRows(props);
     this._list = null;
   }
@@ -349,6 +351,7 @@ class TreeView<
       nextProps.tree !== this.props.tree ||
       nextProps.expandedNodeIds !== this.props.expandedNodeIds
     ) {
+      this._expandedNodes = new Set(nextProps.expandedNodeIds);
       this._visibleRows = this._getAllVisibleRows(nextProps);
     }
   }
@@ -356,7 +359,6 @@ class TreeView<
   _renderRow(nodeId: NodeIndex, index: number, columnIndex: number) {
     const {
       tree,
-      expandedNodeIds,
       fixedColumns,
       mainColumn,
       appendageColumn,
@@ -380,7 +382,7 @@ class TreeView<
       );
     }
     const canBeExpanded = tree.hasChildren(nodeId);
-    const isExpanded = expandedNodeIds.includes(nodeId);
+    const isExpanded = !this._isCollapsed(nodeId);
     return (
       <TreeViewRowScrolledColumns
         displayData={displayData}
@@ -408,7 +410,7 @@ class TreeView<
     depth: number
   ) {
     arr.push(nodeId);
-    if (!props.expandedNodeIds.includes(nodeId)) {
+    if (this._isCollapsed(nodeId)) {
       return;
     }
     const children = props.tree.getChildren(nodeId);
@@ -429,7 +431,7 @@ class TreeView<
   }
 
   _isCollapsed(nodeId: NodeIndex): boolean {
-    return !this.props.expandedNodeIds.includes(nodeId);
+    return !this._expandedNodes.has(nodeId);
   }
 
   _toggle(
@@ -437,7 +439,7 @@ class TreeView<
     newExpanded: boolean = this._isCollapsed(nodeId),
     toggleAll: * = false
   ) {
-    const newSet = new Set(this.props.expandedNodeIds);
+    const newSet = new Set(this._expandedNodes);
     if (newExpanded) {
       newSet.add(nodeId);
       if (toggleAll) {


### PR DESCRIPTION
The testcase is this profile: http://localhost:4242/public/280e10708c0660695ef5af145c53179d29d9796c/calltree/?hiddenThreads=&react_perf&thread=0&threadOrder=0-2-3-4-5-1&v=3

STR is:
1. Right click on "root"
2. Click "Expand All"
=> On my computer, this STR goes from 11s to 5s with this patch.
3. Then collapse a node
=> On my computer, this STR goes from 4.4s to 3.9s.
