### PR TITLE
Add an open/close button for the Sidebar

### DIFF
--- a/res/css/photon-components.css
+++ b/res/css/photon-components.css
@@ -1,0 +1,49 @@
+.photon-button {
+  /* reset default styles */
+  background: none;
+  border: none;
+  margin: 0;
+  padding: 0;
+
+  /* photon styles */
+  background-color: var(--grey-90-a10);
+  padding: 0 8px;
+  border-radius: 2px;
+}
+
+.photon-button:hover {
+  background-color: var(--grey-90-a20);
+}
+
+.photon-button:hover:active {
+  background-color: var(--grey-90-a30);
+}
+
+/* This is a Firefox-specific style because Firefox adds a focusring at a bad
+ * position. We're adding our own below. */
+.photon-button::-moz-focus-inner {
+  border: none;
+}
+
+/* Using -moz-focusring to target Firefox only, as a result of the style above */
+.photon-button:-moz-focusring {
+  outline: 1px dotted black;
+
+  /* This should be eventually the default behavior.
+   * See https://bugzilla.mozilla.org/show_bug.cgi?id=315209 */
+  -moz-outline-radius: 2px;
+}
+
+.photon-button-ghost {
+  background-color: transparent;
+  height: 32px;
+  width: 32px;
+}
+
+.photon-button-ghost:hover {
+  background-color: var(--grey-90-a10);
+}
+
+.photon-button-ghost:hover:active {
+  background-color: var(--grey-90-a20);
+}

