### PR TITLE
Enable the sidebar for the call tree and the flame chart, closed by d…

### DIFF
--- a/src/components/sidebar/index.js
+++ b/src/components/sidebar/index.js
@@ -5,7 +5,7 @@
 
 // Disabling the call tree's sidebar until it's useful
 // https://github.com/devtools-html/perf.html/issues/914
-// import CallTreeSidebar from './CallTreeSidebar';
+import CallTreeSidebar from './CallTreeSidebar';
 
 import type { TabSlug } from '../../app-logic/tabs-handling';
 
@@ -15,9 +15,8 @@ export default function selectSidebar(
   selectedTab: TabSlug
 ): React.ComponentType<{||}> | null {
   return {
-    //calltree: CallTreeSidebar,
-    calltree: null,
-    'flame-graph': null,
+    calltree: CallTreeSidebar,
+    'flame-graph': CallTreeSidebar,
     'stack-chart': null,
     'marker-chart': null,
     'marker-table': null,

--- a/src/test/components/__snapshots__/Details.test.js.snap
+++ b/src/test/components/__snapshots__/Details.test.js.snap
@@ -5,7 +5,14 @@ exports[`app/Details renders an initial view with the right panel 1`] = `
   className="Details"
 >
   <TabBar
-    extraElements={false}
+    extraElements={
+      <button
+        className="sidebar-open-close-button photon-button photon-button-ghost sidebar-open-close-button-isclosed"
+        onClick={[Function]}
+        title="Open the sidebar"
+        type="button"
+      />
+    }
     onChangeTabOrder={[Function]}
     onSelectTab={[Function]}
     selectedTabName="calltree"
@@ -60,7 +67,14 @@ exports[`app/Details renders an initial view with the right panel for tab calltr
   className="Details"
 >
   <TabBar
-    extraElements={false}
+    extraElements={
+      <button
+        className="sidebar-open-close-button photon-button photon-button-ghost sidebar-open-close-button-isclosed"
+        onClick={[Function]}
+        title="Open the sidebar"
+        type="button"
+      />
+    }
     onChangeTabOrder={[Function]}
     onSelectTab={[Function]}
     selectedTabName="calltree"
@@ -115,7 +129,14 @@ exports[`app/Details renders an initial view with the right panel for tab flame-
   className="Details"
 >
   <TabBar
-    extraElements={false}
+    extraElements={
+      <button
+        className="sidebar-open-close-button photon-button photon-button-ghost sidebar-open-close-button-isclosed"
+        onClick={[Function]}
+        title="Open the sidebar"
+        type="button"
+      />
+    }
     onChangeTabOrder={[Function]}
     onSelectTab={[Function]}
     selectedTabName="flame-graph"
@@ -390,7 +411,14 @@ exports[`app/Details show the correct state for the sidebar open button 1`] = `
   className="Details"
 >
   <TabBar
-    extraElements={false}
+    extraElements={
+      <button
+        className="sidebar-open-close-button photon-button photon-button-ghost sidebar-open-close-button-isclosed"
+        onClick={[Function]}
+        title="Open the sidebar"
+        type="button"
+      />
+    }
     onChangeTabOrder={[Function]}
     onSelectTab={[Function]}
     selectedTabName="calltree"
@@ -445,7 +473,14 @@ exports[`app/Details show the correct state for the sidebar open button 2`] = `
   className="Details"
 >
   <TabBar
-    extraElements={false}
+    extraElements={
+      <button
+        className="sidebar-open-close-button photon-button photon-button-ghost sidebar-open-close-button-isclosed"
+        onClick={[Function]}
+        title="Open the sidebar"
+        type="button"
+      />
+    }
     onChangeTabOrder={[Function]}
     onSelectTab={[Function]}
     selectedTabName="calltree"
@@ -500,7 +535,14 @@ exports[`app/Details show the correct state for the sidebar open button 3`] = `
   className="Details"
 >
   <TabBar
-    extraElements={false}
+    extraElements={
+      <button
+        className="sidebar-open-close-button photon-button photon-button-ghost sidebar-open-close-button-isclosed"
+        onClick={[Function]}
+        title="Open the sidebar"
+        type="button"
+      />
+    }
     onChangeTabOrder={[Function]}
     onSelectTab={[Function]}
     selectedTabName="calltree"
@@ -555,7 +597,14 @@ exports[`app/Details show the correct state for the sidebar open button 4`] = `
   className="Details"
 >
   <TabBar
-    extraElements={false}
+    extraElements={
+      <button
+        className="sidebar-open-close-button photon-button photon-button-ghost sidebar-open-close-button-isclosed"
+        onClick={[Function]}
+        title="Open the sidebar"
+        type="button"
+      />
+    }
     onChangeTabOrder={[Function]}
     onSelectTab={[Function]}
     selectedTabName="calltree"

--- a/src/test/components/__snapshots__/DetailsContainer.test.js.snap
+++ b/src/test/components/__snapshots__/DetailsContainer.test.js.snap
@@ -14,6 +14,7 @@ exports[`app/DetailsContainer renders an initial view with or without a sidebar 
   vertical={false}
 >
   <Connect(ProfileViewer) />
+  <Connect(CallTreeSidebar) />
 </t>
 `;
 
@@ -31,6 +32,7 @@ exports[`app/DetailsContainer renders an initial view with or without a sidebar 
   vertical={false}
 >
   <Connect(ProfileViewer) />
+  <Connect(CallTreeSidebar) />
 </t>
 `;
 
@@ -48,6 +50,7 @@ exports[`app/DetailsContainer renders an initial view with or without a sidebar 
   vertical={false}
 >
   <Connect(ProfileViewer) />
+  <Connect(CallTreeSidebar) />
 </t>
 `;
 


### PR DESCRIPTION
…efault

[Here is a direct link with a profile](https://deploy-preview-1148--perf-html.netlify.com/public/434c69a7881cc4942ebead5079d234109c8d2a1f/calltree/?hiddenThreads=2-3&thread=4&threadOrder=0-2-3-4-1&v=3)

[Here is a direct link with a big profile](https://deploy-preview-1148--perf-html.netlify.com/public/280e10708c0660695ef5af145c53179d29d9796c/calltree/?hiddenThreads=1&thread=4&threadOrder=0-2-3-4-5-1&v=3), where you can see better the performance problems, both with a normal and an inverted tree.