### PR TITLE
Add a 'Share with/without URLs' button after sharing with or without URLs

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -7,7 +7,7 @@ import { getSelectedTab, getDataSource } from '../reducers/url-state';
 import { sendAnalytics } from '../utils/analytics';
 import type { Action, ThunkAction } from '../types/store';
 import type { TabSlug } from '../app-logic/tabs-handling';
-import type { UrlState } from '../types/reducers';
+import type { ProfileSharingStatus, UrlState } from '../types/reducers';
 
 export function changeSelectedTab(selectedTab: TabSlug): ThunkAction<void> {
   return (dispatch, getState) => {
@@ -29,6 +29,15 @@ export function profilePublished(hash: string): Action {
   return {
     type: 'PROFILE_PUBLISHED',
     hash,
+  };
+}
+
+export function setProfileSharingStatus(
+  profileSharingStatus: ProfileSharingStatus
+): Action {
+  return {
+    type: 'SET_PROFILE_SHARING_STATUS',
+    profileSharingStatus,
   };
 }
 

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -15,6 +15,7 @@ import { decompress } from '../utils/gz';
 import { TemporaryError } from '../utils/errors';
 import JSZip from 'jszip';
 import {
+  getDataSource,
   getHiddenThreads,
   getSelectedThreadIndexOrNull,
 } from '../reducers/url-state';
@@ -50,6 +51,7 @@ export function viewProfile(
 ): ThunkAction<void> {
   return (dispatch, getState) => {
     const threadIndexes = profile.threads.map((_, threadIndex) => threadIndex);
+    const dataSource = getDataSource(getState());
     let hiddenThreadIndexes;
     let selectedThreadIndex = getSelectedThreadIndexOrNull(getState());
 
@@ -93,6 +95,7 @@ export function viewProfile(
       hiddenThreadIndexes,
       selectedThreadIndex,
       pathInZipFile,
+      dataSource,
     });
   };
 }

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -19,6 +19,7 @@ import {
   getSelectedThreadIndexOrNull,
 } from '../reducers/url-state';
 import { defaultThreadOrder } from '../profile-logic/profile-data';
+import { setProfileSharingStatus } from './app';
 
 import type {
   FunctionsUpdatePerThread,
@@ -94,6 +95,16 @@ export function viewProfile(
       selectedThreadIndex,
       pathInZipFile,
     });
+
+    // Update ProfileSharingStatus from profile metadata.
+    // If the profiler is not published before, networkURLsRemoved
+    // will be undefined.
+    dispatch(
+      setProfileSharingStatus({
+        sharedWithUrls: profile.meta.networkURLsRemoved === false,
+        sharedWithoutUrls: profile.meta.networkURLsRemoved === true,
+      })
+    );
   };
 }
 

--- a/src/actions/receive-profile.js
+++ b/src/actions/receive-profile.js
@@ -19,7 +19,6 @@ import {
   getSelectedThreadIndexOrNull,
 } from '../reducers/url-state';
 import { defaultThreadOrder } from '../profile-logic/profile-data';
-import { setProfileSharingStatus } from './app';
 
 import type {
   FunctionsUpdatePerThread,
@@ -95,16 +94,6 @@ export function viewProfile(
       selectedThreadIndex,
       pathInZipFile,
     });
-
-    // Update ProfileSharingStatus from profile metadata.
-    // If the profiler is not published before, networkURLsRemoved
-    // will be undefined.
-    dispatch(
-      setProfileSharingStatus({
-        sharedWithUrls: profile.meta.networkURLsRemoved === false,
-        sharedWithoutUrls: profile.meta.networkURLsRemoved === true,
-      })
-    );
   };
 }
 

--- a/src/components/app/ProfileSharing.css
+++ b/src/components/app/ProfileSharing.css
@@ -21,7 +21,8 @@
 .profileSharingShareButton,
 .profileSharingUploadingButton,
 .profileSharingPermalinkButton,
-.profileSharingUploadErrorButton {
+.profileSharingUploadErrorButton,
+.profileSharingSecondaryShareButton {
   height: 24px;
   margin-bottom: -24px;
 }
@@ -61,7 +62,8 @@
   background: var(--internal-uploading-progress-fill-color);
 }
 
