### PR TITLE
(WIP) Run Jest concurrently in CircleCI 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
       - run: yarn lint
       - run: yarn flow --quiet
       - run: yarn flow stop # stop flow to recover some memory
-      - run: yarn test --coverage --runInBand
+      - run: yarn test --coverage
       - run: yarn build-prod:quiet
       - run: bash <(curl -s https://codecov.io/bash)
 


### PR DESCRIPTION
Previously I configured Jest to run sequentially in CI because the available memory was too small and this was very slow. Now that we moved to CircleCI 2.0 in #986 we can try running this concurrently again.