### PR TITLE
Make sure all actions are exact objects

### DIFF
--- a/src/components/app/SymbolicationStatusOverlay.js
+++ b/src/components/app/SymbolicationStatusOverlay.js
@@ -11,7 +11,7 @@ import {
 } from '../../reducers/profile-view';
 import explicitConnect from '../../utils/connect';
 
-import type { RequestedLib } from '../../types/reducers';
+import type { RequestedLib } from '../../types/actions';
 import type {
   ExplicitConnectOptions,
   ConnectedProps,

--- a/src/profile-logic/errors.js
+++ b/src/profile-logic/errors.js
@@ -4,15 +4,15 @@
 
 // @flow
 
-import type { Library } from './symbol-store';
+import type { RequestedLib } from '../types/actions';
 
 // Used during the symbolication process to express that we couldn't find
 // symbols for a specific library
 export class SymbolsNotFoundError extends Error {
-  library: Library;
+  library: RequestedLib;
   error: ?Error;
 
-  constructor(message: string, library: Library, error?: Error) {
+  constructor(message: string, library: RequestedLib, error?: Error) {
     super(message);
     // Workaround for a babel issue when extending Errors
     (this: any).__proto__ = SymbolsNotFoundError.prototype;

--- a/src/profile-logic/symbol-store.js
+++ b/src/profile-logic/symbol-store.js
@@ -7,15 +7,11 @@ import SymbolStoreDB from './symbol-store-db';
 import { SymbolsNotFoundError } from './errors';
 import bisection from 'bisection';
 
+import type { RequestedLib } from '../types/actions';
 import type { SymbolTableAsTuple } from './symbol-store-db';
 
-export type Library = {
-  debugName: string,
-  breakpadId: string,
-};
-
 export type LibSymbolicationRequest = {
-  lib: Library,
+  lib: RequestedLib,
   addresses: Set<number>,
 };
 
@@ -33,7 +29,7 @@ interface SymbolProvider {
   ): Promise<Map<number, AddressResult>>[];
 
   // Expensive, should be called if requestSymbolsFromServer was unsuccessful.
-  requestSymbolTableFromAddon(lib: Library): Promise<SymbolTableAsTuple>;
+  requestSymbolTableFromAddon(lib: RequestedLib): Promise<SymbolTableAsTuple>;
 }
 
 export interface AbstractSymbolStore {
@@ -97,7 +93,7 @@ export class SymbolStore {
   // only contain the symbols we requested and not all the symbols of a given
   // library.
   _storeSymbolTableInDB(
-    lib: Library,
+    lib: RequestedLib,
     symbolTable: SymbolTableAsTuple
   ): Promise<void> {
     return this._db

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -37,13 +37,12 @@ import type {
   MarkerTimingRows,
 } from '../types/profile-derived';
 import type { Milliseconds, StartEndRange } from '../types/units';
-import type { Action, ProfileSelection } from '../types/actions';
+import type { Action, ProfileSelection, RequestedLib } from '../types/actions';
 import type {
   State,
   Reducer,
   ProfileViewState,
   ProfileSharingStatus,
-  RequestedLib,
   SymbolicationStatus,
   ThreadViewOptions,
 } from '../types/reducers';

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -29,104 +29,136 @@ export type DataSource =
   | 'public'
   | 'from-url';
 export type ProfileSelection =
-  | { hasSelection: false, isModifying: false }
-  | {
-      hasSelection: true,
-      isModifying: boolean,
-      selectionStart: number,
-      selectionEnd: number,
-    };
+  | {| +hasSelection: false, +isModifying: false |}
+  | {|
+      +hasSelection: true,
+      +isModifying: boolean,
+      +selectionStart: number,
+      +selectionEnd: number,
+    |};
 export type FuncToFuncMap = Map<IndexIntoFuncTable, IndexIntoFuncTable>;
 export type FunctionsUpdatePerThread = {
-  [id: ThreadIndex]: {
+  [id: ThreadIndex]: {|
     oldFuncToNewFuncMap: FuncToFuncMap,
     funcIndices: IndexIntoFuncTable[],
     funcNames: string[],
-  },
+  |},
 };
 
-export type RequestedLib = { debugName: string, breakpadId: string };
+export type RequestedLib = {|
+  +debugName: string,
+  +breakpadId: string,
+|};
 export type ImplementationFilter = 'combined' | 'js' | 'cpp';
 
 type ProfileAction =
-  | { type: 'ROUTE_NOT_FOUND', url: string }
-  | { type: 'CHANGE_THREAD_ORDER', threadOrder: ThreadIndex[] }
-  | {
-      type: 'HIDE_THREAD',
-      threadIndex: ThreadIndex,
-      hiddenThreads: ThreadIndex[],
-      threadOrder: ThreadIndex[],
-    }
-  | { type: 'SHOW_THREAD', threadIndex: ThreadIndex }
-  | {
-      type: 'ISOLATE_THREAD',
-      hiddenThreadIndexes: ThreadIndex[],
-      isolatedThreadIndex: ThreadIndex,
-    }
-  | {
-      type: 'ASSIGN_TASK_TRACER_NAMES',
-      addressIndices: number[],
-      symbolNames: string[],
-    }
-  | {
-      type: 'CHANGE_SELECTED_CALL_NODE',
-      threadIndex: ThreadIndex,
-      selectedCallNodePath: CallNodePath,
-    }
-  | {
-      type: 'FOCUS_CALL_TREE',
-    }
-  | {
-      type: 'CHANGE_EXPANDED_CALL_NODES',
-      threadIndex: ThreadIndex,
-      expandedCallNodePaths: Array<CallNodePath>,
-    }
-  | {
-      type: 'CHANGE_SELECTED_MARKER',
-      threadIndex: ThreadIndex,
-      selectedMarker: IndexIntoMarkersTable | -1,
-    }
-  | { type: 'UPDATE_PROFILE_SELECTION', selection: ProfileSelection }
-  | { type: 'CHANGE_TAB_ORDER', tabOrder: number[] }
-  | {
-      type: 'CHANGE_SELECTED_ZIP_FILE',
-      selectedZipFileIndex: IndexIntoZipFileTable | null,
-    }
-  | {
-      type: 'CHANGE_EXPANDED_ZIP_FILES',
-      expandedZipFileIndexes: Array<IndexIntoZipFileTable | null>,
-    }
+  | {|
+      +type: 'ROUTE_NOT_FOUND',
+      +url: string,
+    |}
+  | {|
+      +type: 'CHANGE_THREAD_ORDER',
+      +threadOrder: ThreadIndex[],
+    |}
+  | {|
+      +type: 'HIDE_THREAD',
+      +threadIndex: ThreadIndex,
+      +hiddenThreads: ThreadIndex[],
+      +threadOrder: ThreadIndex[],
+    |}
+  | {|
+      +type: 'SHOW_THREAD',
+      +threadIndex: ThreadIndex,
+    |}
+  | {|
+      +type: 'ISOLATE_THREAD',
+      +hiddenThreadIndexes: ThreadIndex[],
+      +isolatedThreadIndex: ThreadIndex,
+    |}
+  | {|
+      +type: 'ASSIGN_TASK_TRACER_NAMES',
+      +addressIndices: number[],
+      +symbolNames: string[],
+    |}
+  | {|
+      +type: 'CHANGE_SELECTED_CALL_NODE',
+      +threadIndex: ThreadIndex,
+      +selectedCallNodePath: CallNodePath,
+    |}
+  | {|
+      +type: 'FOCUS_CALL_TREE',
+    |}
+  | {|
+      +type: 'CHANGE_EXPANDED_CALL_NODES',
+      +threadIndex: ThreadIndex,
+      +expandedCallNodePaths: Array<CallNodePath>,
+    |}
+  | {|
+      +type: 'CHANGE_SELECTED_MARKER',
+      +threadIndex: ThreadIndex,
+      +selectedMarker: IndexIntoMarkersTable | -1,
+    |}
+  | {|
+      +type: 'UPDATE_PROFILE_SELECTION',
+      +selection: ProfileSelection,
+    |}
+  | {|
+      +type: 'CHANGE_TAB_ORDER',
+      +tabOrder: number[],
+    |}
+  | {|
+      +type: 'CHANGE_SELECTED_ZIP_FILE',
+      +selectedZipFileIndex: IndexIntoZipFileTable | null,
+    |}
+  | {|
+      +type: 'CHANGE_EXPANDED_ZIP_FILES',
+      +expandedZipFileIndexes: Array<IndexIntoZipFileTable | null>,
+    |}
   | {|
       +type: 'SET_CALL_NODE_CONTEXT_MENU_VISIBILITY',
       +isVisible: boolean,
     |}
-  | {
-      type: 'SET_PROFILE_SHARING_STATUS',
-      profileSharingStatus: ProfileSharingStatus,
-    };
+  | {|
+      +type: 'SET_PROFILE_SHARING_STATUS',
+      +profileSharingStatus: ProfileSharingStatus,
+    |};
 
 type ReceiveProfileAction =
-  | {
-      type: 'COALESCED_FUNCTIONS_UPDATE',
-      functionsUpdatePerThread: FunctionsUpdatePerThread,
-    }
-  | { type: 'DONE_SYMBOLICATING' }
-  | { type: 'ERROR_RECEIVING_PROFILE_FROM_FILE', error: Error }
-  | {
-      type: 'TEMPORARY_ERROR_RECEIVING_PROFILE_FROM_ADDON',
-      error: TemporaryError,
-    }
-  | { type: 'FATAL_ERROR_RECEIVING_PROFILE_FROM_ADDON', error: Error }
-  | {
-      type: 'TEMPORARY_ERROR_RECEIVING_PROFILE_FROM_STORE',
-      error: TemporaryError,
-    }
-  | {
-      type: 'TEMPORARY_ERROR_RECEIVING_PROFILE_FROM_URL',
-      error: TemporaryError,
-    }
-  | { type: 'FATAL_ERROR_RECEIVING_PROFILE_FROM_STORE', error: Error }
-  | { type: 'FATAL_ERROR_RECEIVING_PROFILE_FROM_URL', error: Error }
+  | {|
+      +type: 'COALESCED_FUNCTIONS_UPDATE',
+      +functionsUpdatePerThread: FunctionsUpdatePerThread,
+    |}
+  | {|
+      +type: 'DONE_SYMBOLICATING',
+    |}
+  | {|
+      +type: 'ERROR_RECEIVING_PROFILE_FROM_FILE',
+      +error: Error,
+    |}
+  | {|
+      +type: 'TEMPORARY_ERROR_RECEIVING_PROFILE_FROM_ADDON',
+      +error: TemporaryError,
+    |}
+  | {|
+      +type: 'FATAL_ERROR_RECEIVING_PROFILE_FROM_ADDON',
+      +error: Error,
+    |}
+  | {|
+      +type: 'TEMPORARY_ERROR_RECEIVING_PROFILE_FROM_STORE',
+      +error: TemporaryError,
+    |}
+  | {|
+      +type: 'TEMPORARY_ERROR_RECEIVING_PROFILE_FROM_URL',
+      +error: TemporaryError,
+    |}
+  | {|
+      +type: 'FATAL_ERROR_RECEIVING_PROFILE_FROM_STORE',
+      +error: Error,
+    |}
+  | {|
+      +type: 'FATAL_ERROR_RECEIVING_PROFILE_FROM_URL',
+      +error: Error,
+    |}
   | {|
       +type: 'VIEW_PROFILE',
       +profile: Profile,
@@ -137,71 +169,71 @@ type ReceiveProfileAction =
     |}
   | {| +type: 'RECEIVE_ZIP_FILE', +zip: JSZip |}
   | {| +type: 'PROCESS_PROFILE_FROM_ZIP_FILE', +pathInZipFile: string |}
-  | {| +type: 'FAILED_TO_PROCESS_PROFILE_FROM_ZIP_FILE', error: any |}
+  | {| +type: 'FAILED_TO_PROCESS_PROFILE_FROM_ZIP_FILE', +error: any |}
   | {| +type: 'DISMISS_PROCESS_PROFILE_FROM_ZIP_ERROR' |}
   | {| +type: 'RETURN_TO_ZIP_FILE_LIST' |}
-  | {| +type: 'FILE_NOT_FOUND_IN_ZIP_FILE', pathInZipFile: string |}
-  | { type: 'REQUESTING_SYMBOL_TABLE', requestedLib: RequestedLib }
-  | { type: 'RECEIVED_SYMBOL_TABLE_REPLY', requestedLib: RequestedLib }
-  | { type: 'START_SYMBOLICATING' }
-  | { type: 'WAITING_FOR_PROFILE_FROM_ADDON' }
-  | { type: 'WAITING_FOR_PROFILE_FROM_STORE' }
-  | { type: 'WAITING_FOR_PROFILE_FROM_URL' };
+  | {| +type: 'FILE_NOT_FOUND_IN_ZIP_FILE', +pathInZipFile: string |}
+  | {| +type: 'REQUESTING_SYMBOL_TABLE', +requestedLib: RequestedLib |}
+  | {| +type: 'RECEIVED_SYMBOL_TABLE_REPLY', +requestedLib: RequestedLib |}
+  | {| +type: 'START_SYMBOLICATING' |}
+  | {| +type: 'WAITING_FOR_PROFILE_FROM_ADDON' |}
+  | {| +type: 'WAITING_FOR_PROFILE_FROM_STORE' |}
+  | {| +type: 'WAITING_FOR_PROFILE_FROM_URL' |};
 
 type StackChartAction =
-  | { type: 'CHANGE_STACK_CHART_COLOR_STRATEGY', getCategory: GetCategory }
-  | { type: 'CHANGE_STACK_CHART_LABELING_STRATEGY', getLabel: GetLabel }
-  | { type: 'HAS_ZOOMED_VIA_MOUSEWHEEL' };
+  | {| +type: 'CHANGE_STACK_CHART_COLOR_STRATEGY', +getCategory: GetCategory |}
+  | {| +type: 'CHANGE_STACK_CHART_LABELING_STRATEGY', +getLabel: GetLabel |}
+  | {| +type: 'HAS_ZOOMED_VIA_MOUSEWHEEL' |};
 
 type UrlEnhancerAction =
-  | {| type: 'URL_SETUP_DONE' |}
-  | {| type: 'UPDATE_URL_STATE', newUrlState: UrlState |};
+  | {| +type: 'URL_SETUP_DONE' |}
+  | {| +type: 'UPDATE_URL_STATE', +newUrlState: UrlState |};
 
 type UrlStateAction =
-  | { type: 'WAITING_FOR_PROFILE_FROM_FILE' }
-  | { type: 'PROFILE_PUBLISHED', hash: string }
-  | { type: 'CHANGE_SELECTED_TAB', selectedTab: TabSlug }
-  | { type: 'ADD_RANGE_FILTER', start: number, end: number }
-  | { type: 'POP_RANGE_FILTERS', firstRemovedFilterIndex: number }
-  | { type: 'CHANGE_SELECTED_THREAD', selectedThread: ThreadIndex }
-  | { type: 'CHANGE_RIGHT_CLICKED_THREAD', selectedThread: ThreadIndex }
-  | { type: 'CHANGE_CALL_TREE_SEARCH_STRING', searchString: string }
-  | {
-      type: 'ADD_TRANSFORM_TO_STACK',
-      threadIndex: ThreadIndex,
-      transform: Transform,
-      transformedThread: Thread,
-    }
-  | {
-      type: 'POP_TRANSFORMS_FROM_STACK',
-      threadIndex: ThreadIndex,
-      firstRemovedFilterIndex: number,
-    }
-  | {
-      type: 'CHANGE_IMPLEMENTATION_FILTER',
-      implementation: ImplementationFilter,
-      threadIndex: ThreadIndex,
-      transformedThread: Thread,
-      previousImplementation: ImplementationFilter,
-      implementation: ImplementationFilter,
-    }
+  | {| +type: 'WAITING_FOR_PROFILE_FROM_FILE' |}
+  | {| +type: 'PROFILE_PUBLISHED', +hash: string |}
+  | {| +type: 'CHANGE_SELECTED_TAB', +selectedTab: TabSlug |}
+  | {| +type: 'ADD_RANGE_FILTER', +start: number, +end: number |}
+  | {| +type: 'POP_RANGE_FILTERS', +firstRemovedFilterIndex: number |}
+  | {| +type: 'CHANGE_SELECTED_THREAD', +selectedThread: ThreadIndex |}
+  | {| +type: 'CHANGE_RIGHT_CLICKED_THREAD', +selectedThread: ThreadIndex |}
+  | {| +type: 'CHANGE_CALL_TREE_SEARCH_STRING', +searchString: string |}
   | {|
-      type: 'CHANGE_INVERT_CALLSTACK',
-      invertCallstack: boolean,
-      callTree: CallTree,
-      callNodeTable: CallNodeTable,
-      selectedThreadIndex: ThreadIndex,
+      +type: 'ADD_TRANSFORM_TO_STACK',
+      +threadIndex: ThreadIndex,
+      +transform: Transform,
+      +transformedThread: Thread,
     |}
-  | { type: 'CHANGE_MARKER_SEARCH_STRING', searchString: string };
+  | {|
+      +type: 'POP_TRANSFORMS_FROM_STACK',
+      +threadIndex: ThreadIndex,
+      +firstRemovedFilterIndex: number,
+    |}
+  | {|
+      +type: 'CHANGE_IMPLEMENTATION_FILTER',
+      +implementation: ImplementationFilter,
+      +threadIndex: ThreadIndex,
+      +transformedThread: Thread,
+      +previousImplementation: ImplementationFilter,
+      +implementation: ImplementationFilter,
+    |}
+  | {|
+      +type: 'CHANGE_INVERT_CALLSTACK',
+      +invertCallstack: boolean,
+      +callTree: CallTree,
+      +callNodeTable: CallNodeTable,
+      +selectedThreadIndex: ThreadIndex,
+    |}
+  | {| +type: 'CHANGE_MARKER_SEARCH_STRING', +searchString: string |};
 
 type IconsAction =
-  | { type: 'ICON_HAS_LOADED', icon: string }
-  | { type: 'ICON_IN_ERROR', icon: string };
+  | {| +type: 'ICON_HAS_LOADED', +icon: string |}
+  | {| +type: 'ICON_IN_ERROR', +icon: string |};
 
 type SidebarAction = {|
-  type: 'CHANGE_SIDEBAR_OPEN_STATE',
-  tab: TabSlug,
-  isOpen: boolean,
+  +type: 'CHANGE_SIDEBAR_OPEN_STATE',
+  +tab: TabSlug,
+  +isOpen: boolean,
 |};
 
 export type Action =

--- a/src/types/reducers.js
+++ b/src/types/reducers.js
@@ -9,6 +9,7 @@ import type {
   DataSource,
   ProfileSelection,
   ImplementationFilter,
+  RequestedLib,
 } from './actions';
 import type { TabSlug } from '../app-logic/tabs-handling';
 import type { Milliseconds, StartEndRange } from './units';
@@ -24,7 +25,6 @@ import type { PathSet } from '../utils/path.js';
 
 export type Reducer<T> = (T | void, Action) => T;
 
-export type RequestedLib = { debugName: string, breakpadId: string };
 export type SymbolicationStatus = 'DONE' | 'SYMBOLICATING';
 export type ThreadViewOptions = {
   selectedCallNodePath: CallNodePath,


### PR DESCRIPTION
Note that I made`RequestedLib` consistent in using only one definition. Changing it to an exact object made flow error where the type definitions were duplicated.