### PR TITLE
Change child-src to frame-src to fix CSP issues

### DIFF
--- a/res/_headers
+++ b/res/_headers
@@ -29,5 +29,5 @@
   # 5. `connect-src` is `*` to support `from-url`. We also do requests to bitly to shorten URLs.
   # 6. `frame-ancestors` is the same purpose as `X-Frame-Options` above.
   # 7. `form-action`prevents forms, we don't need this.`
-  # 8. `child-src` allows the embedding of YouTube videos in the docs.
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'sha256-eRTCQnd2fhPykpATDzCv4gdVk/EOdDq+6yzFXaWgGEw=' 'sha256-AdiT28wTL5FNaRVHWQVFC0ic3E20Gu4/PiC9xukS9+E=' https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src *; object-src 'none'; connect-src *; frame-ancestors 'self'; form-action 'none'; child-src www.youtube-nocookie.com
+  # 8. `frame-src` allows the embedding of YouTube videos in the docs.
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'sha256-eRTCQnd2fhPykpATDzCv4gdVk/EOdDq+6yzFXaWgGEw=' 'sha256-AdiT28wTL5FNaRVHWQVFC0ic3E20Gu4/PiC9xukS9+E=' https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src *; object-src 'none'; connect-src *; frame-ancestors 'self'; form-action 'none'; frame-src www.youtube-nocookie.com


### PR DESCRIPTION
Resolves #1027 

I manually tested the deploy preview, and can confirm that zee-worker is loading, and that you can upload profiles.

In addition I manually tested that the youtube-nocookie.com iframe correctly loads, while the CSP blocks other iframe domains.