### PR TITLE
Simplify the style for selected rows, makes the appendage column colo…

### DIFF
--- a/res/style.css
+++ b/res/style.css
@@ -169,26 +169,23 @@ body, #root, .profileViewer {
 
 .treeViewAppendageColumn {
   margin-left: 10px;
-  color: #999;
+  opacity: 0.6;
 }
 
-.treeViewRow.even, .treeViewRow.even > .treeViewFixedColumn {
+.treeViewRow.even {
   background-color: #FFFFFF;
 }
-.treeViewRow.odd, .treeViewRow.odd > .treeViewFixedColumn {
+.treeViewRow.odd {
   background-color: #F5F5F5;
 }
-.treeViewRow.selected,
-.treeViewRow.selected > .treeViewFixedColumn {
+.treeViewRow.selected {
   background-color: -moz-dialog;
   color: black;
 }
 .treeViewRow.dim > .treeViewMainColumn {
-  color: #aaa;
+  opacity: 0.7
 }
-.treeViewBody:focus > * > * > * > .treeViewRow.selected,
-.treeViewBody:focus > * > * > * > .treeViewRow.selected a,
-.treeViewBody:focus > * > * > * > .treeViewRow.selected > .treeViewFixedColumn {
+.treeViewBody:focus .treeViewRow.selected {
   background-color: highlight;
   color: highlighttext;
 }


### PR DESCRIPTION
…r more visible when selected

On my Linux (I think the colors are different on Mac and Windows):
Before:
![image](https://user-images.githubusercontent.com/454175/38615047-9a10684a-3d8f-11e8-9a0c-f0a2ed2dbfa9.png)

After:
![image](https://user-images.githubusercontent.com/454175/38615082-b619a240-3d8f-11e8-9480-516cbdb7376d.png)
