### PR TITLE
Add documentation button to the homepage

### DIFF
--- a/res/img/svg/help-blue.svg
+++ b/res/img/svg/help-blue.svg
@@ -1,0 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="#0a84ff" d="M8 1a7 7 0 1 0 7 7 7.008 7.008 0 0 0-7-7zm0 13a6 6 0 1 1 6-6 6.007 6.007 0 0 1-6 6zM8 3.125A2.7 2.7 0 0 0 5.125 6a.875.875 0 0 0 1.75 0c0-1 .6-1.125 1.125-1.125a1.105 1.105 0 0 1 1.13.744.894.894 0 0 1-.53 1.016A2.738 2.738 0 0 0 7.125 9v.337a.875.875 0 0 0 1.75 0v-.37a1.041 1.041 0 0 1 .609-.824A2.637 2.637 0 0 0 10.82 5.16 2.838 2.838 0 0 0 8 3.125zm0 7.625A1.25 1.25 0 1 0 9.25 12 1.25 1.25 0 0 0 8 10.75z"></path>
+</svg>

--- a/src/components/app/Home.css
+++ b/src/components/app/Home.css
@@ -109,18 +109,20 @@
   box-shadow: 0 2px 4px #ddd;
 }
 
-.homeSectionInstallButton {
-  display: inline-block;
-  padding: 0.7em;
+.homeSectionButton {
+  padding: 0.5em;
+  margin: 15px 0;
+  display: block;
   border: 2px solid var(--blue-50);
   color: var(--blue-50);
   text-decoration: none;
   transition: background-color 300ms;
   font-weight: bold;
   font-size: 16px;
+  text-align: center;
 }
 
-.homeSectionInstallButton:hover {
+.homeSectionButton:hover {
   color: #fff;
   background-color: var(--blue-50);
 }
@@ -132,6 +134,21 @@
   top: 2px;
   padding-right: 12px;
   padding-left: 5px;
+}
+
+.homeSectionDocsIcon {
+  width: 20px;
+  height: 20px;
+  position: relative;
+  margin: 0 10px -4px 3px;
+  background: url(../../../res/img/svg/help-blue.svg);
+  background-size: 100% 100%;
+  display: inline-block;
+}
+
+.homeSectionButton:hover .homeSectionDocsIcon {
+  /* Make the icon white */
+  filter: grayscale(1) brightness(3);
 }
 
 .homeSectionPerfScreenshot {
@@ -203,4 +220,5 @@
     padding-left: 1em;
     padding-right: 1em;
   }
+
 }

--- a/src/components/app/Home.js
+++ b/src/components/app/Home.js
@@ -77,6 +77,14 @@ class UploadButton extends React.PureComponent<UploadButtonProps> {
   }
 }
 
