### PR TITLE
Fix symbolication on Windows by using lib.debugName instead of lib.name

### DIFF
--- a/src/profile-logic/symbolication.js
+++ b/src/profile-logic/symbolication.js
@@ -156,7 +156,7 @@ function getThreadSymbolicationInfo(thread: Thread): ThreadSymbolicationInfo {
   const { funcTable } = thread;
   const libKeyToAddressToFuncMap = new Map();
   for (const [lib, funcsToSymbolicate] of foundFuncMap) {
-    const libKey = `${lib.name}/${lib.breakpadId}`;
+    const libKey = `${lib.debugName}/${lib.breakpadId}`;
     const addressToFuncMap = new Map();
     libKeyToAddressToFuncMap.set(libKey, addressToFuncMap);
     for (const funcIndex of funcsToSymbolicate) {


### PR DESCRIPTION
Symbolication is currently broken because I made a mistake in #830. This patch fixes it and adds a test.