### PR TITLE
[WIP] Avoid allocations in getFlameGraphTiming

### DIFF
--- a/src/profile-logic/flame-graph.js
+++ b/src/profile-logic/flame-graph.js
@@ -45,8 +45,7 @@ type Stack = Array<{
 export function getFlameGraphTiming(
   callTree: CallTree.CallTree
 ): FlameGraphTiming {
-  callTree.preloadChildrenCache();
-
+  const [children, pointers, lengths] = callTree.getAllChildren();
   const timing = [];
   // Array of call nodes to recursively process in the loop below.
   // Start with the roots of the call tree.
@@ -89,19 +88,13 @@ export function getFlameGraphTiming(
     timeOffset[depth + 1] = timeOffset[depth];
     timeOffset[depth] += totalTimeRelative;
 
-    const children = callTree.getChildren(nodeIndex).slice();
-    children.sort(
-      (a, b) =>
-        callTree.getNodeData(a).funcName < callTree.getNodeData(b).funcName
-          ? -1
-          : 1
-    );
-
     // Since we're popping the stack at the top of the while loop, put
     // in the children in reverse order here to retain the ascending
     // order when processing them.
-    for (let i = children.length - 1; i >= 0; i--) {
-      stack.push({ nodeIndex: children[i], depth: depth + 1 });
+    let length = lengths[nodeIndex];
+    let i = pointers[nodeIndex];
+    while (length--) {
+      stack.push({ nodeIndex: children[i++], depth: depth + 1 });
     }
   }
   return timing;


### PR DESCRIPTION
If we can avoid allocating the many arrays as a result of calling `CallTree.preloadChildrenCache()` we can quite a nice speedup in the flame graph. I figured we can put everything needed by the `getFlameGraphTiming()` into one flat array which then can be queried by indexing into it. I'm adding this PR for feedback as I wonder if this is a viable approach.

Unfortunately the interface becomes less ergonomic as the consumer now itself has to index into the returned array, and I think it doesn't fit very well into the abstraction provided by `CallTree`. So if we use this code, we might move it out of `CallTree` and put it closer to flame graph specific code. But before we do that I wonder if the interface can be improved in some way. Can we provide a better interface while keeping down the number of allocations?

Of course this needs to have tests, but I'll defer that until after I get some feedback.