### PR TITLE
Scroll to selected call node in flame graph

### DIFF
--- a/src/components/flame-graph/Canvas.js
+++ b/src/components/flame-graph/Canvas.js
@@ -217,6 +217,19 @@ class FlameGraphCanvas extends React.PureComponent<Props> {
     (this: any)._hitTest = this._hitTest.bind(this);
   }
 
+  componentDidUpdate(prevProps) {
+    // If the stack depth changes (say, when changing the time range
+    // selection or applying a transform), move the viewport
+    // vertically so that its offset from the base of the flame graph
+    // is maintained.
+    if (prevProps.maxStackDepth !== this.props.maxStackDepth) {
+      this.props.viewport.moveViewport(
+        0,
+        (prevProps.maxStackDepth - this.props.maxStackDepth) * ROW_HEIGHT
+      );
+    }
+  }
+
   _drawCanvas(
     ctx: CanvasRenderingContext2D,
     hoveredItem: HoveredStackTiming | null

--- a/src/components/flame-graph/Canvas.js
+++ b/src/components/flame-graph/Canvas.js
@@ -37,6 +37,7 @@ export type OwnProps = {|
   +selectedCallNodeIndex: IndexIntoCallNodeTable | null,
   +onSelectionChange: (IndexIntoCallNodeTable | null) => void,
   +disableTooltips: boolean,
+  +scrollToSelectionGeneration: number,
 |};
 
 type Props = {|
@@ -218,17 +219,55 @@ class FlameGraphCanvas extends React.PureComponent<Props> {
   }
 
   componentDidUpdate(prevProps) {
-    // If the stack depth changes (say, when changing the time range
-    // selection or applying a transform), move the viewport
-    // vertically so that its offset from the base of the flame graph
-    // is maintained.
-    if (prevProps.maxStackDepth !== this.props.maxStackDepth) {
+    // We want to scroll the selection into view when this component
+    // is mounted, but using componentDidMount won't work here as the
+    // viewport will not have completed setting its size by
+    // then. Instead, look for when the viewport's isSizeSet prop
+    // changes to true.
+    const viewportDidMount =
+      !prevProps.viewport.isSizeSet && this.props.viewport.isSizeSet;
+
+    if (
+      viewportDidMount ||
+      this.props.scrollToSelectionGeneration >
+        prevProps.scrollToSelectionGeneration
+    ) {
+      this._scrollSelectionIntoView();
+    } else if (prevProps.maxStackDepth !== this.props.maxStackDepth) {
+      // If the stack depth changes (say, when changing the time range
+      // selection or applying a transform), move the viewport
+      // vertically so that its offset from the base of the flame graph
+      // is maintained.
       this.props.viewport.moveViewport(
         0,
         (prevProps.maxStackDepth - this.props.maxStackDepth) * ROW_HEIGHT
       );
     }
   }
+
+  _scrollSelectionIntoView = () => {
+    const {
+      selectedCallNodeIndex,
+      maxStackDepth,
+      callNodeInfo: { callNodeTable },
+    } = this.props;
+
+    if (selectedCallNodeIndex === null) {
+      return;
+    }
+
+    const depth = callNodeTable.depth[selectedCallNodeIndex];
+    const y = (maxStackDepth - depth - 1) * ROW_HEIGHT;
+
+    if (y < this.props.viewport.viewportTop) {
+      this.props.viewport.moveViewport(0, this.props.viewport.viewportTop - y);
+    } else if (y + ROW_HEIGHT > this.props.viewport.viewportBottom) {
+      this.props.viewport.moveViewport(
+        0,
+        this.props.viewport.viewportBottom - (y + ROW_HEIGHT)
+      );
+    }
+  };
 
   _drawCanvas(
     ctx: CanvasRenderingContext2D,

--- a/src/components/flame-graph/FlameGraph.js
+++ b/src/components/flame-graph/FlameGraph.js
@@ -10,6 +10,7 @@ import {
   selectedThreadSelectors,
   getDisplayRange,
   getProfileViewOptions,
+  getScrollToSelectionGeneration,
 } from '../../reducers/profile-view';
 import {
   getSelectedThreadIndex,
@@ -53,6 +54,7 @@ type StateProps = {|
   +selectedCallNodeIndex: IndexIntoCallNodeTable | null,
   +isCallNodeContextMenuVisible: boolean,
   +invertCallstack: boolean,
+  +scrollToSelectionGeneration: number,
 |};
 type DispatchProps = {|
   +changeSelectedCallNode: typeof changeSelectedCallNode,
@@ -89,6 +91,7 @@ class FlameGraph extends React.PureComponent<Props> {
       selectedCallNodeIndex,
       isCallNodeContextMenuVisible,
       invertCallstack,
+      scrollToSelectionGeneration,
     } = this.props;
 
     if (invertCallstack) {
@@ -137,6 +140,7 @@ class FlameGraph extends React.PureComponent<Props> {
               flameGraphTiming,
               callNodeInfo,
               selectedCallNodeIndex,
+              scrollToSelectionGeneration,
               stackFrameHeight: STACK_FRAME_HEIGHT,
               onSelectionChange: this._onSelectedCallNodeChange,
               disableTooltips: isCallNodeContextMenuVisible,
@@ -176,6 +180,7 @@ const options: ExplicitConnectOptions<{||}, StateProps, DispatchProps> = {
       isCallNodeContextMenuVisible: getProfileViewOptions(state)
         .isCallNodeContextMenuVisible,
       invertCallstack: getInvertCallstack(state),
+      scrollToSelectionGeneration: getScrollToSelectionGeneration(state),
     };
   },
   mapDispatchToProps: {

--- a/src/components/flame-graph/FlameGraph.js
+++ b/src/components/flame-graph/FlameGraph.js
@@ -148,12 +148,12 @@ class FlameGraph extends React.PureComponent<Props> {
   }
 }
 
-// This function is given the FlameGraphCanvas's chartProps.
-function viewportNeedsUpdate(
-  prevProps: { +flameGraphTiming: FlameGraphTiming },
-  newProps: { +flameGraphTiming: FlameGraphTiming }
-) {
-  return prevProps.flameGraphTiming !== newProps.flameGraphTiming;
+function viewportNeedsUpdate() {
+  // By always returning false we prevent the viewport from being
+  // reset and scrolled all the way to the bottom when doing
+  // operations like changing the time selection or applying a
+  // transform.
+  return false;
 }
 
 const options: ExplicitConnectOptions<{||}, StateProps, DispatchProps> = {

--- a/src/components/shared/chart/Viewport.js
+++ b/src/components/shared/chart/Viewport.js
@@ -54,8 +54,8 @@ const { DOM_DELTA_PAGE, DOM_DELTA_LINE } =
     ? new WheelEvent('mouse')
     : { DOM_DELTA_LINE: 1, DOM_DELTA_PAGE: 2 };
 
-// These viewport values are computed dynamically by the HOC, and then passed into
-// the props of the wrapped component.
+// These viewport values (most of which are computed dynamically by
+// the HOC) are passed into the props of the wrapped component.
 export type Viewport = {|
   +containerWidth: CssPixels,
   +containerHeight: CssPixels,
@@ -64,6 +64,7 @@ export type Viewport = {|
   +viewportTop: CssPixels,
   +viewportBottom: CssPixels,
   +isDragging: boolean,
+  +moveViewport: (CssPixels, CssPixels) => boolean,
 |};
 
 type ViewportStateProps = {|
@@ -161,6 +162,7 @@ export const withChartViewport: WithChartViewport<*, *> =
 
       constructor(props: ViewportProps) {
         super(props);
+        (this: any).moveViewport = this.moveViewport.bind(this);
         (this: any)._mouseWheelListener = this._mouseWheelListener.bind(this);
         (this: any)._mouseDownListener = this._mouseDownListener.bind(this);
         (this: any)._mouseMoveListener = this._mouseMoveListener.bind(this);
@@ -557,6 +559,7 @@ export const withChartViewport: WithChartViewport<*, *> =
           viewportTop,
           viewportBottom,
           isDragging,
+          moveViewport: this.moveViewport,
         };
 
         return (

--- a/src/components/shared/chart/Viewport.js
+++ b/src/components/shared/chart/Viewport.js
@@ -65,6 +65,7 @@ export type Viewport = {|
   +viewportBottom: CssPixels,
   +isDragging: boolean,
   +moveViewport: (CssPixels, CssPixels) => boolean,
+  +isSizeSet: boolean,
 |};
 
 type ViewportStateProps = {|
@@ -113,6 +114,7 @@ type State = {|
   dragY: CssPixels,
   isDragging: boolean,
   isShiftScrollHintVisible: boolean,
+  isSizeSet: boolean,
 |};
 
 require('./Viewport.css');
@@ -212,6 +214,7 @@ export const withChartViewport: WithChartViewport<*, *> =
           dragY: 0,
           isDragging: false,
           isShiftScrollHintVisible: false,
+          isSizeSet: false,
         };
       }
 
@@ -272,6 +275,7 @@ export const withChartViewport: WithChartViewport<*, *> =
               viewportTop: startsAtBottom
                 ? prevState.viewportBottom - rect.height
                 : prevState.viewportTop,
+              isSizeSet: true,
             }));
           }
         }
@@ -539,6 +543,7 @@ export const withChartViewport: WithChartViewport<*, *> =
           viewportRight,
           isDragging,
           isShiftScrollHintVisible,
+          isSizeSet,
         } = this.state;
 
         const viewportClassName = classNames({
@@ -560,6 +565,7 @@ export const withChartViewport: WithChartViewport<*, *> =
           viewportBottom,
           isDragging,
           moveViewport: this.moveViewport,
+          isSizeSet,
         };
 
         return (


### PR DESCRIPTION
This PR also makes sure the selected call node scrolls into view when switching tabs (that is, when the flame graph canvas is mounted)