### PR TITLE
Change color of sidebar left border

### DIFF
--- a/src/components/app/DetailsContainer.css
+++ b/src/components/app/DetailsContainer.css
@@ -17,12 +17,12 @@
 
 .DetailsContainer .layout-splitter {
   background: var(--grey-10); /* Same background as sidebars */
-  border-left: 1px solid var(--grey-40);
+  border-left: 1px solid var(--grey-30);
   border-top: 1px solid var(--grey-30);
 }
 
 .DetailsContainer .layout-splitter:hover {
-  background: var(--grey-40); /* same as the border above */
+  background: var(--grey-30); /* same as the border above */
 }
 
 


### PR DESCRIPTION
(please look at last commit only)

Before: the border is slightly darker as other borders
![image](https://user-images.githubusercontent.com/454175/41911660-8e5b6fa0-794d-11e8-9171-3c642a682dcf.png)

After: the border as the same color as other borders
![image](https://user-images.githubusercontent.com/454175/41911583-55119f08-794d-11e8-9755-16d223af4753.png)

other possibility: make it even darker than before
![image](https://user-images.githubusercontent.com/454175/41911732-c1e860b2-794d-11e8-875b-ea2d711d3c58.png)

I think I'd like to darken all "separation" borders actually: sidebar, but also between the header and the rest of the view, to get a clearer separation.
Also maybe borders isn't the right way to achieve this. SO MANY QUESTIONS.

Thoughts @digitarald @zoepage @mstange @gregtatum ?
