### PR TITLE
 Move network markers to a separate panel (Fixes #1067)

### DIFF
--- a/src/components/app/ProfileViewer.js
+++ b/src/components/app/ProfileViewer.js
@@ -78,6 +78,10 @@ class ProfileViewer extends PureComponent<Props> {
         name: 'marker-table',
         title: 'Marker Table',
       },
+      {
+        name: 'network-chart',
+        title: 'Network',
+      },
     ];
   }
 
@@ -130,6 +134,7 @@ class ProfileViewer extends PureComponent<Props> {
             'marker-table': <MarkerTable />,
             'stack-chart': <StackChart />,
             'marker-chart': <MarkerChart />,
+            'network-chart': <MarkerChart />,
             'flame-graph': <FlameGraph />,
           }[selectedTab]
         }

--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -6,7 +6,7 @@
 import React, { PureComponent } from 'react';
 import explicitConnect from '../../utils/connect';
 import TreeView from '../shared/TreeView';
-import EmptyReasons from './EmptyReasons';
+import CallTreeEmptyReasons from './CallTreeEmptyReasons';
 import NodeIcon from '../shared/NodeIcon';
 import { getCallNodePathFromIndex } from '../../profile-logic/profile-data';
 import {
@@ -175,7 +175,7 @@ class CallTreeComponent extends PureComponent<Props> {
       callNodeMaxDepth,
     } = this.props;
     if (tree.getRoots().length === 0) {
-      return <EmptyReasons />;
+      return <CallTreeEmptyReasons />;
     }
     return (
       <TreeView

--- a/src/components/calltree/CallTreeEmptyReasons.js
+++ b/src/components/calltree/CallTreeEmptyReasons.js
@@ -2,17 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
+
 import React, { PureComponent } from 'react';
+
+import EmptyReasons from '../shared/EmptyReasons';
 import { selectedThreadSelectors } from '../../reducers/profile-view';
 import { oneLine } from 'common-tags';
 import explicitConnect, {
   type ExplicitConnectOptions,
   type ConnectedProps,
 } from '../../utils/connect';
+
 import type { Thread } from '../../types/profile';
 import type { State } from '../../types/store';
-
-import './EmptyReasons.css';
 
 type StateProps = {|
   threadName: string,
@@ -26,7 +28,7 @@ type Props = ConnectedProps<{||}, StateProps, {||}>;
  * This component attempts to tell why exactly a call tree is empty with no samples
  * and display a friendly message to the end user.
  */
-class EmptyReasons extends PureComponent<Props> {
+class CallTreeEmptyReasons extends PureComponent<Props> {
   render() {
     const { thread, rangeFilteredThread, threadName } = this.props;
     let reason;
@@ -43,10 +45,11 @@ class EmptyReasons extends PureComponent<Props> {
     }
 
     return (
-      <div className="CallTreeEmptyReasons">
-        <h3>The call tree is empty for “{threadName}”</h3>
-        <p>{reason}</p>
-      </div>
+      <EmptyReasons
+        threadName={threadName}
+        reason={reason}
+        viewName="call tree"
+      />
     );
   }
 }
@@ -57,7 +60,7 @@ const options: ExplicitConnectOptions<{||}, StateProps, {||}> = {
     thread: selectedThreadSelectors.getThread(state),
     rangeFilteredThread: selectedThreadSelectors.getRangeFilteredThread(state),
   }),
-  component: EmptyReasons,
+  component: CallTreeEmptyReasons,
 };
 
 export default explicitConnect(options);

--- a/src/components/marker-chart/MarkerChartEmptyReasons.js
+++ b/src/components/marker-chart/MarkerChartEmptyReasons.js
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+
+import React, { PureComponent } from 'react';
+
+import EmptyReasons from '../shared/EmptyReasons';
+import { selectedThreadSelectors } from '../../reducers/profile-view';
+import { getSelectedTab } from '../../reducers/url-state';
+
+import explicitConnect, {
+  type ExplicitConnectOptions,
+  type ConnectedProps,
+} from '../../utils/connect';
+
+import type { State } from '../../types/store';
+import type { TabSlug } from '../../types/actions';
+import type { Thread } from '../../types/profile';
+
+type StateProps = {|
+  +thread: Thread,
+  +threadName: string,
+  +selectedTab: TabSlug,
+|};
+
+type Props = ConnectedProps<{||}, StateProps, {||}>;
+class MarkerChartEmptyReasons extends PureComponent<Props> {
+  render() {
+    const { selectedTab, thread, threadName } = this.props;
+
+    let reason;
+    let viewName = 'marker chart';
+    if (thread.markers.length === 0) {
+      reason = 'This thread contains no markers.';
+    } else if (selectedTab === 'network-chart') {
+      viewName = 'network chart';
+      reason = 'This thread has no network markers.';
+    } else {
+      // I can't think of a possible reason coming here at the moment as we
+      // don't have any search yet.
+      reason = 'No markers have been found in this thread.';
+    }
+
+    return (
+      <EmptyReasons
+        threadName={threadName}
+        reason={reason}
+        viewName={viewName}
+      />
+    );
+  }
+}
+
+const options: ExplicitConnectOptions<{||}, StateProps, {||}> = {
+  mapStateToProps: (state: State) => ({
+    thread: selectedThreadSelectors.getThread(state),
+    threadName: selectedThreadSelectors.getFriendlyThreadName(state),
+    selectedTab: getSelectedTab(state),
+  }),
+  component: MarkerChartEmptyReasons,
+};
+
+export default explicitConnect(options);

--- a/src/components/marker-chart/index.js
+++ b/src/components/marker-chart/index.js
@@ -6,6 +6,8 @@
 import * as React from 'react';
 import explicitConnect from '../../utils/connect';
 import MarkerChartCanvas from './Canvas';
+import MarkerChartEmptyReasons from './MarkerChartEmptyReasons';
+
 import {
   selectedThreadSelectors,
   getDisplayRange,
@@ -73,6 +75,10 @@ class MarkerChart extends React.PureComponent<Props> {
       updateProfileSelection,
     } = this.props;
 
+    if (!markers.length) {
+      return <MarkerChartEmptyReasons />;
+    }
+
     // The viewport needs to know about the height of what it's drawing, calculate
     // that here at the top level component.
     const maxViewportHeight = maxMarkerRows * ROW_HEIGHT;
@@ -116,7 +122,7 @@ function viewportNeedsUpdate(
 
 const options: ExplicitConnectOptions<{||}, StateProps, DispatchProps> = {
   mapStateToProps: state => {
-    const markers = selectedThreadSelectors.getTracingMarkers(state);
+    const markers = selectedThreadSelectors.getTracingMarkersForView(state);
     const markerTimingRows = selectedThreadSelectors.getMarkerTiming(state);
     const threadName = selectedThreadSelectors.getFriendlyThreadName(state);
 

--- a/src/components/shared/EmptyReasons.css
+++ b/src/components/shared/EmptyReasons.css
@@ -1,4 +1,4 @@
-.CallTreeEmptyReasons {
+.EmptyReasons {
   flex: 1;
   display: flex;
   align-items: center;

--- a/src/components/shared/EmptyReasons.js
+++ b/src/components/shared/EmptyReasons.js
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+import React, { PureComponent } from 'react';
+
+import './EmptyReasons.css';
+
+type Props = {|
+  +viewName: string,
+  +threadName: string,
+  +reason: string,
+|};
+
+/**
+ * This component tells why a panel is empty and display a friendly message to
+ * the end user.
+ */
+export default class EmptyReasons extends PureComponent<Props> {
+  render() {
+    const { viewName, reason, threadName } = this.props;
+
+    return (
+      <div className="EmptyReasons">
+        <h3>
+          The {viewName} is empty for “{threadName}”
+        </h3>
+        <p>{reason}</p>
+      </div>
+    );
+  }
+}

--- a/src/components/sidebar/index.js
+++ b/src/components/sidebar/index.js
@@ -20,6 +20,7 @@ export default function selectSidebar(
     'marker-table': null,
     'stack-chart': null,
     'marker-chart': null,
+    'network-chart': null,
     'flame-graph': null,
   }[selectedTab];
 }

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -1189,6 +1189,10 @@ export function filterTracingMarkersToRange(
   );
 }
 
+export function isNetworkMarker(marker: TracingMarker): boolean {
+  return !!(marker.data && marker.data.type === 'Network');
+}
+
 export function getFriendlyThreadName(
   threads: Thread[],
   thread: Thread

--- a/src/test/components/MarkerChart.test.js
+++ b/src/test/components/MarkerChart.test.js
@@ -4,9 +4,12 @@
 
 // @flow
 import * as React from 'react';
-import MarkerChart from '../../components/marker-chart';
 import renderer from 'react-test-renderer';
 import { Provider } from 'react-redux';
+
+import MarkerChart from '../../components/marker-chart';
+import { changeSelectedTab } from '../../actions/app';
+
 import mockCanvasContext from '../fixtures/mocks/canvas-context';
 import { storeWithProfile } from '../fixtures/stores';
 import { getProfileWithMarkers } from '../fixtures/profiles/make-profile';
@@ -72,10 +75,26 @@ it('renders MarkerChart correctly', () => {
         phase: 2,
       },
     ],
+    [
+      'Load event',
+      11,
+      {
+        type: 'Network',
+        startTime: 11,
+        endTime: 12,
+        id: 31666793873480,
+        status: 'STATUS_START',
+        pri: 0,
+        URI: 'https://tiles.services.mozilla.com/v3/links/ping-centre',
+      },
+    ],
   ]);
 
+  const store = storeWithProfile(profile);
+  store.dispatch(changeSelectedTab('marker-chart'));
+
   const markerChart = renderer.create(
-    <Provider store={storeWithProfile(profile)}>
+    <Provider store={store}>
       <MarkerChart />
     </Provider>,
     { createNodeMock }
@@ -83,10 +102,15 @@ it('renders MarkerChart correctly', () => {
 
   flushRafCalls();
 
-  const tree = markerChart.toJSON();
-  const drawCalls = ctx.__flushDrawLog();
+  let drawCalls = ctx.__flushDrawLog();
+  expect(markerChart).toMatchSnapshot();
+  expect(drawCalls).toMatchSnapshot();
 
-  expect(tree).toMatchSnapshot();
+  store.dispatch(changeSelectedTab('network-chart'));
+
+  flushRafCalls();
+  drawCalls = ctx.__flushDrawLog();
+  expect(markerChart).toMatchSnapshot();
   expect(drawCalls).toMatchSnapshot();
 
   delete window.devicePixelRatio;

--- a/src/test/components/ProfileThreadTracingMarkerOverview.test.js
+++ b/src/test/components/ProfileThreadTracingMarkerOverview.test.js
@@ -51,6 +51,11 @@ describe('ProfileThreadTracingMarkerOverview', function() {
       ['Marker A', 0, { startTime: 0, endTime: 10 }],
       ['Marker B', 0, { startTime: 0, endTime: 10 }],
       ['Marker C', 5, { startTime: 5, endTime: 15 }],
+      [
+        'BHR-detected hang',
+        5,
+        { type: 'BHR-detected hang', startTime: 2, endTime: 13 },
+      ],
     ]);
 
     const overview = renderer.create(

--- a/src/test/components/__snapshots__/MarkerChart.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerChart.test.js.snap
@@ -1,5 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Empty Reasons shows a reason when a profil has no network markers 1`] = `
+<div
+  className="EmptyReasons"
+>
+  <h3>
+    The 
+    network chart
+     is empty for “
+    Empty
+    ”
+  </h3>
+  <p>
+    This thread has no network markers.
+  </p>
+</div>
+`;
+
+exports[`Empty Reasons shows a reason when a profile has no marker 1`] = `
+<div
+  className="EmptyReasons"
+>
+  <h3>
+    The 
+    marker chart
+     is empty for “
+    Empty
+    ”
+  </h3>
+  <p>
+    This thread contains no markers.
+  </p>
+</div>
+`;
+
 exports[`renders MarkerChart correctly 1`] = `
 <div
   className="markerChart"

--- a/src/test/components/__snapshots__/MarkerChart.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerChart.test.js.snap
@@ -453,3 +453,246 @@ Array [
   ],
 ]
 `;
+
+exports[`renders MarkerChart correctly 3`] = `
+<div
+  className="markerChart"
+>
+  <div
+    className="markerChartLabels grippy"
+    title="thread: \\"Empty\\" (0)
+process: \\"default\\" (0)"
+  >
+    <span
+      className="markerChartLabelsName"
+    >
+      Empty
+    </span>
+  </div>
+  <div
+    className="chartViewport"
+    onMouseDown={[Function]}
+    onWheel={[Function]}
+  >
+    <div>
+      <canvas
+        className="chartCanvas markerChartCanvas"
+        onDoubleClick={[Function]}
+        onMouseDown={[Function]}
+        onMouseMove={[Function]}
+        onMouseOut={[Function]}
+      />
+    </div>
+    <div
+      className="chartViewportShiftScroll hidden"
+    >
+      Zoom Chart:
+      <kbd
+        className="chartViewportShiftScrollKbd"
+      >
+        Shift
+      </kbd>
+      <kbd
+        className="chartViewportShiftScrollKbd"
+      >
+        Scroll
+      </kbd>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders MarkerChart correctly 4`] = `
+Array [
+  Array [
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    200,
+    300,
+  ],
+  Array [
+    "set lineWidth",
+    1,
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff",
+  ],
+  Array [
+    "beginPath",
+  ],
+  Array [
+    "arc",
+    143.75,
+    7.5,
+    3.75,
+    0,
+    6.283185307179586,
+  ],
+  Array [
+    "fill",
+  ],
+  Array [
+    "set fillStyle",
+    "#eee",
+  ],
+  Array [
+    "fillRect",
+    0,
+    15,
+    200,
+    1,
+  ],
+  Array [
+    "createLinearGradient",
+    0,
+    0,
+    150,
+    0,
+  ],
+  Array [
+    "addColorStop",
+    0,
+    "rgba(255, 255, 255, 0.8)",
+  ],
+  Array [
+    "addColorStop",
+    1,
+    "rgba(255, 255, 255, 0.0)",
+  ],
+  Array [
+    "set fillStyle",
+    Object {
+      "addColorStop": [MockFunction] {
+        "calls": Array [
+          Array [
+            0,
+            "rgba(255, 255, 255, 0.8)",
+          ],
+          Array [
+            1,
+            "rgba(255, 255, 255, 0.0)",
+          ],
+        ],
+      },
+    },
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    150,
+    15,
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "Load event",
+    5,
+    11,
+  ],
+  Array [
+    "set fillStyle",
+    "#ffffff",
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    200,
+    300,
+  ],
+  Array [
+    "set lineWidth",
+    1,
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff",
+  ],
+  Array [
+    "beginPath",
+  ],
+  Array [
+    "arc",
+    143.75,
+    7.5,
+    3.75,
+    0,
+    6.283185307179586,
+  ],
+  Array [
+    "fill",
+  ],
+  Array [
+    "set fillStyle",
+    "#eee",
+  ],
+  Array [
+    "fillRect",
+    0,
+    15,
+    200,
+    1,
+  ],
+  Array [
+    "createLinearGradient",
+    0,
+    0,
+    150,
+    0,
+  ],
+  Array [
+    "addColorStop",
+    0,
+    "rgba(255, 255, 255, 0.8)",
+  ],
+  Array [
+    "addColorStop",
+    1,
+    "rgba(255, 255, 255, 0.0)",
+  ],
+  Array [
+    "set fillStyle",
+    Object {
+      "addColorStop": [MockFunction] {
+        "calls": Array [
+          Array [
+            0,
+            "rgba(255, 255, 255, 0.8)",
+          ],
+          Array [
+            1,
+            "rgba(255, 255, 255, 0.0)",
+          ],
+        ],
+      },
+    },
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    150,
+    15,
+  ],
+  Array [
+    "set fillStyle",
+    "#000000",
+  ],
+  Array [
+    "fillText",
+    "Load event",
+    5,
+    11,
+  ],
+]
+`;

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
@@ -110,10 +110,12 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows a reason for a call tre
     </li>
   </ol>
   <div
-    className="CallTreeEmptyReasons"
+    className="EmptyReasons"
   >
     <h3>
-      The call tree is empty for “
+      The 
+      call tree
+       is empty for “
       Empty Thread
       ”
     </h3>
@@ -234,10 +236,12 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows reasons for being out o
     </li>
   </ol>
   <div
-    className="CallTreeEmptyReasons"
+    className="EmptyReasons"
   >
     <h3>
-      The call tree is empty for “
+      The 
+      call tree
+       is empty for “
       Thread with samples
       ”
     </h3>
@@ -358,10 +362,12 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows reasons for when sample
     </li>
   </ol>
   <div
-    className="CallTreeEmptyReasons"
+    className="EmptyReasons"
   >
     <h3>
-      The call tree is empty for “
+      The 
+      call tree
+       is empty for “
       Thread with samples
       ”
     </h3>

--- a/src/test/store/app.test.js
+++ b/src/test/store/app.test.js
@@ -66,13 +66,15 @@ describe('app actions', function() {
         2,
         3,
         4,
+        5,
       ]);
-      dispatch(AppActions.changeTabOrder([2, 3, 1, 4, 0]));
+      dispatch(AppActions.changeTabOrder([2, 3, 1, 4, 5, 0]));
       expect(ProfileViewSelectors.getTabOrder(getState())).toEqual([
         2,
         3,
         1,
         4,
+        5,
         0,
       ]);
     });

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -50,6 +50,7 @@ export type TabSlug =
   | 'calltree'
   | 'stack-chart'
   | 'marker-chart'
+  | 'network-chart'
   | 'marker-table'
   | 'flame-graph';
 

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -340,6 +340,12 @@ export type StyleMarkerPayload = StyleMarkerPayload_Shared & {
   cause?: CauseBacktrace,
 };
 
+export type BHRMarkerPayload = {
+  type: 'BHR-detected hang',
+  startTime: Milliseconds,
+  endTime: Milliseconds,
+};
+
 export type DummyForTestsMarkerPayload = {
   type: 'DummyForTests',
   startTime: Milliseconds,
@@ -362,6 +368,7 @@ export type MarkerPayload =
   | GCMajorMarkerPayload
   | GCSliceMarkerPayload
   | StyleMarkerPayload
+  | BHRMarkerPayload
   | DummyForTestsMarkerPayload
   | null;
 

--- a/src/url-handling.js
+++ b/src/url-handling.js
@@ -133,6 +133,7 @@ export function urlStateToUrlObject(urlState: UrlState): UrlObject {
       query.markerSearch = urlState.profileSpecific.markersSearchString;
       break;
     case 'marker-chart':
+    case 'network-chart':
       break;
     default:
       assertExhaustiveCheck(selectedTab);

--- a/src/utils/flow.js
+++ b/src/utils/flow.js
@@ -42,6 +42,7 @@ export function toValidTabSlug(tabSlug: any): TabSlug | null {
     case 'calltree':
     case 'stack-chart':
     case 'marker-chart':
+    case 'network-chart':
     case 'marker-table':
     case 'flame-graph':
       return coercedTabSlug;


### PR DESCRIPTION
This also moves BHR markers out of the header's timeline's black markers line (part of #1070), and implements an EmptyReason panel for the marker chart (part of #771).