### PR TITLE
Parse files as JSON-encoded profiles by default

### DIFF
--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -660,12 +660,26 @@ describe('actions/receive-profile', function() {
       return { getState, dispatch, view };
     }
 
-    it('can load json', async function() {
+    it('can load json with a good mime type', async function() {
       const profile = getEmptyProfile();
       profile.meta.product = 'JSON Test';
 
       const { getState, view } = await setupTestWithFile({
         type: 'application/json',
+        payload: serializeProfile(profile),
+      });
+      expect(view.phase).toBe('DATA_LOADED');
+      expect(ProfileViewSelectors.getProfile(getState()).meta.product).toEqual(
+        'JSON Test'
+      );
+    });
+
+    it('can load json with an empty mime type', async function() {
+      const profile = getEmptyProfile();
+      profile.meta.product = 'JSON Test';
+
+      const { getState, view } = await setupTestWithFile({
+        type: '',
         payload: serializeProfile(profile),
       });
       expect(view.phase).toBe('DATA_LOADED');


### PR DESCRIPTION
Before this patch and since #1025 we were parsing profiles as JSON only
if the received mime type was 'application/json'. To do this we relied
on the system to give us this mime-type. However this happens only if
the file name actually ends with '.json', and this isn't always the case
in our use cases.
So in this patch we revert to the old behavior where we parse as JSON if
we don't recognize a zip or gzip mime-type. We still require a valid
mime-type for these 2 other types though.

Fixes #1047