### PR TITLE
Speed up getFlameGraphTiming by not calling getDisplayData (#844)

### DIFF
--- a/src/profile-logic/call-tree.js
+++ b/src/profile-logic/call-tree.js
@@ -170,6 +170,18 @@ export class CallTree {
     };
   }
 
+  getTimingDisplayData(callNodeIndex: IndexIntoCallNodeTable) {
+    const totalTime = this._callNodeTimes.totalTime[callNodeIndex];
+    const selfTime = this._callNodeTimes.selfTime[callNodeIndex];
+    const formatNumber = this._isIntegerInterval
+      ? _formatIntegerNumber
+      : _formatDecimalNumber;
+    return {
+      totalTime: `${formatNumber(totalTime)}`,
+      selfTime: selfTime === 0 ? '—' : `${formatNumber(selfTime)}`,
+    };
+  }
+
   getDisplayData(callNodeIndex: IndexIntoCallNodeTable): CallNodeDisplayData {
     let displayData = this._displayDataByIndex.get(callNodeIndex);
     if (displayData === undefined) {

--- a/src/profile-logic/call-tree.js
+++ b/src/profile-logic/call-tree.js
@@ -185,22 +185,13 @@ export class CallTree {
   getDisplayData(callNodeIndex: IndexIntoCallNodeTable): CallNodeDisplayData {
     let displayData = this._displayDataByIndex.get(callNodeIndex);
     if (displayData === undefined) {
-      const {
-        funcName,
-        totalTime,
-        totalTimeRelative,
-        selfTime,
-      } = this.getNodeData(callNodeIndex);
-
+      const { funcName, totalTimeRelative } = this.getNodeData(callNodeIndex);
       const funcIndex = this._callNodeTable.func[callNodeIndex];
       const resourceIndex = this._funcTable.resource[funcIndex];
       const resourceType = this._resourceTable.type[resourceIndex];
       const isJS = this._funcTable.isJS[funcIndex];
       const libName = this._getOriginAnnotation(funcIndex);
       const precision = this._isIntegerInterval ? 0 : 1;
-      const formatNumber = this._isIntegerInterval
-        ? _formatIntegerNumber
-        : _formatDecimalNumber;
 
       let icon = null;
       if (resourceType === resourceTypes.webhost) {
@@ -210,9 +201,8 @@ export class CallTree {
       }
 
       displayData = {
-        totalTime: `${formatNumber(totalTime)}`,
+        ...this.getTimingDisplayData(callNodeIndex),
         totalTimePercent: `${(100 * totalTimeRelative).toFixed(precision)}%`,
-        selfTime: selfTime === 0 ? '—' : `${formatNumber(selfTime)}`,
         name: funcName,
         lib: libName,
         // Dim platform pseudo-stacks.

--- a/src/profile-logic/flame-graph.js
+++ b/src/profile-logic/flame-graph.js
@@ -66,7 +66,7 @@ export function getFlameGraphTiming(
       nodeIndex
     );
 
-    const { totalTime, selfTime } = callTree.getDisplayData(nodeIndex);
+    const { totalTime, selfTime } = callTree.getTimingDisplayData(nodeIndex);
 
     // Select an existing row, or create a new one.
     let row = timing[depth];

--- a/src/test/unit/profile-tree.test.js
+++ b/src/test/unit/profile-tree.test.js
@@ -239,6 +239,15 @@ describe('unfiltered call tree', function() {
         });
       });
     });
+
+    describe('getTimingDisplayData()', function() {
+      it('gets formatted timing data for a given callNodeIndex', function() {
+        expect(callTree.getTimingDisplayData(D)).toEqual({
+          selfTime: '—',
+          totalTime: '1',
+        });
+      });
+    });
   });
 
   /**


### PR DESCRIPTION
Create a new CallTree method getTimingDisplayData which only returns
the formatted numbers needed by getFlameGraphTiming.