### PR TITLE
Don't display non-working disclosure arrows in the marker table tree.

### DIFF
--- a/src/components/marker-table/index.js
+++ b/src/components/marker-table/index.js
@@ -61,15 +61,8 @@ class MarkerTree {
     return markerIndex === -1 ? this.getRoots() : [];
   }
 
-  hasChildren(markerIndex: IndexIntoMarkersTable): boolean {
-    // If this marker has a cause callstack, indicate it with a tree disclosure
-    // arrow. However, we don't currently support expanding those marker nodes
-    // or displaying the cause callstacks, so this is not the greatest piece
-    // of UI.
-    return (
-      this._markers.data[markerIndex] !== null &&
-      'cause' in this._markers.data[markerIndex]
-    );
+  hasChildren(_markerIndex: IndexIntoMarkersTable): boolean {
+    return false;
   }
 
   getAllDescendants() {


### PR DESCRIPTION
Fixes #912.