### PR TITLE
Restore double click behaviour in shared canvas component (#927)

### DIFF
--- a/src/components/shared/chart/Canvas.js
+++ b/src/components/shared/chart/Canvas.js
@@ -153,7 +153,10 @@ export default class ChartCanvas<HoveredItem> extends React.Component<
     // component to clear the hovered item.  Thus, at the time when
     // this event handler is called, `this.state.hoveredItem` is null.
     // Obtain the hovered item from the mouse event instead.
-    const maybeHoveredItem = this._hoveredItemFromMouseEvent(event);
+    const maybeHoveredItem =
+      this.state.hoveredItem === null
+        ? this._hoveredItemFromMouseEvent(event)
+        : this.state.hoveredItem;
     this.props.onDoubleClickItem(maybeHoveredItem);
   }
 


### PR DESCRIPTION
The solution to #922 would replace the code in this PR with something cleaner.