### PR TITLE
Revert to clearRect in the ThreadStackGraph

### DIFF
--- a/src/components/header/IntervalMarkerOverview.js
+++ b/src/components/header/IntervalMarkerOverview.js
@@ -252,13 +252,12 @@ class IntervalMarkerOverview extends React.PureComponent<Props, State> {
       c.width = pixelWidth;
       c.height = pixelHeight;
     }
-    const ctx = c.getContext('2d', { alpha: false });
+    const ctx = c.getContext('2d');
     if (ctx === null || ctx === undefined) {
       return;
     }
 
-    ctx.fillStyle = '#ffffff';
-    ctx.fillRect(0, 0, pixelWidth, pixelHeight);
+    ctx.clearRect(0, 0, pixelWidth, pixelHeight);
     ctx.scale(devicePixelRatio, devicePixelRatio);
 
     intervalMarkers.forEach(marker => {

--- a/src/components/header/ThreadStackGraph.js
+++ b/src/components/header/ThreadStackGraph.js
@@ -82,9 +82,7 @@ class ThreadStackGraph extends PureComponent<Props> {
     const rect = canvas.getBoundingClientRect();
     canvas.width = Math.round(rect.width * devicePixelRatio);
     canvas.height = Math.round(rect.height * devicePixelRatio);
-    const ctx = canvas.getContext('2d', { alpha: false });
-    ctx.fillStyle = '#ffffff';
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    const ctx = canvas.getContext('2d');
     let maxDepth = 0;
     const { callNodeTable, stackIndexToCallNodeIndex } = callNodeInfo;
     const sampleCallNodes = getSampleCallNodes(

--- a/src/test/components/__snapshots__/ProfileThreadTracingMarkerOverview.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileThreadTracingMarkerOverview.test.js.snap
@@ -17,11 +17,7 @@ exports[`ProfileThreadTracingMarkerOverview renders correctly 1`] = `
 exports[`ProfileThreadTracingMarkerOverview renders correctly 2`] = `
 Array [
   Array [
-    "set fillStyle",
-    "#ffffff",
-  ],
-  Array [
-    "fillRect",
+    "clearRect",
     0,
     0,
     200,

--- a/src/test/components/__snapshots__/ProfileViewerHeader.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileViewerHeader.test.js.snap
@@ -345,17 +345,6 @@ exports[`calltree/ProfileViewerHeader renders the header 2`] = `
 Array [
   Array [
     "set fillStyle",
-    "#ffffff",
-  ],
-  Array [
-    "fillRect",
-    0,
-    0,
-    200,
-    300,
-  ],
-  Array [
-    "set fillStyle",
     "#45a1ff",
   ],
   Array [
@@ -427,14 +416,32 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#ffffff",
+    "#45a1ff",
   ],
   Array [
     "fillRect",
+    88.88888888888889,
     0,
-    0,
-    200,
+    22.22222222222222,
     300,
+  ],
+  Array [
+    "fillRect",
+    111.11111111111111,
+    0,
+    22.22222222222222,
+    300,
+  ],
+  Array [
+    "fillRect",
+    133.33333333333331,
+    75,
+    22.22222222222222,
+    225,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
   ],
   Array [
     "set fillStyle",
@@ -466,51 +473,7 @@ Array [
     "#003eaa",
   ],
   Array [
-    "set fillStyle",
-    "#ffffff",
-  ],
-  Array [
-    "fillRect",
-    0,
-    0,
-    200,
-    300,
-  ],
-  Array [
-    "set fillStyle",
-    "#45a1ff",
-  ],
-  Array [
-    "fillRect",
-    88.88888888888889,
-    0,
-    22.22222222222222,
-    300,
-  ],
-  Array [
-    "fillRect",
-    111.11111111111111,
-    0,
-    22.22222222222222,
-    300,
-  ],
-  Array [
-    "fillRect",
-    133.33333333333331,
-    75,
-    22.22222222222222,
-    225,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "set fillStyle",
-    "#ffffff",
-  ],
-  Array [
-    "fillRect",
+    "clearRect",
     0,
     0,
     300,
@@ -527,11 +490,7 @@ Array [
     1,
   ],
   Array [
-    "set fillStyle",
-    "#ffffff",
-  ],
-  Array [
-    "fillRect",
+    "clearRect",
     0,
     0,
     300,
@@ -548,11 +507,7 @@ Array [
     1,
   ],
   Array [
-    "set fillStyle",
-    "#ffffff",
-  ],
-  Array [
-    "fillRect",
+    "clearRect",
     0,
     0,
     300,


### PR DESCRIPTION
This clearRect PR was a bit too aggressive, as we show the highlighted thread with the background color.