### PR TITLE
Extract tabs list in a separate file

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -6,7 +6,7 @@
 import { getSelectedTab, getDataSource } from '../reducers/url-state';
 import { sendAnalytics } from '../utils/analytics';
 import type { Action, ThunkAction } from '../types/store';
-import type { TabSlug } from '../types/actions';
+import type { TabSlug } from '../app-logic/tabs-handling';
 import type { UrlState } from '../types/reducers';
 
 export function changeSelectedTab(selectedTab: TabSlug): ThunkAction<void> {

--- a/src/app-logic/tabs-handling.js
+++ b/src/app-logic/tabs-handling.js
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+/**
+ * This object contains all our tab slugs with their associated title. This is
+ * the "master list of tabs". This is in object form because that's how we can
+ * easily derive the TabSlug type with Flow.
+ */
+export const tabsWithTitle = {
+  calltree: 'Call Tree',
+  'flame-graph': 'Flame Graph',
+  'stack-chart': 'Stack Chart',
+  'marker-chart': 'Marker Chart',
+  'marker-table': 'Marker Table',
+  'network-chart': 'Network',
+};
+
+export type TabSlug = $Keys<typeof tabsWithTitle>;
+export type TabWithTitle = {| name: TabSlug, title: string |};
+
+/**
+ * This array contains the list of all tab slugs that we use as codes throughout
+ * the codebase, and especially in the URL.
+ */
+export const tabSlugs: $ReadOnlyArray<TabSlug> =
+  // getOwnPropertyNames is guaranteed to keep the order in which properties
+  // were defined, and this order is important for us.
+  Object.getOwnPropertyNames(tabsWithTitle);
+
+/**
+ * This array contains the same data as tabsWithTitle above, but in an ordered
+ * array so that we can use it directly in some of our components.
+ */
+export const tabsWithTitleArray: $ReadOnlyArray<TabWithTitle> = tabSlugs.map(
+  tabSlug => ({
+    name: tabSlug,
+    title: tabsWithTitle[tabSlug],
+  })
+);
+
+/**
+ * This function returns the initial order of the tabs.
+ * This is simply the sequence of all array indices in ascending order.
+ */
+export function getInitialTabOrder(): number[] {
+  return Array.from({ length: tabSlugs.length }, (_, i) => i);
+}

--- a/src/components/app/Details.js
+++ b/src/components/app/Details.js
@@ -19,13 +19,13 @@ import CallNodeContextMenu from '../shared/CallNodeContextMenu';
 import MarkerTableContextMenu from '../marker-table/ContextMenu';
 import ProfileThreadHeaderContextMenu from '../header/ProfileThreadHeaderContextMenu';
 import { toValidTabSlug } from '../../utils/flow';
+import { tabsWithTitleArray } from '../../app-logic/tabs-handling';
 
-import type { Tab } from './TabBar';
 import type {
   ExplicitConnectOptions,
   ConnectedProps,
 } from '../../utils/connect';
-import type { TabSlug } from '../../types/actions';
+import type { TabSlug } from '../../app-logic/tabs-handling';
 
 require('./Details.css');
 
@@ -42,34 +42,6 @@ type DispatchProps = {|
 type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
 
 class ProfileViewer extends PureComponent<Props> {
-  // If updating this list, make sure and update the tabOrder reducer with another index.
-  _tabs: Tab[] = [
-    {
-      name: 'calltree',
-      title: 'Call Tree',
-    },
-    {
-      name: 'flame-graph',
-      title: 'Flame Graph',
-    },
-    {
-      name: 'stack-chart',
-      title: 'Stack Chart',
-    },
-    {
-      name: 'marker-chart',
-      title: 'Marker Chart',
-    },
-    {
-      name: 'marker-table',
-      title: 'Marker Table',
-    },
-    {
-      name: 'network-chart',
-      title: 'Network',
-    },
-  ];
-
   _onSelectTab = (selectedTab: string) => {
     const { changeSelectedTab } = this.props;
     const tabSlug = toValidTabSlug(selectedTab);
@@ -84,7 +56,7 @@ class ProfileViewer extends PureComponent<Props> {
     return (
       <div className="Details">
         <TabBar
-          tabs={this._tabs}
+          tabs={tabsWithTitleArray}
           selectedTabName={selectedTab}
           tabOrder={tabOrder}
           onSelectTab={this._onSelectTab}

--- a/src/components/app/DetailsContainer.js
+++ b/src/components/app/DetailsContainer.js
@@ -12,7 +12,7 @@ import selectSidebar from '../sidebar';
 import { getSelectedTab } from '../../reducers/url-state';
 import explicitConnect from '../../utils/connect';
 
-import type { TabSlug } from '../../types/actions';
+import type { TabSlug } from '../../app-logic/tabs-handling';
 import type { ExplicitConnectOptions } from '../../utils/connect';
 
 import './DetailsContainer.css';

--- a/src/components/app/TabBar.js
+++ b/src/components/app/TabBar.js
@@ -8,21 +8,17 @@ import React, { PureComponent } from 'react';
 import classNames from 'classnames';
 import Reorderable from '../shared/Reorderable';
 
-import type { Action, TabSlug } from '../../types/actions';
+import type { Action } from '../../types/actions';
+import type { TabWithTitle } from '../../app-logic/tabs-handling';
 
-export type Tab = {
-  name: TabSlug,
-  title: string,
-};
-
-type Props = {
-  className?: string,
-  tabs: Tab[],
-  selectedTabName: string,
-  tabOrder: number[],
-  onSelectTab: string => void,
-  onChangeTabOrder: (number[]) => Action,
-};
+type Props = {|
+  +className?: string,
+  +tabs: $ReadOnlyArray<TabWithTitle>,
+  +selectedTabName: string,
+  +tabOrder: number[],
+  +onSelectTab: string => void,
+  +onChangeTabOrder: (number[]) => Action,
+|};
 
 class TabBar extends PureComponent<Props> {
   constructor(props: Props) {

--- a/src/components/marker-chart/MarkerChartEmptyReasons.js
+++ b/src/components/marker-chart/MarkerChartEmptyReasons.js
@@ -15,7 +15,7 @@ import explicitConnect, {
 } from '../../utils/connect';
 
 import type { State } from '../../types/store';
-import type { TabSlug } from '../../types/actions';
+import type { TabSlug } from '../../app-logic/tabs-handling';
 import type { Thread } from '../../types/profile';
 
 type StateProps = {|

--- a/src/components/shared/CallNodeContextMenu.js
+++ b/src/components/shared/CallNodeContextMenu.js
@@ -27,7 +27,8 @@ import {
 } from '../../utils/flow';
 
 import type { TransformType } from '../../types/transforms';
-import type { ImplementationFilter, TabSlug } from '../../types/actions';
+import type { ImplementationFilter } from '../../types/actions';
+import type { TabSlug } from '../../app-logic/tabs-handling';
 import type {
   IndexIntoCallNodeTable,
   CallNodeInfo,

--- a/src/components/sidebar/index.js
+++ b/src/components/sidebar/index.js
@@ -7,7 +7,7 @@
 // https://github.com/devtools-html/perf.html/issues/914
 // import CallTreeSidebar from './CallTreeSidebar';
 
-import type { TabSlug } from '../../types/actions';
+import type { TabSlug } from '../../app-logic/tabs-handling';
 
 import './sidebar.css';
 

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -20,6 +20,7 @@ import * as MarkerTiming from '../profile-logic/marker-timing';
 import * as CallTree from '../profile-logic/call-tree';
 import { assertExhaustiveCheck, ensureExists } from '../utils/flow';
 import { arePathsEqual, PathSet } from '../utils/path';
+import { getInitialTabOrder } from '../app-logic/tabs-handling';
 
 import type {
   Profile,
@@ -393,7 +394,7 @@ function zeroAt(state: Milliseconds = 0, action: Action) {
   }
 }
 
-function tabOrder(state: number[] = [0, 1, 2, 3, 4, 5], action: Action) {
+function tabOrder(state: number[] = getInitialTabOrder(), action: Action) {
   switch (action.type) {
     case 'CHANGE_TAB_ORDER':
       return action.tabOrder;

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -21,9 +21,9 @@ import type {
   Action,
   DataSource,
   ImplementationFilter,
-  TabSlug,
 } from '../types/actions';
 import type { State, UrlState, Reducer } from '../types/reducers';
+import type { TabSlug } from '../app-logic/tabs-handling';
 
 // Pre-allocate an array to help with strict equality tests in the selectors.
 const EMPTY_TRANSFORM_STACK = [];

--- a/src/test/components/Details.test.js
+++ b/src/test/components/Details.test.js
@@ -11,7 +11,8 @@ import { changeSelectedTab } from '../../actions/app';
 import { storeWithProfile } from '../fixtures/stores';
 import { getProfileFromTextSamples } from '../fixtures/profiles/make-profile';
 
-import type { TabSlug } from '../../types/actions';
+import { tabSlugs } from '../../app-logic/tabs-handling';
+import type { TabSlug } from '../../app-logic/tabs-handling';
 
 describe('app/DetailsContainer', function() {
   const { profile } = getProfileFromTextSamples(`
@@ -21,14 +22,6 @@ describe('app/DetailsContainer', function() {
     D F I
     E E
   `);
-
-  const tabSlugs: TabSlug[] = [
-    'stack-chart',
-    'marker-chart',
-    'flame-graph',
-    'marker-table',
-    'calltree', // 'calltree' not first on purpose
-  ];
 
   it('renders an initial view with the right panel', () => {
     const store = storeWithProfile(profile);

--- a/src/test/components/DetailsContainer.test.js
+++ b/src/test/components/DetailsContainer.test.js
@@ -11,7 +11,8 @@ import { changeSelectedTab } from '../../actions/app';
 import { storeWithProfile } from '../fixtures/stores';
 import { getProfileFromTextSamples } from '../fixtures/profiles/make-profile';
 
-import type { TabSlug } from '../../types/actions';
+import { tabSlugs } from '../../app-logic/tabs-handling';
+import type { TabSlug } from '../../app-logic/tabs-handling';
 
 describe('app/DetailsContainer', function() {
   const { profile } = getProfileFromTextSamples(`
@@ -21,14 +22,6 @@ describe('app/DetailsContainer', function() {
     D F I
     E E
   `);
-
-  const tabSlugs: TabSlug[] = [
-    'stack-chart',
-    'marker-chart',
-    'flame-graph',
-    'marker-table',
-    'calltree', // 'calltree' not first on purpose
-  ];
 
   it('renders an initial view with or without a sidebar', () => {
     const store = storeWithProfile(profile);

--- a/src/test/components/__snapshots__/Details.test.js.snap
+++ b/src/test/components/__snapshots__/Details.test.js.snap
@@ -270,6 +270,60 @@ exports[`app/DetailsContainer renders an initial view with the right panel for t
 </div>
 `;
 
+exports[`app/DetailsContainer renders an initial view with the right panel for tab network-chart 1`] = `
+<div
+  className="Details"
+>
+  <TabBar
+    onChangeTabOrder={[Function]}
+    onSelectTab={[Function]}
+    selectedTabName="network-chart"
+    tabOrder={
+      Array [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+      ]
+    }
+    tabs={
+      Array [
+        Object {
+          "name": "calltree",
+          "title": "Call Tree",
+        },
+        Object {
+          "name": "flame-graph",
+          "title": "Flame Graph",
+        },
+        Object {
+          "name": "stack-chart",
+          "title": "Stack Chart",
+        },
+        Object {
+          "name": "marker-chart",
+          "title": "Marker Chart",
+        },
+        Object {
+          "name": "marker-table",
+          "title": "Marker Table",
+        },
+        Object {
+          "name": "network-chart",
+          "title": "Network",
+        },
+      ]
+    }
+  />
+  <Connect(MarkerChart) />
+  <Connect(CallNodeContextMenu) />
+  <Connect(MarkersContextMenu) />
+  <Connect(ProfileThreadHeaderContextMenu) />
+</div>
+`;
+
 exports[`app/DetailsContainer renders an initial view with the right panel for tab stack-chart 1`] = `
 <div
   className="Details"

--- a/src/test/components/__snapshots__/DetailsContainer.test.js.snap
+++ b/src/test/components/__snapshots__/DetailsContainer.test.js.snap
@@ -85,6 +85,23 @@ exports[`app/DetailsContainer renders an initial view with or without a sidebar 
 </t>
 `;
 
+exports[`app/DetailsContainer renders an initial view with or without a sidebar for tab network-chart 1`] = `
+<t
+  customClassName="DetailsContainer"
+  onDragEnd={[Function]}
+  onDragStart={null}
+  onSecondaryPaneSizeChange={null}
+  percentage={true}
+  primaryIndex={0}
+  primaryMinSize={0}
+  secondaryInitialSize={20}
+  secondaryMinSize={0}
+  vertical={false}
+>
+  <Connect(ProfileViewer) />
+</t>
+`;
+
 exports[`app/DetailsContainer renders an initial view with or without a sidebar for tab stack-chart 1`] = `
 <t
   customClassName="DetailsContainer"

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -18,6 +18,7 @@ import type { GetCategory } from '../profile-logic/color-categories';
 import type { TemporaryError } from '../utils/errors';
 import type { Transform } from './transforms';
 import type { IndexIntoZipFileTable } from '../profile-logic/zip-files';
+import type { TabSlug } from '../app-logic/tabs-handling';
 import type { UrlState } from '../types/reducers';
 
 export type DataSource =
@@ -46,13 +47,6 @@ export type FunctionsUpdatePerThread = {
 
 export type RequestedLib = { debugName: string, breakpadId: string };
 export type ImplementationFilter = 'combined' | 'js' | 'cpp';
-export type TabSlug =
-  | 'calltree'
-  | 'stack-chart'
-  | 'marker-chart'
-  | 'network-chart'
-  | 'marker-table'
-  | 'flame-graph';
 
 type ProfileAction =
   | { type: 'ROUTE_NOT_FOUND', url: string }

--- a/src/types/reducers.js
+++ b/src/types/reducers.js
@@ -9,8 +9,8 @@ import type {
   DataSource,
   ProfileSelection,
   ImplementationFilter,
-  TabSlug,
 } from './actions';
+import type { TabSlug } from '../app-logic/tabs-handling';
 import type { Milliseconds, StartEndRange } from './units';
 import type { IndexIntoMarkersTable, Profile, ThreadIndex } from './profile';
 import type { CallNodePath } from './profile-derived';

--- a/src/utils/flow.js
+++ b/src/utils/flow.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
-import type { TabSlug } from '../types/actions';
+import type { TabSlug } from '../app-logic/tabs-handling';
 import type { TransformType } from '../types/transforms';
 
 /**


### PR DESCRIPTION
I needed a way to get the list of tabs for the initial state of the reducer I write in #1096, so instead of duplicating this data _again_ I decided to extract it.

I also like how this helps defining the TabSlug type, and how the initial tabOrder won't ever be unsynced anymore.