-.profileSharingShareButtonButton:not([disabled]) {
+.profileSharingShareButtonButton:not([disabled]),
+.profileSharingSecondaryShareButtonButton:not([disabled]) {
   background-color: var(--internal-share-button-background-color);
   color: white;
 }
@@ -69,20 +71,23 @@
 .profileSharingCompositeButtonContainer:not(.currentButtonIsShareButton) > .profileSharingShareButton,
 .profileSharingCompositeButtonContainer:not(.currentButtonIsUploadingButton) > .profileSharingUploadingButton,
 .profileSharingCompositeButtonContainer:not(.currentButtonIsPermalinkButton) > .profileSharingPermalinkButton,
-.profileSharingCompositeButtonContainer:not(.currentButtonIsUploadErrorButton) > .profileSharingUploadErrorButton {
+.profileSharingCompositeButtonContainer:not(.currentButtonIsUploadErrorButton) > .profileSharingUploadErrorButton,
+.profileSharingCompositeButtonContainer:not(.currentButtonIsSecondaryShareButton) > .profileSharingSecondaryShareButton {
   pointer-events: none;
 }
 
 .profileSharingShareButtonButton,
 .profileSharingUploadingButtonInner,
 .profileSharingPermalinkButtonButton,
-.profileSharingUploadErrorButtonButton {
-  transition: transform 200ms ease-in-out;
+.profileSharingUploadErrorButtonButton,
+.profileSharingSecondaryShareButtonButton {
+  transition: transform 200ms ease-in-out, margin-left 200ms ease-in-out;
 }
 
 .profileSharingCompositeButtonContainer:not(.currentButtonIsShareButton) > .profileSharingShareButton > .buttonWithPanelButtonWrapper > .profileSharingShareButtonButton,
 .profileSharingCompositeButtonContainer.currentButtonIsPermalinkButton > .profileSharingUploadingButton > .profileSharingUploadingButtonInner,
-.profileSharingCompositeButtonContainer.currentButtonIsUploadErrorButton > .profileSharingUploadingButton > .profileSharingUploadingButtonInner {
+.profileSharingCompositeButtonContainer.currentButtonIsUploadErrorButton > .profileSharingUploadingButton > .profileSharingUploadingButtonInner,
+.profileSharingCompositeButtonContainer:not(.currentButtonIsSecondaryShareButton) .profileSharingSecondaryShareButtonButton {
   transform: translateY(-24px);
 }
 
@@ -90,6 +95,14 @@
 .profileSharingCompositeButtonContainer:not(.currentButtonIsPermalinkButton) > .profileSharingPermalinkButton > .buttonWithPanelButtonWrapper > .profileSharingPermalinkButtonButton,
 .profileSharingCompositeButtonContainer:not(.currentButtonIsUploadErrorButton) > .profileSharingUploadErrorButton > .buttonWithPanelButtonWrapper > .profileSharingUploadErrorButtonButton {
   transform: translateY(24px);
+}
+
+.currentButtonIsPermalinkButton.currentButtonIsSecondaryShareButton .profileSharingPermalinkButton {
+  width: 112px;
+}
+
+.currentButtonIsPermalinkButton.currentButtonIsSecondaryShareButton .profileSharingSecondaryShareButton {
+  margin-left: 112px;
 }
 
 .profileSharingPrivacyPanel,

--- a/src/components/app/ProfileSharing.js
+++ b/src/components/app/ProfileSharing.js
@@ -353,8 +353,10 @@ class ProfileSharingCompositeButton extends PureComponent<
 
   _onSecondarySharePanelOpen() {
     const { profileSharingStatus } = this.props;
-    // Even if the sharedWitouthUrls is true, we force it to share
-    // without URLs if `profileSharingStatus.sharedWithUrls` is true.
+    // In the secondary sharing panel, we disable the URL sharing checkbox and
+    // force it to the value we haven't used yet.
+    // Note that we can't have both sharedWithUrls and sharedWithoutUrls set to
+    // true here because we don't show the secondary panel when that's the case.
     this.setState({
       shareNetworkUrls: !profileSharingStatus.sharedWithUrls,
     });
@@ -373,7 +375,7 @@ class ProfileSharingCompositeButton extends PureComponent<
     // 1. If we loaded a profile from a file or the public store that got its network URLs removed before.
     //    Note that profiles captured from the add-on have this property set to false.
     // 2. If it's been shared in both modes already; in that case we show no button at all.
-    const wontSecondaryShareProfile =
+    const disableSecondaryShareProfile =
       profile.meta.networkURLsRemoved ||
       (profileSharingStatus.sharedWithUrls &&
         profileSharingStatus.sharedWithoutUrls);
@@ -382,7 +384,7 @@ class ProfileSharingCompositeButton extends PureComponent<
     // (either loaded from a public store or previously shared), because otherwise
     // we show the primary button (or errors).
     const isSecondaryShareButtonVisible =
-      state === 'public' && !wontSecondaryShareProfile;
+      state === 'public' && !disableSecondaryShareProfile;
 
     const secondaryShareLabel = profileSharingStatus.sharedWithUrls
       ? 'Share without URLs'

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -842,39 +842,36 @@ export function serializeProfile(
   includeNetworkUrls: boolean = true
 ): string {
   // stringTable -> stringArray
-  const newProfile = Object.assign(
-    {},
-    { meta: { ...profile.meta, networkURLsRemoved: !includeNetworkUrls } },
-    {
-      threads: profile.threads.map(thread => {
-        const stringArray = thread.stringTable.serializeToArray();
-        const newThread = Object.assign({}, thread);
-        delete newThread.stringTable;
-        if (includeNetworkUrls === false) {
-          for (let i = 0; i < newThread.markers.length; i++) {
-            const currentMarker = newThread.markers.data[i];
-            if (
-              currentMarker &&
-              currentMarker.type &&
-              currentMarker.type === 'Network'
-            ) {
-              // Remove the URI fields from marker payload.
-              currentMarker.URI = '';
-              currentMarker.RedirectURI = '';
-              // Strip the URL from the marker name
-              const stringIndex = newThread.markers.name[i];
-              stringArray[stringIndex] = stringArray[stringIndex].replace(
-                /:.*/,
-                ''
-              );
-            }
+  const newProfile = Object.assign({}, profile, {
+    meta: { ...profile.meta, networkURLsRemoved: !includeNetworkUrls },
+    threads: profile.threads.map(thread => {
+      const stringArray = thread.stringTable.serializeToArray();
+      const newThread = Object.assign({}, thread);
+      delete newThread.stringTable;
+      if (includeNetworkUrls === false) {
+        for (let i = 0; i < newThread.markers.length; i++) {
+          const currentMarker = newThread.markers.data[i];
+          if (
+            currentMarker &&
+            currentMarker.type &&
+            currentMarker.type === 'Network'
+          ) {
+            // Remove the URI fields from marker payload.
+            currentMarker.URI = '';
+            currentMarker.RedirectURI = '';
+            // Strip the URL from the marker name
+            const stringIndex = newThread.markers.name[i];
+            stringArray[stringIndex] = stringArray[stringIndex].replace(
+              /:.*/,
+              ''
+            );
           }
         }
-        newThread.stringArray = stringArray;
-        return newThread;
-      }),
-    }
-  );
+      }
+      newThread.stringArray = stringArray;
+      return newThread;
+    }),
+  });
   return JSON.stringify(newProfile);
 }
 

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -433,8 +433,15 @@ function profileSharingStatus(
     case 'SET_PROFILE_SHARING_STATUS':
       return action.profileSharingStatus;
     case 'VIEW_PROFILE':
+      // Here are the possible cases:
+      // - older shared profiles, newly captured profiles, and profiles from a file don't
+      //   have the property `networkURLsRemoved`. We use the `dataSource` value
+      //   to distinguish between these cases.
+      // - newer profiles that have been shared do have this property.
       return {
-        sharedWithUrls: action.profile.meta.networkURLsRemoved === false,
+        sharedWithUrls:
+          !action.profile.meta.networkURLsRemoved &&
+          action.dataSource === 'public',
         sharedWithoutUrls: action.profile.meta.networkURLsRemoved === true,
       };
     default:

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -42,6 +42,7 @@ import type {
   State,
   Reducer,
   ProfileViewState,
+  ProfileSharingStatus,
   RequestedLib,
   SymbolicationStatus,
   ThreadViewOptions,
@@ -421,6 +422,21 @@ function isCallNodeContextMenuVisible(state: boolean = false, action: Action) {
   }
 }
 
+function profileSharingStatus(
+  state: ProfileSharingStatus = {
+    sharedWithUrls: false,
+    sharedWithoutUrls: false,
+  },
+  action: Action
+): ProfileSharingStatus {
+  switch (action.type) {
+    case 'SET_PROFILE_SHARING_STATUS':
+      return action.profileSharingStatus;
+    default:
+      return state;
+  }
+}
+
 /**
  * Provide a mechanism to wrap the reducer in a special function that can reset
  * the state to the default values. This is useful when viewing multiple profiles
@@ -456,6 +472,7 @@ export default wrapReducerInResetter(
       tabOrder,
       rightClickedThread,
       isCallNodeContextMenuVisible,
+      profileSharingStatus,
     }),
     profile,
   })
@@ -473,6 +490,8 @@ export const getProfileRootRange = (state: State) =>
   getProfileViewOptions(state).rootRange;
 export const getSymbolicationStatus = (state: State) =>
   getProfileViewOptions(state).symbolicationStatus;
+export const getProfileSharingStatus = (state: State) =>
+  getProfileViewOptions(state).profileSharingStatus;
 export const getScrollToSelectionGeneration = createSelector(
   getProfileViewOptions,
   viewOptions => viewOptions.scrollToSelectionGeneration

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -432,6 +432,11 @@ function profileSharingStatus(
   switch (action.type) {
     case 'SET_PROFILE_SHARING_STATUS':
       return action.profileSharingStatus;
+    case 'VIEW_PROFILE':
+      return {
+        sharedWithUrls: action.profile.meta.networkURLsRemoved === false,
+        sharedWithoutUrls: action.profile.meta.networkURLsRemoved === true,
+      };
     default:
       return state;
   }

--- a/src/test/components/ProfileSharing.test.js
+++ b/src/test/components/ProfileSharing.test.js
@@ -12,24 +12,65 @@ import {
   startSymbolicating,
   doneSymbolicating,
 } from '../../actions/receive-profile';
+import exampleProfile from '../fixtures/profiles/timings-with-js';
+import { processProfile } from '../../profile-logic/process-profile';
 
 describe('app/ProfileSharing', function() {
-  it('renders the ProfileSharing buttons', () => {
-    /**
-     * Mock out any created refs for the components with relevant information.
-     */
-    function createNodeMock(element) {
-      if (element.type === 'input') {
-        return {
-          focus() {},
-          select() {},
-          blur() {},
-        };
-      }
-      return null;
+  /**
+   * Mock out any created refs for the components with relevant information.
+   */
+  function createNodeMock(element) {
+    if (element.type === 'input') {
+      return {
+        focus() {},
+        select() {},
+        blur() {},
+      };
     }
+    return null;
+  }
 
+  // profile.meta.networkURLsRemoved flag is set to false as a default.
+  it('renders the ProfileSharing buttons', () => {
     const store = storeWithProfile();
+    store.dispatch(startSymbolicating());
+
+    const profileSharing = renderer.create(
+      <Provider store={store}>
+        <ProfileSharing />
+      </Provider>,
+      { createNodeMock }
+    );
+
+    expect(profileSharing).toMatchSnapshot();
+
+    store.dispatch(doneSymbolicating());
+    expect(profileSharing).toMatchSnapshot();
+  });
+
+  it('renders the ProfileSharing buttons with profile.meta.networkURLsRemoved set to true', () => {
+    const profile = processProfile(exampleProfile());
+    profile.meta.networkURLsRemoved = true;
+    const store = storeWithProfile(profile);
+    store.dispatch(startSymbolicating());
+
+    const profileSharing = renderer.create(
+      <Provider store={store}>
+        <ProfileSharing />
+      </Provider>,
+      { createNodeMock }
+    );
+
+    expect(profileSharing).toMatchSnapshot();
+
+    store.dispatch(doneSymbolicating());
+    expect(profileSharing).toMatchSnapshot();
+  });
+
+  it('renders the ProfileSharing buttons with profile.meta.networkURLsRemoved set to undefined', () => {
+    const profile = processProfile(exampleProfile());
+    profile.meta.networkURLsRemoved = undefined;
+    const store = storeWithProfile(profile);
     store.dispatch(startSymbolicating());
 
     const profileSharing = renderer.create(

--- a/src/test/components/__snapshots__/ProfileSharing.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileSharing.test.js.snap
@@ -73,6 +73,7 @@ exports[`app/ProfileSharing renders the ProfileSharing buttons 1`] = `
                 <input
                   checked={false}
                   className="profileSharingShareNetworkUrlsCheckbox"
+                  disabled={false}
                   onChange={[Function]}
                   type="checkbox"
                 />
@@ -202,6 +203,99 @@ exports[`app/ProfileSharing renders the ProfileSharing buttons 1`] = `
               onClick={[Function]}
               type="button"
               value="Try Again"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="buttonWithPanel profileSharingSecondaryShareButton"
+    >
+      <div
+        className="buttonWithPanelButtonWrapper"
+      >
+        <input
+          className="buttonWithPanelButton profileSharingSecondaryShareButtonButton"
+          disabled={true}
+          onClick={[Function]}
+          type="button"
+          value="Share without URLs"
+        />
+      </div>
+      <div
+        className="arrowPanelAnchor"
+      >
+        <div
+          className="arrowPanel hasTitle hasButtons profileSharingPrivacyPanel"
+        >
+          <div
+            className="arrowPanelArrow"
+          />
+          <h1
+            className="arrowPanelTitle"
+          >
+            Upload Profile – Privacy Notice
+          </h1>
+          <div
+            className="arrowPanelContent"
+          >
+            <section
+              className="privacyNotice"
+            >
+              <p>
+                You’re about to upload your profile publicly where anyone will be able to access it.
+      To better diagnose performance problems profiles include the following information:
+              </p>
+              <ul>
+                <li>
+                  The URLs of all painted tabs, and running scripts.
+                </li>
+                <li>
+                  The metadata of all your add-ons to identify slow add-ons.
+                </li>
+                <li>
+                  Firefox build and runtime configuration.
+                </li>
+              </ul>
+              <p>
+                To view all the information you can download the full profile to a file and open the
+      json structure with a text editor.
+              </p>
+              <p>
+                By default, the URLs of all network requests will be removed while sharing the profile
+        but keeping the URLs may help to identify the problems. Please select the checkbox
+        below to share the URLs of the network requests:
+              </p>
+            </section>
+            <p
+              className="profileSharingShareNetworkUrlsContainer"
+            >
+              <label>
+                <input
+                  checked={false}
+                  className="profileSharingShareNetworkUrlsCheckbox"
+                  disabled={true}
+                  onChange={undefined}
+                  type="checkbox"
+                />
+                Share the URLs of all network requests
+              </label>
+            </p>
+          </div>
+          <div
+            className="arrowPanelButtons"
+          >
+            <input
+              className="arrowPanelCancelButton"
+              onClick={[Function]}
+              type="button"
+              value="Cancel"
+            />
+            <input
+              className="arrowPanelOkButton"
+              onClick={[Function]}
+              type="button"
+              value="Share"
             />
           </div>
         </div>
@@ -320,6 +414,7 @@ exports[`app/ProfileSharing renders the ProfileSharing buttons 2`] = `
                 <input
                   checked={false}
                   className="profileSharingShareNetworkUrlsCheckbox"
+                  disabled={false}
                   onChange={[Function]}
                   type="checkbox"
                 />
@@ -449,6 +544,99 @@ exports[`app/ProfileSharing renders the ProfileSharing buttons 2`] = `
               onClick={[Function]}
               type="button"
               value="Try Again"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="buttonWithPanel profileSharingSecondaryShareButton"
+    >
+      <div
+        className="buttonWithPanelButtonWrapper"
+      >
+        <input
+          className="buttonWithPanelButton profileSharingSecondaryShareButtonButton"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+          value="Share without URLs"
+        />
+      </div>
+      <div
+        className="arrowPanelAnchor"
+      >
+        <div
+          className="arrowPanel hasTitle hasButtons profileSharingPrivacyPanel"
+        >
+          <div
+            className="arrowPanelArrow"
+          />
+          <h1
+            className="arrowPanelTitle"
+          >
+            Upload Profile – Privacy Notice
+          </h1>
+          <div
+            className="arrowPanelContent"
+          >
+            <section
+              className="privacyNotice"
+            >
+              <p>
+                You’re about to upload your profile publicly where anyone will be able to access it.
+      To better diagnose performance problems profiles include the following information:
+              </p>
+              <ul>
+                <li>
+                  The URLs of all painted tabs, and running scripts.
+                </li>
+                <li>
+                  The metadata of all your add-ons to identify slow add-ons.
+                </li>
+                <li>
+                  Firefox build and runtime configuration.
+                </li>
+              </ul>
+              <p>
+                To view all the information you can download the full profile to a file and open the
+      json structure with a text editor.
+              </p>
+              <p>
+                By default, the URLs of all network requests will be removed while sharing the profile
+        but keeping the URLs may help to identify the problems. Please select the checkbox
+        below to share the URLs of the network requests:
+              </p>
+            </section>
+            <p
+              className="profileSharingShareNetworkUrlsContainer"
+            >
+              <label>
+                <input
+                  checked={false}
+                  className="profileSharingShareNetworkUrlsCheckbox"
+                  disabled={true}
+                  onChange={undefined}
+                  type="checkbox"
+                />
+                Share the URLs of all network requests
+              </label>
+            </p>
+          </div>
+          <div
+            className="arrowPanelButtons"
+          >
+            <input
+              className="arrowPanelCancelButton"
+              onClick={[Function]}
+              type="button"
+              value="Cancel"
+            />
+            <input
+              className="arrowPanelOkButton"
+              onClick={[Function]}
+              type="button"
+              value="Share"
             />
           </div>
         </div>

--- a/src/test/components/__snapshots__/ProfileSharing.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileSharing.test.js.snap
@@ -681,3 +681,1367 @@ exports[`app/ProfileSharing renders the ProfileSharing buttons 2`] = `
   </div>
 </div>
 `;
+
+exports[`app/ProfileSharing renders the ProfileSharing buttons with profile.meta.networkURLsRemoved set to true 1`] = `
+<div
+  className="profileSharing"
+>
+  <div
+    className="profileSharingCompositeButtonContainer currentButtonIsShareButton"
+  >
+    <div
+      className="buttonWithPanel profileSharingShareButton"
+    >
+      <div
+        className="buttonWithPanelButtonWrapper"
+      >
+        <input
+          className="buttonWithPanelButton profileSharingShareButtonButton"
+          disabled={true}
+          onClick={[Function]}
+          type="button"
+          value="Sharing will be enabled once symbolication is complete"
+        />
+      </div>
+      <div
+        className="arrowPanelAnchor"
+      >
+        <div
+          className="arrowPanel hasTitle hasButtons profileSharingPrivacyPanel"
+        >
+          <div
+            className="arrowPanelArrow"
+          />
+          <h1
+            className="arrowPanelTitle"
+          >
+            Upload Profile – Privacy Notice
+          </h1>
+          <div
+            className="arrowPanelContent"
+          >
+            <section
+              className="privacyNotice"
+            >
+              <p>
+                You’re about to upload your profile publicly where anyone will be able to access it.
+      To better diagnose performance problems profiles include the following information:
+              </p>
+              <ul>
+                <li>
+                  The URLs of all painted tabs, and running scripts.
+                </li>
+                <li>
+                  The metadata of all your add-ons to identify slow add-ons.
+                </li>
+                <li>
+                  Firefox build and runtime configuration.
+                </li>
+              </ul>
+              <p>
+                To view all the information you can download the full profile to a file and open the
+      json structure with a text editor.
+              </p>
+              <p>
+                By default, the URLs of all network requests will be removed while sharing the profile
+        but keeping the URLs may help to identify the problems. Please select the checkbox
+        below to share the URLs of the network requests:
+              </p>
+            </section>
+            <p
+              className="profileSharingShareNetworkUrlsContainer"
+            >
+              <label>
+                <input
+                  checked={false}
+                  className="profileSharingShareNetworkUrlsCheckbox"
+                  disabled={false}
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                Share the URLs of all network requests
+              </label>
+            </p>
+          </div>
+          <div
+            className="arrowPanelButtons"
+          >
+            <input
+              className="arrowPanelCancelButton"
+              onClick={[Function]}
+              type="button"
+              value="Cancel"
+            />
+            <input
+              className="arrowPanelOkButton"
+              onClick={[Function]}
+              type="button"
+              value="Share"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="profileSharingUploadingButton"
+    >
+      <div
+        className="profileSharingUploadingButtonInner"
+      >
+        <progress
+          className="profileSharingUploadingButtonProgress"
+          value={0}
+        />
+        <div
+          className="profileSharingUploadingButtonLabel"
+        >
+          Uploading...
+        </div>
+      </div>
+    </div>
+    <div
+      className="buttonWithPanel profileSharingPermalinkButton"
+    >
+      <div
+        className="buttonWithPanelButtonWrapper"
+      >
+        <input
+          className="buttonWithPanelButton profileSharingPermalinkButtonButton"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+          value="Permalink"
+        />
+      </div>
+      <div
+        className="arrowPanelAnchor"
+      >
+        <div
+          className="arrowPanel profileSharingPermalinkPanel"
+        >
+          <div
+            className="arrowPanelArrow"
+          />
+          <div
+            className="arrowPanelContent"
+          >
+            <input
+              className="profileSharingPermalinkTextField"
+              readOnly="readOnly"
+              type="text"
+              value="about:blank"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="buttonWithPanel profileSharingUploadErrorButton"
+    >
+      <div
+        className="buttonWithPanelButtonWrapper"
+      >
+        <input
+          className="buttonWithPanelButton profileSharingUploadErrorButtonButton"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+          value="Upload Error"
+        />
+      </div>
+      <div
+        className="arrowPanelAnchor"
+      >
+        <div
+          className="arrowPanel hasTitle hasButtons profileSharingUploadErrorPanel"
+        >
+          <div
+            className="arrowPanelArrow"
+          />
+          <h1
+            className="arrowPanelTitle"
+          >
+            Upload Error
+          </h1>
+          <div
+            className="arrowPanelContent"
+          >
+            <p>
+              An error occurred during upload:
+            </p>
+            <pre />
+          </div>
+          <div
+            className="arrowPanelButtons"
+          >
+            <input
+              className="arrowPanelCancelButton"
+              onClick={[Function]}
+              type="button"
+              value="Cancel"
+            />
+            <input
+              className="arrowPanelOkButton"
+              onClick={[Function]}
+              type="button"
+              value="Try Again"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="buttonWithPanel profileSharingSecondaryShareButton"
+    >
+      <div
+        className="buttonWithPanelButtonWrapper"
+      >
+        <input
+          className="buttonWithPanelButton profileSharingSecondaryShareButtonButton"
+          disabled={true}
+          onClick={[Function]}
+          type="button"
+          value="Share with URLs"
+        />
+      </div>
+      <div
+        className="arrowPanelAnchor"
+      >
+        <div
+          className="arrowPanel hasTitle hasButtons profileSharingPrivacyPanel"
+        >
+          <div
+            className="arrowPanelArrow"
+          />
+          <h1
+            className="arrowPanelTitle"
+          >
+            Upload Profile – Privacy Notice
+          </h1>
+          <div
+            className="arrowPanelContent"
+          >
+            <section
+              className="privacyNotice"
+            >
+              <p>
+                You’re about to upload your profile publicly where anyone will be able to access it.
+      To better diagnose performance problems profiles include the following information:
+              </p>
+              <ul>
+                <li>
+                  The URLs of all painted tabs, and running scripts.
+                </li>
+                <li>
+                  The metadata of all your add-ons to identify slow add-ons.
+                </li>
+                <li>
+                  Firefox build and runtime configuration.
+                </li>
+              </ul>
+              <p>
+                To view all the information you can download the full profile to a file and open the
+      json structure with a text editor.
+              </p>
+              <p>
+                By default, the URLs of all network requests will be removed while sharing the profile
+        but keeping the URLs may help to identify the problems. Please select the checkbox
+        below to share the URLs of the network requests:
+              </p>
+            </section>
+            <p
+              className="profileSharingShareNetworkUrlsContainer"
+            >
+              <label>
+                <input
+                  checked={false}
+                  className="profileSharingShareNetworkUrlsCheckbox"
+                  disabled={true}
+                  onChange={undefined}
+                  type="checkbox"
+                />
+                Share the URLs of all network requests
+              </label>
+            </p>
+          </div>
+          <div
+            className="arrowPanelButtons"
+          >
+            <input
+              className="arrowPanelCancelButton"
+              onClick={[Function]}
+              type="button"
+              value="Cancel"
+            />
+            <input
+              className="arrowPanelOkButton"
+              onClick={[Function]}
+              type="button"
+              value="Share"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="buttonWithPanel profileSharingProfileDownloadButton"
+  >
+    <div
+      className="buttonWithPanelButtonWrapper"
+    >
+      <input
+        className="buttonWithPanelButton profileSharingProfileDownloadButtonButton"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+        value="Save as file..."
+      />
+    </div>
+    <div
+      className="arrowPanelAnchor"
+    >
+      <div
+        className="arrowPanel hasTitle profileSharingProfileDownloadPanel"
+      >
+        <div
+          className="arrowPanelArrow"
+        />
+        <h1
+          className="arrowPanelTitle"
+        >
+          Save Profile to a Local File
+        </h1>
+        <div
+          className="arrowPanelContent"
+        >
+          <section />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`app/ProfileSharing renders the ProfileSharing buttons with profile.meta.networkURLsRemoved set to true 2`] = `
+<div
+  className="profileSharing"
+>
+  <div
+    className="profileSharingCompositeButtonContainer currentButtonIsShareButton"
+  >
+    <div
+      className="buttonWithPanel profileSharingShareButton"
+    >
+      <div
+        className="buttonWithPanelButtonWrapper"
+      >
+        <input
+          className="buttonWithPanelButton profileSharingShareButtonButton"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+          value="Share..."
+        />
+      </div>
+      <div
+        className="arrowPanelAnchor"
+      >
+        <div
+          className="arrowPanel hasTitle hasButtons profileSharingPrivacyPanel"
+        >
+          <div
+            className="arrowPanelArrow"
+          />
+          <h1
+            className="arrowPanelTitle"
+          >
+            Upload Profile – Privacy Notice
+          </h1>
+          <div
+            className="arrowPanelContent"
+          >
+            <section
+              className="privacyNotice"
+            >
+              <p>
+                You’re about to upload your profile publicly where anyone will be able to access it.
+      To better diagnose performance problems profiles include the following information:
+              </p>
+              <ul>
+                <li>
+                  The URLs of all painted tabs, and running scripts.
+                </li>
+                <li>
+                  The metadata of all your add-ons to identify slow add-ons.
+                </li>
+                <li>
+                  Firefox build and runtime configuration.
+                </li>
+              </ul>
+              <p>
+                To view all the information you can download the full profile to a file and open the
+      json structure with a text editor.
+              </p>
+              <p>
+                By default, the URLs of all network requests will be removed while sharing the profile
+        but keeping the URLs may help to identify the problems. Please select the checkbox
+        below to share the URLs of the network requests:
+              </p>
+            </section>
+            <p
+              className="profileSharingShareNetworkUrlsContainer"
+            >
+              <label>
+                <input
+                  checked={false}
+                  className="profileSharingShareNetworkUrlsCheckbox"
+                  disabled={false}
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                Share the URLs of all network requests
+              </label>
+            </p>
+          </div>
+          <div
+            className="arrowPanelButtons"
+          >
+            <input
+              className="arrowPanelCancelButton"
+              onClick={[Function]}
+              type="button"
+              value="Cancel"
+            />
+            <input
+              className="arrowPanelOkButton"
+              onClick={[Function]}
+              type="button"
+              value="Share"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="profileSharingUploadingButton"
+    >
+      <div
+        className="profileSharingUploadingButtonInner"
+      >
+        <progress
+          className="profileSharingUploadingButtonProgress"
+          value={0}
+        />
+        <div
+          className="profileSharingUploadingButtonLabel"
+        >
+          Uploading...
+        </div>
+      </div>
+    </div>
+    <div
+      className="buttonWithPanel profileSharingPermalinkButton"
+    >
+      <div
+        className="buttonWithPanelButtonWrapper"
+      >
+        <input
+          className="buttonWithPanelButton profileSharingPermalinkButtonButton"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+          value="Permalink"
+        />
+      </div>
+      <div
+        className="arrowPanelAnchor"
+      >
+        <div
+          className="arrowPanel profileSharingPermalinkPanel"
+        >
+          <div
+            className="arrowPanelArrow"
+          />
+          <div
+            className="arrowPanelContent"
+          >
+            <input
+              className="profileSharingPermalinkTextField"
+              readOnly="readOnly"
+              type="text"
+              value="about:blank"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="buttonWithPanel profileSharingUploadErrorButton"
+    >
+      <div
+        className="buttonWithPanelButtonWrapper"
+      >
+        <input
+          className="buttonWithPanelButton profileSharingUploadErrorButtonButton"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+          value="Upload Error"
+        />
+      </div>
+      <div
+        className="arrowPanelAnchor"
+      >
+        <div
+          className="arrowPanel hasTitle hasButtons profileSharingUploadErrorPanel"
+        >
+          <div
+            className="arrowPanelArrow"
+          />
+          <h1
+            className="arrowPanelTitle"
+          >
+            Upload Error
+          </h1>
+          <div
+            className="arrowPanelContent"
+          >
+            <p>
+              An error occurred during upload:
+            </p>
+            <pre />
+          </div>
+          <div
+            className="arrowPanelButtons"
+          >
+            <input
+              className="arrowPanelCancelButton"
+              onClick={[Function]}
+              type="button"
+              value="Cancel"
+            />
+            <input
+              className="arrowPanelOkButton"
+              onClick={[Function]}
+              type="button"
+              value="Try Again"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="buttonWithPanel profileSharingSecondaryShareButton"
+    >
+      <div
+        className="buttonWithPanelButtonWrapper"
+      >
+        <input
+          className="buttonWithPanelButton profileSharingSecondaryShareButtonButton"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+          value="Share with URLs"
+        />
+      </div>
+      <div
+        className="arrowPanelAnchor"
+      >
+        <div
+          className="arrowPanel hasTitle hasButtons profileSharingPrivacyPanel"
+        >
+          <div
+            className="arrowPanelArrow"
+          />
+          <h1
+            className="arrowPanelTitle"
+          >
+            Upload Profile – Privacy Notice
+          </h1>
+          <div
+            className="arrowPanelContent"
+          >
+            <section
+              className="privacyNotice"
+            >
+              <p>
+                You’re about to upload your profile publicly where anyone will be able to access it.
+      To better diagnose performance problems profiles include the following information:
+              </p>
+              <ul>
+                <li>
+                  The URLs of all painted tabs, and running scripts.
+                </li>
+                <li>
+                  The metadata of all your add-ons to identify slow add-ons.
+                </li>
+                <li>
+                  Firefox build and runtime configuration.
+                </li>
+              </ul>
+              <p>
+                To view all the information you can download the full profile to a file and open the
+      json structure with a text editor.
+              </p>
+              <p>
+                By default, the URLs of all network requests will be removed while sharing the profile
+        but keeping the URLs may help to identify the problems. Please select the checkbox
+        below to share the URLs of the network requests:
+              </p>
+            </section>
+            <p
+              className="profileSharingShareNetworkUrlsContainer"
+            >
+              <label>
+                <input
+                  checked={false}
+                  className="profileSharingShareNetworkUrlsCheckbox"
+                  disabled={true}
+                  onChange={undefined}
+                  type="checkbox"
+                />
+                Share the URLs of all network requests
+              </label>
+            </p>
+          </div>
+          <div
+            className="arrowPanelButtons"
+          >
+            <input
+              className="arrowPanelCancelButton"
+              onClick={[Function]}
+              type="button"
+              value="Cancel"
+            />
+            <input
+              className="arrowPanelOkButton"
+              onClick={[Function]}
+              type="button"
+              value="Share"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="buttonWithPanel profileSharingProfileDownloadButton"
+  >
+    <div
+      className="buttonWithPanelButtonWrapper"
+    >
+      <input
+        className="buttonWithPanelButton profileSharingProfileDownloadButtonButton"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+        value="Save as file..."
+      />
+    </div>
+    <div
+      className="arrowPanelAnchor"
+    >
+      <div
+        className="arrowPanel hasTitle profileSharingProfileDownloadPanel"
+      >
+        <div
+          className="arrowPanelArrow"
+        />
+        <h1
+          className="arrowPanelTitle"
+        >
+          Save Profile to a Local File
+        </h1>
+        <div
+          className="arrowPanelContent"
+        >
+          <section />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`app/ProfileSharing renders the ProfileSharing buttons with profile.meta.networkURLsRemoved set to undefined 1`] = `
+<div
+  className="profileSharing"
+>
+  <div
+    className="profileSharingCompositeButtonContainer currentButtonIsShareButton"
+  >
+    <div
+      className="buttonWithPanel profileSharingShareButton"
+    >
+      <div
+        className="buttonWithPanelButtonWrapper"
+      >
+        <input
+          className="buttonWithPanelButton profileSharingShareButtonButton"
+          disabled={true}
+          onClick={[Function]}
+          type="button"
+          value="Sharing will be enabled once symbolication is complete"
+        />
+      </div>
+      <div
+        className="arrowPanelAnchor"
+      >
+        <div
+          className="arrowPanel hasTitle hasButtons profileSharingPrivacyPanel"
+        >
+          <div
+            className="arrowPanelArrow"
+          />
+          <h1
+            className="arrowPanelTitle"
+          >
+            Upload Profile – Privacy Notice
+          </h1>
+          <div
+            className="arrowPanelContent"
+          >
+            <section
+              className="privacyNotice"
+            >
+              <p>
+                You’re about to upload your profile publicly where anyone will be able to access it.
+      To better diagnose performance problems profiles include the following information:
+              </p>
+              <ul>
+                <li>
+                  The URLs of all painted tabs, and running scripts.
+                </li>
+                <li>
+                  The metadata of all your add-ons to identify slow add-ons.
+                </li>
+                <li>
+                  Firefox build and runtime configuration.
+                </li>
+              </ul>
+              <p>
+                To view all the information you can download the full profile to a file and open the
+      json structure with a text editor.
+              </p>
+              <p>
+                By default, the URLs of all network requests will be removed while sharing the profile
+        but keeping the URLs may help to identify the problems. Please select the checkbox
+        below to share the URLs of the network requests:
+              </p>
+            </section>
+            <p
+              className="profileSharingShareNetworkUrlsContainer"
+            >
+              <label>
+                <input
+                  checked={false}
+                  className="profileSharingShareNetworkUrlsCheckbox"
+                  disabled={false}
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                Share the URLs of all network requests
+              </label>
+            </p>
+          </div>
+          <div
+            className="arrowPanelButtons"
+          >
+            <input
+              className="arrowPanelCancelButton"
+              onClick={[Function]}
+              type="button"
+              value="Cancel"
+            />
+            <input
+              className="arrowPanelOkButton"
+              onClick={[Function]}
+              type="button"
+              value="Share"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="profileSharingUploadingButton"
+    >
+      <div
+        className="profileSharingUploadingButtonInner"
+      >
+        <progress
+          className="profileSharingUploadingButtonProgress"
+          value={0}
+        />
+        <div
+          className="profileSharingUploadingButtonLabel"
+        >
+          Uploading...
+        </div>
+      </div>
+    </div>
+    <div
+      className="buttonWithPanel profileSharingPermalinkButton"
+    >
+      <div
+        className="buttonWithPanelButtonWrapper"
+      >
+        <input
+          className="buttonWithPanelButton profileSharingPermalinkButtonButton"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+          value="Permalink"
+        />
+      </div>
+      <div
+        className="arrowPanelAnchor"
+      >
+        <div
+          className="arrowPanel profileSharingPermalinkPanel"
+        >
+          <div
+            className="arrowPanelArrow"
+          />
+          <div
+            className="arrowPanelContent"
+          >
+            <input
+              className="profileSharingPermalinkTextField"
+              readOnly="readOnly"
+              type="text"
+              value="about:blank"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="buttonWithPanel profileSharingUploadErrorButton"
+    >
+      <div
+        className="buttonWithPanelButtonWrapper"
+      >
+        <input
+          className="buttonWithPanelButton profileSharingUploadErrorButtonButton"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+          value="Upload Error"
+        />
+      </div>
+      <div
+        className="arrowPanelAnchor"
+      >
+        <div
+          className="arrowPanel hasTitle hasButtons profileSharingUploadErrorPanel"
+        >
+          <div
+            className="arrowPanelArrow"
+          />
+          <h1
+            className="arrowPanelTitle"
+          >
+            Upload Error
+          </h1>
+          <div
+            className="arrowPanelContent"
+          >
+            <p>
+              An error occurred during upload:
+            </p>
+            <pre />
+          </div>
+          <div
+            className="arrowPanelButtons"
+          >
+            <input
+              className="arrowPanelCancelButton"
+              onClick={[Function]}
+              type="button"
+              value="Cancel"
+            />
+            <input
+              className="arrowPanelOkButton"
+              onClick={[Function]}
+              type="button"
+              value="Try Again"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="buttonWithPanel profileSharingSecondaryShareButton"
+    >
+      <div
+        className="buttonWithPanelButtonWrapper"
+      >
+        <input
+          className="buttonWithPanelButton profileSharingSecondaryShareButtonButton"
+          disabled={true}
+          onClick={[Function]}
+          type="button"
+          value="Share with URLs"
+        />
+      </div>
+      <div
+        className="arrowPanelAnchor"
+      >
+        <div
+          className="arrowPanel hasTitle hasButtons profileSharingPrivacyPanel"
+        >
+          <div
+            className="arrowPanelArrow"
+          />
+          <h1
+            className="arrowPanelTitle"
+          >
+            Upload Profile – Privacy Notice
+          </h1>
+          <div
+            className="arrowPanelContent"
+          >
+            <section
+              className="privacyNotice"
+            >
+              <p>
+                You’re about to upload your profile publicly where anyone will be able to access it.
+      To better diagnose performance problems profiles include the following information:
+              </p>
+              <ul>
+                <li>
+                  The URLs of all painted tabs, and running scripts.
+                </li>
+                <li>
+                  The metadata of all your add-ons to identify slow add-ons.
+                </li>
+                <li>
+                  Firefox build and runtime configuration.
+                </li>
+              </ul>
+              <p>
+                To view all the information you can download the full profile to a file and open the
+      json structure with a text editor.
+              </p>
+              <p>
+                By default, the URLs of all network requests will be removed while sharing the profile
+        but keeping the URLs may help to identify the problems. Please select the checkbox
+        below to share the URLs of the network requests:
+              </p>
+            </section>
+            <p
+              className="profileSharingShareNetworkUrlsContainer"
+            >
+              <label>
+                <input
+                  checked={false}
+                  className="profileSharingShareNetworkUrlsCheckbox"
+                  disabled={true}
+                  onChange={undefined}
+                  type="checkbox"
+                />
+                Share the URLs of all network requests
+              </label>
+            </p>
+          </div>
+          <div
+            className="arrowPanelButtons"
+          >
+            <input
+              className="arrowPanelCancelButton"
+              onClick={[Function]}
+              type="button"
+              value="Cancel"
+            />
+            <input
+              className="arrowPanelOkButton"
+              onClick={[Function]}
+              type="button"
+              value="Share"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="buttonWithPanel profileSharingProfileDownloadButton"
+  >
+    <div
+      className="buttonWithPanelButtonWrapper"
+    >
+      <input
+        className="buttonWithPanelButton profileSharingProfileDownloadButtonButton"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+        value="Save as file..."
+      />
+    </div>
+    <div
+      className="arrowPanelAnchor"
+    >
+      <div
+        className="arrowPanel hasTitle profileSharingProfileDownloadPanel"
+      >
+        <div
+          className="arrowPanelArrow"
+        />
+        <h1
+          className="arrowPanelTitle"
+        >
+          Save Profile to a Local File
+        </h1>
+        <div
+          className="arrowPanelContent"
+        >
+          <section />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`app/ProfileSharing renders the ProfileSharing buttons with profile.meta.networkURLsRemoved set to undefined 2`] = `
+<div
+  className="profileSharing"
+>
+  <div
+    className="profileSharingCompositeButtonContainer currentButtonIsShareButton"
+  >
+    <div
+      className="buttonWithPanel profileSharingShareButton"
+    >
+      <div
+        className="buttonWithPanelButtonWrapper"
+      >
+        <input
+          className="buttonWithPanelButton profileSharingShareButtonButton"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+          value="Share..."
+        />
+      </div>
+      <div
+        className="arrowPanelAnchor"
+      >
+        <div
+          className="arrowPanel hasTitle hasButtons profileSharingPrivacyPanel"
+        >
+          <div
+            className="arrowPanelArrow"
+          />
+          <h1
+            className="arrowPanelTitle"
+          >
+            Upload Profile – Privacy Notice
+          </h1>
+          <div
+            className="arrowPanelContent"
+          >
+            <section
+              className="privacyNotice"
+            >
+              <p>
+                You’re about to upload your profile publicly where anyone will be able to access it.
+      To better diagnose performance problems profiles include the following information:
+              </p>
+              <ul>
+                <li>
+                  The URLs of all painted tabs, and running scripts.
+                </li>
+                <li>
+                  The metadata of all your add-ons to identify slow add-ons.
+                </li>
+                <li>
+                  Firefox build and runtime configuration.
+                </li>
+              </ul>
+              <p>
+                To view all the information you can download the full profile to a file and open the
+      json structure with a text editor.
+              </p>
+              <p>
+                By default, the URLs of all network requests will be removed while sharing the profile
+        but keeping the URLs may help to identify the problems. Please select the checkbox
+        below to share the URLs of the network requests:
+              </p>
+            </section>
+            <p
+              className="profileSharingShareNetworkUrlsContainer"
+            >
+              <label>
+                <input
+                  checked={false}
+                  className="profileSharingShareNetworkUrlsCheckbox"
+                  disabled={false}
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                Share the URLs of all network requests
+              </label>
+            </p>
+          </div>
+          <div
+            className="arrowPanelButtons"
+          >
+            <input
+              className="arrowPanelCancelButton"
+              onClick={[Function]}
+              type="button"
+              value="Cancel"
+            />
+            <input
+              className="arrowPanelOkButton"
+              onClick={[Function]}
+              type="button"
+              value="Share"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="profileSharingUploadingButton"
+    >
+      <div
+        className="profileSharingUploadingButtonInner"
+      >
+        <progress
+          className="profileSharingUploadingButtonProgress"
+          value={0}
+        />
+        <div
+          className="profileSharingUploadingButtonLabel"
+        >
+          Uploading...
+        </div>
+      </div>
+    </div>
+    <div
+      className="buttonWithPanel profileSharingPermalinkButton"
+    >
+      <div
+        className="buttonWithPanelButtonWrapper"
+      >
+        <input
+          className="buttonWithPanelButton profileSharingPermalinkButtonButton"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+          value="Permalink"
+        />
+      </div>
+      <div
+        className="arrowPanelAnchor"
+      >
+        <div
+          className="arrowPanel profileSharingPermalinkPanel"
+        >
+          <div
+            className="arrowPanelArrow"
+          />
+          <div
+            className="arrowPanelContent"
+          >
+            <input
+              className="profileSharingPermalinkTextField"
+              readOnly="readOnly"
+              type="text"
+              value="about:blank"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="buttonWithPanel profileSharingUploadErrorButton"
+    >
+      <div
+        className="buttonWithPanelButtonWrapper"
+      >
+        <input
+          className="buttonWithPanelButton profileSharingUploadErrorButtonButton"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+          value="Upload Error"
+        />
+      </div>
+      <div
+        className="arrowPanelAnchor"
+      >
+        <div
+          className="arrowPanel hasTitle hasButtons profileSharingUploadErrorPanel"
+        >
+          <div
+            className="arrowPanelArrow"
+          />
+          <h1
+            className="arrowPanelTitle"
+          >
+            Upload Error
+          </h1>
+          <div
+            className="arrowPanelContent"
+          >
+            <p>
+              An error occurred during upload:
+            </p>
+            <pre />
+          </div>
+          <div
+            className="arrowPanelButtons"
+          >
+            <input
+              className="arrowPanelCancelButton"
+              onClick={[Function]}
+              type="button"
+              value="Cancel"
+            />
+            <input
+              className="arrowPanelOkButton"
+              onClick={[Function]}
+              type="button"
+              value="Try Again"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="buttonWithPanel profileSharingSecondaryShareButton"
+    >
+      <div
+        className="buttonWithPanelButtonWrapper"
+      >
+        <input
+          className="buttonWithPanelButton profileSharingSecondaryShareButtonButton"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+          value="Share with URLs"
+        />
+      </div>
+      <div
+        className="arrowPanelAnchor"
+      >
+        <div
+          className="arrowPanel hasTitle hasButtons profileSharingPrivacyPanel"
+        >
+          <div
+            className="arrowPanelArrow"
+          />
+          <h1
+            className="arrowPanelTitle"
+          >
+            Upload Profile – Privacy Notice
+          </h1>
+          <div
+            className="arrowPanelContent"
+          >
+            <section
+              className="privacyNotice"
+            >
+              <p>
+                You’re about to upload your profile publicly where anyone will be able to access it.
+      To better diagnose performance problems profiles include the following information:
+              </p>
+              <ul>
+                <li>
+                  The URLs of all painted tabs, and running scripts.
+                </li>
+                <li>
+                  The metadata of all your add-ons to identify slow add-ons.
+                </li>
+                <li>
+                  Firefox build and runtime configuration.
+                </li>
+              </ul>
+              <p>
+                To view all the information you can download the full profile to a file and open the
+      json structure with a text editor.
+              </p>
+              <p>
+                By default, the URLs of all network requests will be removed while sharing the profile
+        but keeping the URLs may help to identify the problems. Please select the checkbox
+        below to share the URLs of the network requests:
+              </p>
+            </section>
+            <p
+              className="profileSharingShareNetworkUrlsContainer"
+            >
+              <label>
+                <input
+                  checked={false}
+                  className="profileSharingShareNetworkUrlsCheckbox"
+                  disabled={true}
+                  onChange={undefined}
+                  type="checkbox"
+                />
+                Share the URLs of all network requests
+              </label>
+            </p>
+          </div>
+          <div
+            className="arrowPanelButtons"
+          >
+            <input
+              className="arrowPanelCancelButton"
+              onClick={[Function]}
+              type="button"
+              value="Cancel"
+            />
+            <input
+              className="arrowPanelOkButton"
+              onClick={[Function]}
+              type="button"
+              value="Share"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="buttonWithPanel profileSharingProfileDownloadButton"
+  >
+    <div
+      className="buttonWithPanelButtonWrapper"
+    >
+      <input
+        className="buttonWithPanelButton profileSharingProfileDownloadButtonButton"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+        value="Save as file..."
+      />
+    </div>
+    <div
+      className="arrowPanelAnchor"
+    >
+      <div
+        className="arrowPanel hasTitle profileSharingProfileDownloadPanel"
+      >
+        <div
+          className="arrowPanelArrow"
+        />
+        <h1
+          className="arrowPanelTitle"
+        >
+          Save Profile to a Local File
+        </h1>
+        <div
+          className="arrowPanelContent"
+        >
+          <section />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/test/components/__snapshots__/ProfileSharing.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileSharing.test.js.snap
@@ -219,7 +219,7 @@ exports[`app/ProfileSharing renders the ProfileSharing buttons 1`] = `
           disabled={true}
           onClick={[Function]}
           type="button"
-          value="Share without URLs"
+          value="Share with URLs"
         />
       </div>
       <div
@@ -560,7 +560,7 @@ exports[`app/ProfileSharing renders the ProfileSharing buttons 2`] = `
           disabled={false}
           onClick={[Function]}
           type="button"
-          value="Share without URLs"
+          value="Share with URLs"
         />
       </div>
       <div

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -263,6 +263,7 @@ describe('actions/receive-profile', function() {
           },
         },
         { phase: 'DATA_LOADED' },
+        { phase: 'DATA_LOADED' },
       ]);
 
       const state = store.getState();
@@ -377,6 +378,7 @@ describe('actions/receive-profile', function() {
             message: errorMessage,
           },
         },
+        { phase: 'DATA_LOADED' },
         { phase: 'DATA_LOADED' },
       ]);
 

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -263,7 +263,6 @@ describe('actions/receive-profile', function() {
           },
         },
         { phase: 'DATA_LOADED' },
-        { phase: 'DATA_LOADED' },
       ]);
 
       const state = store.getState();
@@ -378,7 +377,6 @@ describe('actions/receive-profile', function() {
             message: errorMessage,
           },
         },
-        { phase: 'DATA_LOADED' },
         { phase: 'DATA_LOADED' },
       ]);
 

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -133,6 +133,7 @@ type ReceiveProfileAction =
       +hiddenThreadIndexes: ThreadIndex[],
       +selectedThreadIndex: ThreadIndex | null,
       +pathInZipFile: ?string,
+      +dataSource: DataSource,
     |}
   | {| +type: 'RECEIVE_ZIP_FILE', +zip: JSZip |}
   | {| +type: 'PROCESS_PROFILE_FROM_ZIP_FILE', +pathInZipFile: string |}

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -19,7 +19,7 @@ import type { TemporaryError } from '../utils/errors';
 import type { Transform } from './transforms';
 import type { IndexIntoZipFileTable } from '../profile-logic/zip-files';
 import type { TabSlug } from '../app-logic/tabs-handling';
-import type { UrlState } from '../types/reducers';
+import type { ProfileSharingStatus, UrlState } from '../types/reducers';
 
 export type DataSource =
   | 'none'
@@ -99,7 +99,11 @@ type ProfileAction =
   | {|
       +type: 'SET_CALL_NODE_CONTEXT_MENU_VISIBILITY',
       +isVisible: boolean,
-    |};
+    |}
+  | {
+      type: 'SET_PROFILE_SHARING_STATUS',
+      profileSharingStatus: ProfileSharingStatus,
+    };
 
 type ReceiveProfileAction =
   | {

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -213,6 +213,7 @@ export type ProfileMeta = {|
   sourceURL?: string,
   physicalCPUs?: number,
   logicalCPUs?: number,
+  networkURLsRemoved?: boolean,
 |};
 
 /**

--- a/src/types/reducers.js
+++ b/src/types/reducers.js
@@ -31,6 +31,12 @@ export type ThreadViewOptions = {
   expandedCallNodePaths: PathSet,
   selectedMarker: IndexIntoMarkersTable | -1,
 };
+
+export type ProfileSharingStatus = {
+  sharedWithUrls: boolean,
+  sharedWithoutUrls: boolean,
+};
+
 export type ProfileViewState = {
   viewOptions: {
     perThread: ThreadViewOptions[],
@@ -44,6 +50,7 @@ export type ProfileViewState = {
     tabOrder: number[],
     rightClickedThread: ThreadIndex,
     isCallNodeContextMenuVisible: boolean,
+    profileSharingStatus: ProfileSharingStatus,
   },
   profile: Profile | null,
 };


### PR DESCRIPTION
This PR adds a 'Share with/without URLs' button depending on the previous share option.
If we shared without network URLs and still have the URL data available, then we see a button like this:

<img width="325" alt="screen shot 2018-07-03 at 1 34 33 am" src="https://user-images.githubusercontent.com/466239/42191115-589979d4-7e61-11e8-800a-8abf97ccc236.png">

If we shared with network URLs, then we see a button like this:

<img width="338" alt="screen shot 2018-07-03 at 1 33 35 am" src="https://user-images.githubusercontent.com/466239/42191129-7832ceb2-7e61-11e8-90e7-5094affc9d12.png">

Fixes #1092.
