### PR TITLE
Fix a thrown error for transitioning the URL state with zip files

### DIFF
--- a/src/reducers/zipped-profiles.js
+++ b/src/reducers/zipped-profiles.js
@@ -33,6 +33,24 @@ function zipFile(
   action: Action
 ): ZipFileState {
   switch (action.type) {
+    case 'UPDATE_URL_STATE': {
+      if (
+        action.newUrlState.pathInZipFile === null &&
+        state.phase === 'VIEW_PROFILE_IN_ZIP_FILE'
+      ) {
+        // When the back button is hit on the browser, the UrlState can update, but
+        // the state of the zip file viewer can be out of date. In this case, make
+        // sure and revert the state back to LIST_FILES_IN_ZIP_FILE rather than
+        // VIEW_PROFILE_IN_ZIP_FILE. Otherwise the zip file viewer will try and
+        // display a profile that does not exist.
+        return _validateStateTransition(state, {
+          phase: 'LIST_FILES_IN_ZIP_FILE',
+          zip: state.zip,
+          pathInZipFile: null,
+        });
+      }
+      return state;
+    }
     case 'RECEIVE_ZIP_FILE':
       return _validateStateTransition(state, {
         phase: 'LIST_FILES_IN_ZIP_FILE',


### PR DESCRIPTION
There is an edge case where the URL state goes back to a previous
state where there is no profile, but the zip file state assumes
that one does exist. This commit adds an extra check in the reducer
to handle this problem.