### PR TITLE
Convert ctx.clearRect to ctx.fillRect to fix perf issues; Resolves #897

### DIFF
--- a/src/components/flame-graph/Canvas.js
+++ b/src/components/flame-graph/Canvas.js
@@ -243,7 +243,8 @@ class FlameGraphCanvas extends React.PureComponent<Props> {
     }
     const textMeasurement = this._textMeasurement;
 
-    ctx.clearRect(0, 0, containerWidth, containerHeight);
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, containerWidth, containerHeight);
 
     const startDepth = Math.floor(
       maxStackDepth - viewportBottom / stackFrameHeight
@@ -305,7 +306,8 @@ class FlameGraphCanvas extends React.PureComponent<Props> {
         ctx.fillStyle = isSelected ? 'Highlight' : background;
         ctx.fillRect(x, y, w, h);
         // Ensure spacing between blocks.
-        ctx.clearRect(x, y, 1, h);
+        ctx.fillStyle = '#ffffff';
+        ctx.fillRect(x, y, 1, h);
 
         // TODO - L10N RTL.
         // Constrain the x coordinate to the leftmost area.

--- a/src/components/header/IntervalMarkerOverview.js
+++ b/src/components/header/IntervalMarkerOverview.js
@@ -252,12 +252,13 @@ class IntervalMarkerOverview extends React.PureComponent<Props, State> {
       c.width = pixelWidth;
       c.height = pixelHeight;
     }
-    const ctx = c.getContext('2d');
+    const ctx = c.getContext('2d', { alpha: false });
     if (ctx === null || ctx === undefined) {
       return;
     }
 
-    ctx.clearRect(0, 0, pixelWidth, pixelHeight);
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, pixelWidth, pixelHeight);
     ctx.scale(devicePixelRatio, devicePixelRatio);
 
     intervalMarkers.forEach(marker => {

--- a/src/components/header/ThreadStackGraph.js
+++ b/src/components/header/ThreadStackGraph.js
@@ -82,7 +82,9 @@ class ThreadStackGraph extends PureComponent<Props> {
     const rect = canvas.getBoundingClientRect();
     canvas.width = Math.round(rect.width * devicePixelRatio);
     canvas.height = Math.round(rect.height * devicePixelRatio);
-    const ctx = canvas.getContext('2d');
+    const ctx = canvas.getContext('2d', { alpha: false });
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
     let maxDepth = 0;
     const { callNodeTable, stackIndexToCallNodeIndex } = callNodeInfo;
     const sampleCallNodes = getSampleCallNodes(

--- a/src/components/marker-chart/Canvas.js
+++ b/src/components/marker-chart/Canvas.js
@@ -93,7 +93,8 @@ class MarkerChartCanvas extends React.PureComponent<Props, State> {
       markerTimingRows.length
     );
 
-    ctx.clearRect(0, 0, containerWidth, containerHeight);
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, containerWidth, containerHeight);
 
     this.drawMarkers(ctx, hoveredItem, startRow, endRow);
     this.drawSeparatorsAndLabels(ctx, startRow, endRow);

--- a/src/components/shared/chart/Canvas.js
+++ b/src/components/shared/chart/Canvas.js
@@ -79,7 +79,7 @@ export default class ChartCanvas<HoveredItem> extends React.Component<
       return;
     }
     // Satisfy the null check for Flow.
-    const ctx = this._ctx || canvas.getContext('2d');
+    const ctx = this._ctx || canvas.getContext('2d', { alpha: false });
     if (!this._ctx) {
       this._ctx = ctx;
     }

--- a/src/components/stack-chart/Canvas.js
+++ b/src/components/stack-chart/Canvas.js
@@ -105,7 +105,8 @@ class StackChartCanvas extends React.PureComponent<Props> {
     }
     const textMeasurement = this._textMeasurement;
 
-    ctx.clearRect(0, 0, containerWidth, containerHeight);
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, containerWidth, containerHeight);
 
     const rangeLength: Milliseconds = rangeEnd - rangeStart;
     const viewportLength: UnitIntervalOfProfileRange =
@@ -171,8 +172,10 @@ class StackChartCanvas extends React.PureComponent<Props> {
 
           ctx.fillStyle = isHovered ? 'Highlight' : category.color;
           ctx.fillRect(x, y, w, h);
+
           // Ensure spacing between blocks.
-          ctx.clearRect(x, y, 1, h);
+          ctx.fillStyle = '#ffffff';
+          ctx.fillRect(x, y, 1, h);
 
           // TODO - L10N RTL.
           // Constrain the x coordinate to the leftmost area.

--- a/src/test/components/__snapshots__/FlameGraph.test.js.snap
+++ b/src/test/components/__snapshots__/FlameGraph.test.js.snap
@@ -181,7 +181,11 @@ Array [
     "…",
   ],
   Array [
-    "clearRect",
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
     0,
     0,
     200,
@@ -199,7 +203,11 @@ Array [
     15,
   ],
   Array [
-    "clearRect",
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
     0,
     284,
     1,
@@ -231,7 +239,11 @@ Array [
     15,
   ],
   Array [
-    "clearRect",
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
     0,
     268,
     1,
@@ -263,7 +275,11 @@ Array [
     15,
   ],
   Array [
-    "clearRect",
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
     0,
     252,
     1,
@@ -295,7 +311,11 @@ Array [
     15,
   ],
   Array [
-    "clearRect",
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
     133.33333333333331,
     252,
     1,
@@ -327,7 +347,11 @@ Array [
     15,
   ],
   Array [
-    "clearRect",
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
     0,
     236,
     1,
@@ -359,7 +383,11 @@ Array [
     15,
   ],
   Array [
-    "clearRect",
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
     66.66666666666666,
     236,
     1,
@@ -391,7 +419,11 @@ Array [
     15,
   ],
   Array [
-    "clearRect",
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
     133.33333333333331,
     236,
     1,
@@ -423,7 +455,11 @@ Array [
     15,
   ],
   Array [
-    "clearRect",
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
     0,
     220,
     1,
@@ -455,7 +491,11 @@ Array [
     15,
   ],
   Array [
-    "clearRect",
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
     66.66666666666666,
     220,
     1,

--- a/src/test/components/__snapshots__/MarkerChart.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerChart.test.js.snap
@@ -56,7 +56,11 @@ Array [
     1,
   ],
   Array [
-    "clearRect",
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
     0,
     0,
     200,

--- a/src/test/components/__snapshots__/ProfileThreadTracingMarkerOverview.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileThreadTracingMarkerOverview.test.js.snap
@@ -17,7 +17,11 @@ exports[`ProfileThreadTracingMarkerOverview renders correctly 1`] = `
 exports[`ProfileThreadTracingMarkerOverview renders correctly 2`] = `
 Array [
   Array [
-    "clearRect",
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
     0,
     0,
     200,

--- a/src/test/components/__snapshots__/ProfileViewerHeader.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileViewerHeader.test.js.snap
@@ -345,6 +345,17 @@ exports[`calltree/ProfileViewerHeader renders the header 2`] = `
 Array [
   Array [
     "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    200,
+    300,
+  ],
+  Array [
+    "set fillStyle",
     "#45a1ff",
   ],
   Array [
@@ -416,32 +427,14 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#45a1ff",
+    "#ffffff",
   ],
   Array [
     "fillRect",
-    88.88888888888889,
     0,
-    22.22222222222222,
-    300,
-  ],
-  Array [
-    "fillRect",
-    111.11111111111111,
     0,
-    22.22222222222222,
+    200,
     300,
-  ],
-  Array [
-    "fillRect",
-    133.33333333333331,
-    75,
-    22.22222222222222,
-    225,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
   ],
   Array [
     "set fillStyle",
@@ -473,7 +466,51 @@ Array [
     "#003eaa",
   ],
   Array [
-    "clearRect",
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    200,
+    300,
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff",
+  ],
+  Array [
+    "fillRect",
+    88.88888888888889,
+    0,
+    22.22222222222222,
+    300,
+  ],
+  Array [
+    "fillRect",
+    111.11111111111111,
+    0,
+    22.22222222222222,
+    300,
+  ],
+  Array [
+    "fillRect",
+    133.33333333333331,
+    75,
+    22.22222222222222,
+    225,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
     0,
     0,
     300,
@@ -490,7 +527,11 @@ Array [
     1,
   ],
   Array [
-    "clearRect",
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
     0,
     0,
     300,
@@ -507,7 +548,11 @@ Array [
     1,
   ],
   Array [
-    "clearRect",
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
     0,
     0,
     300,

--- a/src/test/components/__snapshots__/StackChart.test.js.snap
+++ b/src/test/components/__snapshots__/StackChart.test.js.snap
@@ -155,7 +155,11 @@ Array [
     "…",
   ],
   Array [
-    "clearRect",
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
     0,
     0,
     200,
@@ -173,7 +177,11 @@ Array [
     15,
   ],
   Array [
-    "clearRect",
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
     0,
     0,
     1,
@@ -205,7 +213,11 @@ Array [
     15,
   ],
   Array [
-    "clearRect",
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
     0,
     16,
     1,
@@ -237,7 +249,11 @@ Array [
     15,
   ],
   Array [
-    "clearRect",
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
     0,
     32,
     1,
@@ -269,7 +285,11 @@ Array [
     15,
   ],
   Array [
-    "clearRect",
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
     133.33333333333331,
     32,
     1,
@@ -301,7 +321,11 @@ Array [
     15,
   ],
   Array [
-    "clearRect",
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
     0,
     48,
     1,
@@ -333,7 +357,11 @@ Array [
     15,
   ],
   Array [
-    "clearRect",
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
     66.66666666666666,
     48,
     1,
@@ -365,7 +393,11 @@ Array [
     15,
   ],
   Array [
-    "clearRect",
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
     133.33333333333331,
     48,
     1,
@@ -397,7 +429,11 @@ Array [
     15,
   ],
   Array [
-    "clearRect",
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
     0,
     64,
     1,
@@ -429,7 +465,11 @@ Array [
     15,
   ],
   Array [
-    "clearRect",
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
     66.66666666666666,
     64,
     1,


### PR DESCRIPTION
Here is a profile which is much more interactive than the one in the bug: https://perfht.ml/2JfE1Rv

Also this PR makes all of our canvases non-transparent.

Resolves #897