--- a/res/css/style.css
+++ b/res/css/style.css
@@ -14,6 +14,7 @@ html, body {
 body, #root, .profileViewer {
   display: flex;
   flex: 1;
+  min-width: 0; /* This allows Flexible Layout to shrink this further than its min-content */
 }
 
 .profileViewer {
@@ -634,6 +635,8 @@ body, #root, .profileViewer {
   position: relative;
   border: solid transparent;
   border-width: 0 1px 0 1px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .tabBarTab.selected {
   background: #fff;

--- a/res/css/style.css
+++ b/res/css/style.css
@@ -602,6 +602,8 @@ body, #root, .profileViewer {
 .tabBarContainer {
   display: flex;
   flex-flow: row nowrap;
+  justify-content: space-between; /* This pushes the sidebar button to the right */
+  align-items: center;
   background: var(--grey-10);
   position: relative;
   border: solid var(--grey-30);
@@ -609,13 +611,12 @@ body, #root, .profileViewer {
 }
 
 .tabBarTabWrapper {
-  margin: 0;
   padding: 0 0.5px;
   list-style: none;
   display: flex;
   flex-flow: row nowrap;
   margin: 0 -1px;
-  max-width: 100%;
+  min-width: 0; /* This makes the tab container actually shrinkable below min-content */
 }
 
 .tabBarTab {

--- a/res/img/svg/pane-collapse.svg
+++ b/res/img/svg/pane-collapse.svg
@@ -1,0 +1,7 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="#0b0b0b">
+  <path fill-opacity=".3" d="M12 3h2v10h-2V3zM5 9.9V6.1L8 8 5 9.9z"></path>
+  <path d="M14 2H2c-.6 0-1 .4-1 1v10c0 .6.4 1 1 1h12c.6 0 1-.4 1-1V3c0-.6-.4-1-1-1zM2 13V3h9v10H2zm12 0h-2V3h2v10zM8.5 7.2l-3-1.9C4.6 4.7 4 5 4 6.1v3.8c0 1.1.6 1.4 1.5.8l3-1.9c1-.5 1-1 0-1.6zM5 9.9V6.1L8 8 5 9.9z"></path>
+</svg>

--- a/res/img/svg/pane-expand.svg
+++ b/res/img/svg/pane-expand.svg
@@ -1,0 +1,7 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="#0b0b0b">
+  <path fill-opacity=".3" d="M4 13H2V3h2v10zm7-6.9v3.8L8 8l3-1.9z"></path>
+  <path d="M2 14h12c.6 0 1-.4 1-1V3c0-.6-.4-1-1-1H2c-.6 0-1 .4-1 1v10c0 .6.4 1 1 1zM14 3v10H5V3h9zM2 3h2v10H2V3zm5.5 5.8l3 1.9c1 .6 1.5.3 1.5-.8V6.1c0-1.1-.6-1.4-1.5-.8l-3 1.9c-1 .5-1 1 0 1.6zM11 6.1v3.8L8 8l3-1.9z"></path>
+</svg>

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -71,6 +71,10 @@ export function show404(url: string): Action {
   return { type: 'ROUTE_NOT_FOUND', url };
 }
 
+export function changeSidebarOpenState(tab: TabSlug, isOpen: boolean): Action {
+  return { type: 'CHANGE_SIDEBAR_OPEN_STATE', tab, isOpen };
+}
+
 /**
  * This function is called when a browser navigation event happens. A new UrlState
  * is generated when the window.location is serialized, or the state is pulled out of

--- a/src/components/app/Details.css
+++ b/src/components/app/Details.css
@@ -4,3 +4,22 @@
   display: flex;
   flex-direction: column;
 }
+
+.sidebar-open-close-button {
+  flex: none;
+
+  height: 24px;
+  width: 24px;
+  margin: 4px;
+
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+.sidebar-open-close-button-isopen {
+  background-image: url(../../../res/img/svg/pane-collapse.svg);
+}
+
+.sidebar-open-close-button-isclosed {
+  background-image: url(../../../res/img/svg/pane-expand.svg);
+}

--- a/src/components/app/Details.js
+++ b/src/components/app/Details.js
@@ -5,6 +5,8 @@
 // @flow
 
 import React, { PureComponent } from 'react';
+import classNames from 'classnames';
+
 import explicitConnect from '../../utils/connect';
 import TabBar from './TabBar';
 import ProfileCallTreeView from '../calltree/ProfileCallTreeView';
@@ -12,9 +14,16 @@ import MarkerTable from '../marker-table';
 import StackChart from '../stack-chart/';
 import MarkerChart from '../marker-chart/';
 import FlameGraph from '../flame-graph/';
-import { changeSelectedTab, changeTabOrder } from '../../actions/app';
+import selectSidebar from '../sidebar';
+
+import {
+  changeSelectedTab,
+  changeTabOrder,
+  changeSidebarOpenState,
+} from '../../actions/app';
 import { getTabOrder } from '../../reducers/profile-view';
 import { getSelectedTab } from '../../reducers/url-state';
+import { getIsSidebarOpen } from '../../reducers/app';
 import CallNodeContextMenu from '../shared/CallNodeContextMenu';
 import MarkerTableContextMenu from '../marker-table/ContextMenu';
 import ProfileThreadHeaderContextMenu from '../header/ProfileThreadHeaderContextMenu';
@@ -27,16 +36,19 @@ import type {
 } from '../../utils/connect';
 import type { TabSlug } from '../../app-logic/tabs-handling';
 
-require('./Details.css');
+import '../../../res/css/photon-components.css';
+import './Details.css';
 
 type StateProps = {|
   +tabOrder: number[],
   +selectedTab: TabSlug,
+  +isSidebarOpen: boolean,
 |};
 
 type DispatchProps = {|
   +changeSelectedTab: typeof changeSelectedTab,
   +changeTabOrder: typeof changeTabOrder,
+  +changeSidebarOpenState: typeof changeSidebarOpenState,
 |};
 
 type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
@@ -51,8 +63,31 @@ class ProfileViewer extends PureComponent<Props> {
     changeSelectedTab(tabSlug);
   };
 
+  _onClickSidebarButton = () => {
+    const { selectedTab, isSidebarOpen, changeSidebarOpenState } = this.props;
+    changeSidebarOpenState(selectedTab, !isSidebarOpen);
+  };
+
   render() {
-    const { tabOrder, changeTabOrder, selectedTab } = this.props;
+    const { tabOrder, selectedTab, isSidebarOpen, changeTabOrder } = this.props;
+    const hasSidebar = selectSidebar(selectedTab) !== null;
+    const extraButton = hasSidebar && (
+      <button
+        className={classNames(
+          'sidebar-open-close-button',
+          'photon-button',
+          'photon-button-ghost',
+          {
+            'sidebar-open-close-button-isopen': isSidebarOpen,
+            'sidebar-open-close-button-isclosed': !isSidebarOpen,
+          }
+        )}
+        title={isSidebarOpen ? 'Close the sidebar' : 'Open the sidebar'}
+        type="button"
+        onClick={this._onClickSidebarButton}
+      />
+    );
+
     return (
       <div className="Details">
         <TabBar
@@ -61,6 +96,7 @@ class ProfileViewer extends PureComponent<Props> {
           tabOrder={tabOrder}
           onSelectTab={this._onSelectTab}
           onChangeTabOrder={changeTabOrder}
+          extraElements={extraButton}
         />
         {
           {
@@ -84,10 +120,12 @@ const options: ExplicitConnectOptions<{||}, StateProps, DispatchProps> = {
   mapStateToProps: state => ({
     tabOrder: getTabOrder(state),
     selectedTab: getSelectedTab(state),
+    isSidebarOpen: getIsSidebarOpen(state),
   }),
   mapDispatchToProps: {
     changeSelectedTab,
     changeTabOrder,
+    changeSidebarOpenState,
   },
   component: ProfileViewer,
 };

--- a/src/components/app/DetailsContainer.js
+++ b/src/components/app/DetailsContainer.js
@@ -10,6 +10,7 @@ import Details from './Details';
 import selectSidebar from '../sidebar';
 
 import { getSelectedTab } from '../../reducers/url-state';
+import { getIsSidebarOpen } from '../../reducers/app';
 import explicitConnect from '../../utils/connect';
 
 import type { TabSlug } from '../../app-logic/tabs-handling';
@@ -24,10 +25,11 @@ function dispatchResizeEvent() {
 
 type StateProps = {|
   +selectedTab: TabSlug,
+  +isSidebarOpen: boolean,
 |};
 
-function DetailsContainer({ selectedTab }: StateProps) {
-  const Sidebar = selectSidebar(selectedTab);
+function DetailsContainer({ selectedTab, isSidebarOpen }: StateProps) {
+  const Sidebar = isSidebarOpen && selectSidebar(selectedTab);
 
   return (
     <SplitterLayout
@@ -45,6 +47,7 @@ function DetailsContainer({ selectedTab }: StateProps) {
 const options: ExplicitConnectOptions<{||}, StateProps, {||}> = {
   mapStateToProps: state => ({
     selectedTab: getSelectedTab(state),
+    isSidebarOpen: getIsSidebarOpen(state),
   }),
   component: DetailsContainer,
 };

--- a/src/components/app/TabBar.js
+++ b/src/components/app/TabBar.js
@@ -4,7 +4,7 @@
 
 // @flow
 
-import React, { PureComponent } from 'react';
+import * as React from 'react';
 import classNames from 'classnames';
 import Reorderable from '../shared/Reorderable';
 
@@ -18,9 +18,10 @@ type Props = {|
   +tabOrder: number[],
   +onSelectTab: string => void,
   +onChangeTabOrder: (number[]) => Action,
+  +extraElements?: React.Node,
 |};
 
-class TabBar extends PureComponent<Props> {
+class TabBar extends React.PureComponent<Props> {
   constructor(props: Props) {
     super(props);
     (this: any)._mouseDownListener = this._mouseDownListener.bind(this);
@@ -40,6 +41,7 @@ class TabBar extends PureComponent<Props> {
       selectedTabName,
       tabOrder,
       onChangeTabOrder,
+      extraElements,
     } = this.props;
     return (
       <div className={classNames('tabBarContainer', className)}>
@@ -63,6 +65,7 @@ class TabBar extends PureComponent<Props> {
             </li>
           ))}
         </Reorderable>
+        {extraElements}
       </div>
     );
   }

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -5,8 +5,17 @@
 // @flow
 import { combineReducers } from 'redux';
 
+import { getSelectedTab } from './url-state';
+import { tabSlugs } from '../app-logic/tabs-handling';
+
 import type { Action } from '../types/store';
-import type { State, AppState, AppViewState, Reducer } from '../types/reducers';
+import type {
+  State,
+  AppState,
+  AppViewState,
+  IsSidebarOpenPerPanelState,
+  Reducer,
+} from '../types/reducers';
 
 function view(
   state: AppViewState = { phase: 'INITIALIZING' },
@@ -63,10 +72,37 @@ function hasZoomedViaMousewheel(state: boolean = false, action: Action) {
       return state;
   }
 }
+
+function isSidebarOpenPerPanel(
+  state: IsSidebarOpenPerPanelState,
+  action: Action
+): IsSidebarOpenPerPanelState {
+  if (state === undefined) {
+    state = {};
+    tabSlugs.forEach(tabSlug => (state[tabSlug] = false));
+  }
+
+  switch (action.type) {
+    case 'CHANGE_SIDEBAR_OPEN_STATE': {
+      const { tab, isOpen } = action;
+      // Due to how this action will be dispatched we'll always have the value
+      // changed so we don't need the performance optimization of checking the
+      // stored value against the new value.
+      return {
+        ...state,
+        [tab]: isOpen,
+      };
+    }
+    default:
+      return state;
+  }
+}
+
 const appStateReducer: Reducer<AppState> = combineReducers({
   view,
   isUrlSetupDone,
   hasZoomedViaMousewheel,
+  isSidebarOpenPerPanel,
 });
 
 export default appStateReducer;
@@ -75,6 +111,8 @@ export const getApp = (state: State): AppState => state.app;
 export const getView = (state: State): AppViewState => getApp(state).view;
 export const getIsUrlSetupDone = (state: State): boolean =>
   getApp(state).isUrlSetupDone;
-export const getHasZoomedViaMousewheel = (state: Object): boolean => {
+export const getHasZoomedViaMousewheel = (state: State): boolean => {
   return getApp(state).hasZoomedViaMousewheel;
 };
+export const getIsSidebarOpen = (state: State): boolean =>
+  getApp(state).isSidebarOpenPerPanel[getSelectedTab(state)];

--- a/src/test/components/Details.test.js
+++ b/src/test/components/Details.test.js
@@ -7,14 +7,14 @@ import * as React from 'react';
 import { shallowWithStore } from '../fixtures/enzyme';
 
 import Details from '../../components/app/Details';
-import { changeSelectedTab } from '../../actions/app';
+import { changeSelectedTab, changeSidebarOpenState } from '../../actions/app';
 import { storeWithProfile } from '../fixtures/stores';
 import { getProfileFromTextSamples } from '../fixtures/profiles/make-profile';
 
 import { tabSlugs } from '../../app-logic/tabs-handling';
 import type { TabSlug } from '../../app-logic/tabs-handling';
 
-describe('app/DetailsContainer', function() {
+describe('app/Details', function() {
   const { profile } = getProfileFromTextSamples(`
     A A A
     B B B
@@ -38,5 +38,18 @@ describe('app/DetailsContainer', function() {
       const view = shallowWithStore(<Details />, store);
       expect(view.dive()).toMatchSnapshot();
     });
+  });
+
+  it('show the correct state for the sidebar open button', function() {
+    const store = storeWithProfile(profile);
+    const view = shallowWithStore(<Details />, store);
+    expect(view.dive()).toMatchSnapshot();
+    store.dispatch(changeSidebarOpenState('calltree', true));
+    expect(view.dive()).toMatchSnapshot();
+    store.dispatch(changeSelectedTab('flame-graph'));
+    expect(view.dive()).toMatchSnapshot();
+    store.dispatch(changeSidebarOpenState('calltree', false));
+    store.dispatch(changeSelectedTab('calltree'));
+    expect(view.dive()).toMatchSnapshot();
   });
 });

--- a/src/test/components/DetailsContainer.test.js
+++ b/src/test/components/DetailsContainer.test.js
@@ -7,7 +7,7 @@ import * as React from 'react';
 import { shallowWithStore } from '../fixtures/enzyme';
 
 import DetailsContainer from '../../components/app/DetailsContainer';
-import { changeSelectedTab } from '../../actions/app';
+import { changeSelectedTab, changeSidebarOpenState } from '../../actions/app';
 import { storeWithProfile } from '../fixtures/stores';
 import { getProfileFromTextSamples } from '../fixtures/profiles/make-profile';
 
@@ -15,16 +15,25 @@ import { tabSlugs } from '../../app-logic/tabs-handling';
 import type { TabSlug } from '../../app-logic/tabs-handling';
 
 describe('app/DetailsContainer', function() {
-  const { profile } = getProfileFromTextSamples(`
-    A A A
-    B B B
-    C C H
-    D F I
-    E E
-  `);
+  function setup() {
+    const { profile } = getProfileFromTextSamples(`
+      A A A
+      B B B
+      C C H
+      D F I
+      E E
+    `);
+
+    const store = storeWithProfile(profile);
+    // Make sure the sidebar is visible in all tabs
+    tabSlugs.forEach(tabSlug =>
+      store.dispatch(changeSidebarOpenState(tabSlug, true))
+    );
+    return { store };
+  }
 
   it('renders an initial view with or without a sidebar', () => {
-    const store = storeWithProfile(profile);
+    const { store } = setup();
     // dive() will shallow-render the wrapped component
     const view = shallowWithStore(<DetailsContainer />, store);
     expect(view.dive()).toMatchSnapshot();
@@ -32,7 +41,7 @@ describe('app/DetailsContainer', function() {
 
   tabSlugs.forEach((tabSlug: TabSlug) => {
     it(`renders an initial view with or without a sidebar for tab ${tabSlug}`, () => {
-      const store = storeWithProfile(profile);
+      const { store } = setup();
       store.dispatch(changeSelectedTab(tabSlug));
 
       const view = shallowWithStore(<DetailsContainer />, store);

--- a/src/test/components/__snapshots__/Details.test.js.snap
+++ b/src/test/components/__snapshots__/Details.test.js.snap
@@ -5,6 +5,7 @@ exports[`app/DetailsContainer renders an initial view with the right panel 1`] =
   className="Details"
 >
   <TabBar
+    extraElements={false}
     onChangeTabOrder={[Function]}
     onSelectTab={[Function]}
     selectedTabName="calltree"
@@ -59,6 +60,7 @@ exports[`app/DetailsContainer renders an initial view with the right panel for t
   className="Details"
 >
   <TabBar
+    extraElements={false}
     onChangeTabOrder={[Function]}
     onSelectTab={[Function]}
     selectedTabName="calltree"
@@ -113,6 +115,7 @@ exports[`app/DetailsContainer renders an initial view with the right panel for t
   className="Details"
 >
   <TabBar
+    extraElements={false}
     onChangeTabOrder={[Function]}
     onSelectTab={[Function]}
     selectedTabName="flame-graph"
@@ -167,6 +170,7 @@ exports[`app/DetailsContainer renders an initial view with the right panel for t
   className="Details"
 >
   <TabBar
+    extraElements={false}
     onChangeTabOrder={[Function]}
     onSelectTab={[Function]}
     selectedTabName="marker-chart"
@@ -221,6 +225,7 @@ exports[`app/DetailsContainer renders an initial view with the right panel for t
   className="Details"
 >
   <TabBar
+    extraElements={false}
     onChangeTabOrder={[Function]}
     onSelectTab={[Function]}
     selectedTabName="marker-table"
@@ -275,6 +280,7 @@ exports[`app/DetailsContainer renders an initial view with the right panel for t
   className="Details"
 >
   <TabBar
+    extraElements={false}
     onChangeTabOrder={[Function]}
     onSelectTab={[Function]}
     selectedTabName="network-chart"
@@ -329,6 +335,7 @@ exports[`app/DetailsContainer renders an initial view with the right panel for t
   className="Details"
 >
   <TabBar
+    extraElements={false}
     onChangeTabOrder={[Function]}
     onSelectTab={[Function]}
     selectedTabName="stack-chart"

--- a/src/test/components/__snapshots__/Details.test.js.snap
+++ b/src/test/components/__snapshots__/Details.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`app/DetailsContainer renders an initial view with the right panel 1`] = `
+exports[`app/Details renders an initial view with the right panel 1`] = `
 <div
   className="Details"
 >
@@ -55,7 +55,7 @@ exports[`app/DetailsContainer renders an initial view with the right panel 1`] =
 </div>
 `;
 
-exports[`app/DetailsContainer renders an initial view with the right panel for tab calltree 1`] = `
+exports[`app/Details renders an initial view with the right panel for tab calltree 1`] = `
 <div
   className="Details"
 >
@@ -110,7 +110,7 @@ exports[`app/DetailsContainer renders an initial view with the right panel for t
 </div>
 `;
 
-exports[`app/DetailsContainer renders an initial view with the right panel for tab flame-graph 1`] = `
+exports[`app/Details renders an initial view with the right panel for tab flame-graph 1`] = `
 <div
   className="Details"
 >
@@ -165,7 +165,7 @@ exports[`app/DetailsContainer renders an initial view with the right panel for t
 </div>
 `;
 
-exports[`app/DetailsContainer renders an initial view with the right panel for tab marker-chart 1`] = `
+exports[`app/Details renders an initial view with the right panel for tab marker-chart 1`] = `
 <div
   className="Details"
 >
@@ -220,7 +220,7 @@ exports[`app/DetailsContainer renders an initial view with the right panel for t
 </div>
 `;
 
-exports[`app/DetailsContainer renders an initial view with the right panel for tab marker-table 1`] = `
+exports[`app/Details renders an initial view with the right panel for tab marker-table 1`] = `
 <div
   className="Details"
 >
@@ -275,7 +275,7 @@ exports[`app/DetailsContainer renders an initial view with the right panel for t
 </div>
 `;
 
-exports[`app/DetailsContainer renders an initial view with the right panel for tab network-chart 1`] = `
+exports[`app/Details renders an initial view with the right panel for tab network-chart 1`] = `
 <div
   className="Details"
 >
@@ -330,7 +330,7 @@ exports[`app/DetailsContainer renders an initial view with the right panel for t
 </div>
 `;
 
-exports[`app/DetailsContainer renders an initial view with the right panel for tab stack-chart 1`] = `
+exports[`app/Details renders an initial view with the right panel for tab stack-chart 1`] = `
 <div
   className="Details"
 >
@@ -379,6 +379,226 @@ exports[`app/DetailsContainer renders an initial view with the right panel for t
     }
   />
   <Connect(StackChartGraph) />
+  <Connect(CallNodeContextMenu) />
+  <Connect(MarkersContextMenu) />
+  <Connect(ProfileThreadHeaderContextMenu) />
+</div>
+`;
+
+exports[`app/Details show the correct state for the sidebar open button 1`] = `
+<div
+  className="Details"
+>
+  <TabBar
+    extraElements={false}
+    onChangeTabOrder={[Function]}
+    onSelectTab={[Function]}
+    selectedTabName="calltree"
+    tabOrder={
+      Array [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+      ]
+    }
+    tabs={
+      Array [
+        Object {
+          "name": "calltree",
+          "title": "Call Tree",
+        },
+        Object {
+          "name": "flame-graph",
+          "title": "Flame Graph",
+        },
+        Object {
+          "name": "stack-chart",
+          "title": "Stack Chart",
+        },
+        Object {
+          "name": "marker-chart",
+          "title": "Marker Chart",
+        },
+        Object {
+          "name": "marker-table",
+          "title": "Marker Table",
+        },
+        Object {
+          "name": "network-chart",
+          "title": "Network",
+        },
+      ]
+    }
+  />
+  <ProfileCallTreeView />
+  <Connect(CallNodeContextMenu) />
+  <Connect(MarkersContextMenu) />
+  <Connect(ProfileThreadHeaderContextMenu) />
+</div>
+`;
+
+exports[`app/Details show the correct state for the sidebar open button 2`] = `
+<div
+  className="Details"
+>
+  <TabBar
+    extraElements={false}
+    onChangeTabOrder={[Function]}
+    onSelectTab={[Function]}
+    selectedTabName="calltree"
+    tabOrder={
+      Array [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+      ]
+    }
+    tabs={
+      Array [
+        Object {
+          "name": "calltree",
+          "title": "Call Tree",
+        },
+        Object {
+          "name": "flame-graph",
+          "title": "Flame Graph",
+        },
+        Object {
+          "name": "stack-chart",
+          "title": "Stack Chart",
+        },
+        Object {
+          "name": "marker-chart",
+          "title": "Marker Chart",
+        },
+        Object {
+          "name": "marker-table",
+          "title": "Marker Table",
+        },
+        Object {
+          "name": "network-chart",
+          "title": "Network",
+        },
+      ]
+    }
+  />
+  <ProfileCallTreeView />
+  <Connect(CallNodeContextMenu) />
+  <Connect(MarkersContextMenu) />
+  <Connect(ProfileThreadHeaderContextMenu) />
+</div>
+`;
+
+exports[`app/Details show the correct state for the sidebar open button 3`] = `
+<div
+  className="Details"
+>
+  <TabBar
+    extraElements={false}
+    onChangeTabOrder={[Function]}
+    onSelectTab={[Function]}
+    selectedTabName="calltree"
+    tabOrder={
+      Array [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+      ]
+    }
+    tabs={
+      Array [
+        Object {
+          "name": "calltree",
+          "title": "Call Tree",
+        },
+        Object {
+          "name": "flame-graph",
+          "title": "Flame Graph",
+        },
+        Object {
+          "name": "stack-chart",
+          "title": "Stack Chart",
+        },
+        Object {
+          "name": "marker-chart",
+          "title": "Marker Chart",
+        },
+        Object {
+          "name": "marker-table",
+          "title": "Marker Table",
+        },
+        Object {
+          "name": "network-chart",
+          "title": "Network",
+        },
+      ]
+    }
+  />
+  <ProfileCallTreeView />
+  <Connect(CallNodeContextMenu) />
+  <Connect(MarkersContextMenu) />
+  <Connect(ProfileThreadHeaderContextMenu) />
+</div>
+`;
+
+exports[`app/Details show the correct state for the sidebar open button 4`] = `
+<div
+  className="Details"
+>
+  <TabBar
+    extraElements={false}
+    onChangeTabOrder={[Function]}
+    onSelectTab={[Function]}
+    selectedTabName="calltree"
+    tabOrder={
+      Array [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+      ]
+    }
+    tabs={
+      Array [
+        Object {
+          "name": "calltree",
+          "title": "Call Tree",
+        },
+        Object {
+          "name": "flame-graph",
+          "title": "Flame Graph",
+        },
+        Object {
+          "name": "stack-chart",
+          "title": "Stack Chart",
+        },
+        Object {
+          "name": "marker-chart",
+          "title": "Marker Chart",
+        },
+        Object {
+          "name": "marker-table",
+          "title": "Marker Table",
+        },
+        Object {
+          "name": "network-chart",
+          "title": "Network",
+        },
+      ]
+    }
+  />
+  <ProfileCallTreeView />
   <Connect(CallNodeContextMenu) />
   <Connect(MarkersContextMenu) />
   <Connect(ProfileThreadHeaderContextMenu) />

--- a/src/test/store/app.test.js
+++ b/src/test/store/app.test.js
@@ -126,6 +126,21 @@ describe('app actions', function() {
     });
   });
 
+  describe('isSidebarOpen', function() {
+    it('can change the state of the sidebar', function() {
+      const { dispatch, getState } = storeWithSimpleProfile();
+      expect(AppSelectors.getIsSidebarOpen(getState())).toEqual(false);
+      dispatch(AppActions.changeSidebarOpenState('calltree', true));
+      expect(AppSelectors.getIsSidebarOpen(getState())).toEqual(true);
+      dispatch(AppActions.changeSelectedTab('flame-graph'));
+      expect(AppSelectors.getIsSidebarOpen(getState())).toEqual(false);
+      dispatch(AppActions.changeSidebarOpenState('flame-graph', true));
+      expect(AppSelectors.getIsSidebarOpen(getState())).toEqual(true);
+      dispatch(AppActions.changeSidebarOpenState('calltree', false));
+      expect(AppSelectors.getIsSidebarOpen(getState())).toEqual(true);
+    });
+  });
+
   describe('updateUrlState', function() {
     it('can swap out to a different URL state', function() {
       const { dispatch, getState } = storeWithSimpleProfile();

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -198,9 +198,16 @@ type IconsAction =
   | { type: 'ICON_HAS_LOADED', icon: string }
   | { type: 'ICON_IN_ERROR', icon: string };
 
+type SidebarAction = {|
+  type: 'CHANGE_SIDEBAR_OPEN_STATE',
+  tab: TabSlug,
+  isOpen: boolean,
+|};
+
 export type Action =
   | ProfileAction
   | ReceiveProfileAction
+  | SidebarAction
   | StackChartAction
   | UrlEnhancerAction
   | UrlStateAction

--- a/src/types/reducers.js
+++ b/src/types/reducers.js
@@ -100,11 +100,14 @@ export type ZipFileState =
       +pathInZipFile: string,
     |};
 
-export type AppState = {
-  view: AppViewState,
-  isUrlSetupDone: boolean,
-  hasZoomedViaMousewheel: boolean,
-};
+export type IsSidebarOpenPerPanelState = { [TabSlug]: boolean };
+
+export type AppState = {|
+  +view: AppViewState,
+  +isUrlSetupDone: boolean,
+  +hasZoomedViaMousewheel: boolean,
+  +isSidebarOpenPerPanel: IsSidebarOpenPerPanelState,
+|};
 
 export type ZippedProfilesState = {
   zipFile: ZipFileState,


### PR DESCRIPTION
* Closed:
![image](https://user-images.githubusercontent.com/454175/42104227-154ff4a6-7bcc-11e8-8ef0-00410a856672.png)

* Open:
![image](https://user-images.githubusercontent.com/454175/42104210-0860f704-7bcc-11e8-9245-b6c639a1345b.png)


With Harald we discussed that it should be open by default, but I made it closed by default for now while we finish polishing. By being closed by default, I think we can enable it once #1041 lands (without that PR it's quite useless).

[Here's a direct link to this deployed PR with a profile](https://deploy-preview-1096--perf-html.netlify.com/public/280e10708c0660695ef5af145c53179d29d9796c/calltree/?thread=4&threadOrder=0-2-3-4-5-1&v=3).