### PR TITLE
Remove upgrade-insecure-requests from CSP; Resolves #727

### DIFF
--- a/res/.htaccess
+++ b/res/.htaccess
@@ -44,6 +44,4 @@ Header set Referrer-Policy same-origin
 # 5. `connect-src` is `*` to support `from-url`. We also do requests to bitly to shorten URLs.
 # 6. `frame-ancestors` is the same purpose as `X-Frame-Options` above.
 # 7. `form-action`prevents forms, we don't need this.`
-# 8. `upgrade-insecure-requests` instructs the browser to upgrade all insecure
-#     requests to HTTPS, but only the ones to the same hostname.
-Header always add Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-eRTCQnd2fhPykpATDzCv4gdVk/EOdDq+6yzFXaWgGEw=' 'sha256-AdiT28wTL5FNaRVHWQVFC0ic3E20Gu4/PiC9xukS9+E=' https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src *; object-src 'none'; connect-src *; frame-ancestors 'self'; form-action 'none'; upgrade-insecure-requests"
+Header always add Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-eRTCQnd2fhPykpATDzCv4gdVk/EOdDq+6yzFXaWgGEw=' 'sha256-AdiT28wTL5FNaRVHWQVFC0ic3E20Gu4/PiC9xukS9+E=' https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src *; object-src 'none'; connect-src *; frame-ancestors 'self'; form-action 'none'"

--- a/server.js
+++ b/server.js
@@ -36,7 +36,7 @@ const serverConfig = {
       connect-src *;
       frame-ancestors 'self';
       form-action 'none'
-    `, // NOTE: no upgrade-insecure-requests because we're serving as HTTP.
+    `,
   },
   stats: {
     colors: true,

--- a/src/profile-logic/call-tree.js
+++ b/src/profile-logic/call-tree.js
@@ -40,6 +40,10 @@ type CallTreeCountsAndTimings = {
 
 function extractFaviconFromLibname(libname: string): string | null {
   const url = new URL('/favicon.ico', libname);
+  if (url.protocol === 'http:') {
+    // Upgrade http requests.
+    url.protocol = 'https:';
+  }
   return url.href;
 }
 

--- a/src/test/unit/profile-tree.test.js
+++ b/src/test/unit/profile-tree.test.js
@@ -11,6 +11,7 @@ import {
 import {
   getCallNodeInfo,
   invertCallstack,
+  resourceTypes,
   getCallNodeIndexFromPath,
   getOriginAnnotationForFunc,
 } from '../../profile-logic/profile-data';
@@ -246,6 +247,26 @@ describe('unfiltered call tree', function() {
           totalTime: '3',
           totalTimePercent: '100%',
         });
+      });
+    });
+
+    describe('icons from the call tree', function() {
+      it('upgrades http to https', function() {
+        const { profile } = getProfileFromTextSamples(`
+          A:examplecom.js
+        `);
+        const callTree = callTreeFromProfile(profile);
+        const [thread] = profile.threads;
+        const hostStringIndex = thread.stringTable.indexForString('examplecom');
+
+        thread.resourceTable.type[0] = resourceTypes.webhost;
+        thread.resourceTable.host[0] = hostStringIndex;
+        // Hijack the string table to provide the proper host name
+        thread.stringTable._array[hostStringIndex] = 'http://example.com';
+
+        expect(callTree.getDisplayData(A).icon).toEqual(
+          'https://example.com/favicon.ico'
+        );
       });
     });
 


### PR DESCRIPTION
I never got direct feedback on going ahead with #727, but this will unblock:
https://bugzilla.mozilla.org/show_bug.cgi?id=1425308

I added work to mitigate any issues with calling out over http for call tree favicons.

I also tested locally and I was able to serve a profile and open it.