### PR TITLE
Fix a property type for a marker

### DIFF
--- a/src/test/components/MarkerTooltipContents.test.js
+++ b/src/test/components/MarkerTooltipContents.test.js
@@ -153,7 +153,7 @@ describe('MarkerTooltipContents', function() {
               slice: 1,
               pause: 5,
               when: 17.5,
-              budget: 11,
+              budget: '11ms',
               initial_state: 'Initial',
               final_state: 'Final',
               major_gc_number: 1,

--- a/src/test/components/__snapshots__/MarkerTooltipContents.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerTooltipContents.test.js.snap
@@ -529,7 +529,7 @@ Array [
         Budget
         :
       </div>
-      11
+      11ms
       <div
         className="tooltipLabel"
       >

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -60,7 +60,7 @@ type GCSliceData_Shared = {
   final_state: string,
 
   // The incremental GC budget for this slice (see pause above).
-  budget: Milliseconds,
+  budget: string,
 
   // The number of the GCMajor that this slice belongs to.
   major_gc_number: number,


### PR DESCRIPTION
The GCMinor slice budget is stored as a string, not a number, so this patch
tells flow that it is a string.