+function DocsButton() {
+  return (
+    <a href="/docs/" className="homeSectionButton">
+      <span className="homeSectionDocsIcon" />Documentation
+    </a>
+  );
+}
+
 function InstructionTransition(props: {}) {
   return (
     <CSSTransition
@@ -199,19 +207,19 @@ class Home extends React.PureComponent<HomeProps, HomeState> {
             </div>
           </div>
           <div className="homeInstructionsRight">
-            <h2>Getting started</h2>
-            <p>
-              Install the Gecko Profiler Add-on to start recording a performance
-              profile in Firefox, then analyze it and share it with perf.html.
-            </p>
             <InstallButton
               name="Gecko Profiler"
-              className="homeSectionInstallButton"
+              className="homeSectionButton"
               xpiUrl={ADDON_URL}
             >
               <span className="homeSectionPlus">+</span>
               Install add-on
             </InstallButton>
+            <DocsButton />
+            <p>
+              Install the Gecko Profiler Add-on to start recording a performance
+              profile in Firefox, then analyze it and share it with perf.html.
+            </p>
             <p>
               You can also analyze a local profile by either dragging and
               dropping it here or selecting it using the button below.
@@ -233,7 +241,7 @@ class Home extends React.PureComponent<HomeProps, HomeState> {
             </p>
           </div>
           <div className="homeInstructionsRight">
-            <h2>Recording profiles</h2>
+            <DocsButton />
             <p>
               To start profiling, click on the profiling button, or use the
               keyboard shortcuts. The icon is blue when a profile is recording.
@@ -262,7 +270,7 @@ class Home extends React.PureComponent<HomeProps, HomeState> {
             </div>
           </div>
           <div className="homeInstructionsRight">
-            <h2>Recording profiles</h2>
+            <DocsButton />
             <p>
               To start recording a performance profile in Firefox, first install
               the{' '}
@@ -295,6 +303,7 @@ class Home extends React.PureComponent<HomeProps, HomeState> {
             </div>
           </div>
           <div className="homeInstructionsRight">
+            <DocsButton />
             <h2>How to view and record profiles</h2>
             <p>
               Recording performance profiles requires{' '}

--- a/src/test/components/__snapshots__/Home.test.js.snap
+++ b/src/test/components/__snapshots__/Home.test.js.snap
@@ -76,6 +76,15 @@ exports[`app/Home renders the information screen for other browsers 1`] = `
         <div
           className="homeInstructionsRight"
         >
+          <a
+            className="homeSectionButton"
+            href="/docs/"
+          >
+            <span
+              className="homeSectionDocsIcon"
+            />
+            Documentation
+          </a>
           <h2>
             How to view and record profiles
           </h2>
@@ -187,14 +196,8 @@ exports[`app/Home renders the install screen for the extension 1`] = `
         <div
           className="homeInstructionsRight"
         >
-          <h2>
-            Getting started
-          </h2>
-          <p>
-            Install the Gecko Profiler Add-on to start recording a performance profile in Firefox, then analyze it and share it with perf.html.
-          </p>
           <a
-            className="homeSectionInstallButton"
+            className="homeSectionButton"
             href="https://raw.githubusercontent.com/devtools-html/Gecko-Profiler-Addon/master/gecko_profiler.xpi"
             onClick={[Function]}
           >
@@ -205,6 +208,18 @@ exports[`app/Home renders the install screen for the extension 1`] = `
             </span>
             Install add-on
           </a>
+          <a
+            className="homeSectionButton"
+            href="/docs/"
+          >
+            <span
+              className="homeSectionDocsIcon"
+            />
+            Documentation
+          </a>
+          <p>
+            Install the Gecko Profiler Add-on to start recording a performance profile in Firefox, then analyze it and share it with perf.html.
+          </p>
           <p>
             You can also analyze a local profile by either dragging and dropping it here or selecting it using the button below.
           </p>
@@ -306,9 +321,15 @@ exports[`app/Home renders the install screen for the legacy add-on 1`] = `
         <div
           className="homeInstructionsRight"
         >
-          <h2>
-            Recording profiles
-          </h2>
+          <a
+            className="homeSectionButton"
+            href="/docs/"
+          >
+            <span
+              className="homeSectionDocsIcon"
+            />
+            Documentation
+          </a>
           <p>
             To start recording a performance profile in Firefox, first install the
              
@@ -453,9 +474,15 @@ exports[`app/Home renders the usage instructions for pages with the extension in
         <div
           className="homeInstructionsRight"
         >
-          <h2>
-            Recording profiles
-          </h2>
+          <a
+            className="homeSectionButton"
+            href="/docs/"
+          >
+            <span
+              className="homeSectionDocsIcon"
+            />
+            Documentation
+          </a>
           <p>
             To start profiling, click on the profiling button, or use the keyboard shortcuts. The icon is blue when a profile is recording. Hit
             <kbd>


### PR DESCRIPTION
Installed plugin:
<img width="1524" alt="screen shot 2018-05-24 at 1 32 09 pm" src="https://user-images.githubusercontent.com/1588648/40505215-2257832e-5f59-11e8-8446-d7ce63ffc521.png">

Non-Firefox browser:
<img width="1552" alt="screen shot 2018-05-24 at 1 34 56 pm" src="https://user-images.githubusercontent.com/1588648/40505224-2a25bf44-5f59-11e8-8a22-fb6b5699cc40.png">

Firefox with no add-on:
<img width="1552" alt="screen shot 2018-05-24 at 1 35 18 pm" src="https://user-images.githubusercontent.com/1588648/40505241-389e108a-5f59-11e8-8c97-3b3ee46056f9.png">
