### PR TITLE
Add Network load tooltips for markers

### DIFF
--- a/src/components/shared/MarkerTooltipContents.js
+++ b/src/components/shared/MarkerTooltipContents.js
@@ -318,6 +318,14 @@ function getMarkerDetails(
           </div>
         );
       }
+      case 'Network': {
+        return (
+          <div className="tooltipDetails">
+            {_markerDetail('url', 'URL', data.URI)}
+            {_markerDetail('status', 'Status', data.status)}
+          </div>
+        );
+      }
       case 'Styles': {
         return [
           <div className="tooltipDetails" key="details">

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -261,6 +261,22 @@ export type InvalidationPayload = {
 };
 
 /**
+ * Network http/https loads - one marker for each notification of network
+ * state that occurs, plus one for the initial START of the load, with the URI
+ * and the status.  A unique ID is included to allow these to be linked.
+ * Note that the 'name' field currently also has the id ("Load N") so that
+ * marker.js will not merge separate loads.
+ */
+export type NetworkPayload = {
+  type: 'Network',
+  URI: string,
+  id: number,
+  status: string,
+  startTime: Milliseconds,
+  endTime: Milliseconds,
+};
+
+/**
  * The payload for the UserTimings API. These are added through performance.measure()
  * and performance.mark(). https://developer.mozilla.org/en-US/docs/Web/API/Performance
  */
@@ -320,6 +336,7 @@ export type MarkerPayload =
   | GPUMarkerPayload
   | BailoutPayload
   | InvalidationPayload
+  | NetworkPayload
   | UserTimingMarkerPayload
   | PaintProfilerMarkerTracing
   | DOMEventMarkerPayload


### PR DESCRIPTION
This adds tooltips for markers based on Bug 1453387.  URL is visible only on the START status entry at this point, but if we add it to the other markers it will pick the URL up and show it.