### PR TITLE
Add 'Frame Construction' marker type

### DIFF
--- a/src/components/shared/MarkerTooltipContents.js
+++ b/src/components/shared/MarkerTooltipContents.js
@@ -28,6 +28,7 @@ import type { ImplementationFilter } from '../../types/actions';
 import type { Thread, ThreadIndex } from '../../types/profile';
 import type {
   DOMEventMarkerPayload,
+  FrameConstructionMarkerPayload,
   PaintProfilerMarkerTracing,
   PhaseTimes,
   StyleMarkerPayload,
@@ -240,21 +241,37 @@ function _filterInterestingPhaseTimes(
 
 function _markerBacktrace(
   marker: TracingMarker,
-  data: StyleMarkerPayload | PaintProfilerMarkerTracing | DOMEventMarkerPayload,
+  data:
+    | StyleMarkerPayload
+    | PaintProfilerMarkerTracing
+    | DOMEventMarkerPayload
+    | FrameConstructionMarkerPayload,
   thread: Thread,
   implementationFilter: ImplementationFilter
 ): React.Node {
-  if (data.category === 'DOMEvent') {
-    const latency =
-      data.timeStamp === undefined
-        ? null
-        : formatMilliseconds(marker.start - data.timeStamp);
-    return (
-      <div className="tooltipDetails">
-        {_markerDetail('type', 'Type', data.eventType)}
-        {latency === null ? null : _markerDetail('latency', 'Latency', latency)}
-      </div>
-    );
+  switch (data.category) {
+    case 'DOMEvent': {
+      const latency =
+        data.timeStamp === undefined
+          ? null
+          : formatMilliseconds(marker.start - data.timeStamp);
+      return (
+        <div className="tooltipDetails">
+          {_markerDetail('type', 'Type', data.eventType)}
+          {latency === null
+            ? null
+            : _markerDetail('latency', 'Latency', latency)}
+        </div>
+      );
+    }
+    case 'Frame Construction':
+      return (
+        <div className="tooltipDetails">
+          {_markerDetail('category', 'Category', data.category)}
+        </div>
+      );
+    default:
+      break;
   }
   if ('cause' in data && data.cause) {
     const { cause } = data;

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -45,6 +45,7 @@ import type {
 } from '../types/gecko-profile';
 import type {
   DOMEventMarkerPayload,
+  FrameConstructionMarkerPayload,
   MarkerPayload,
   MarkerPayload_Gecko,
   PaintProfilerMarkerTracing,
@@ -632,9 +633,14 @@ function _processMarkers(geckoMarkers: GeckoMarkerStruct): MarkersTable {
             _convertStackToCause(newData);
             // We had to use any here because _convertStackToCause is not
             // providing the type system with information how it's operating
-            return newData.category === 'DOMEvent'
-              ? ((newData: any): DOMEventMarkerPayload)
-              : ((newData: any): PaintProfilerMarkerTracing);
+            switch (newData.category) {
+              case 'DOMEvent':
+                return ((newData: any): DOMEventMarkerPayload);
+              case 'FrameConstruction':
+                return ((newData: any): FrameConstructionMarkerPayload);
+              default:
+                return ((newData: any): PaintProfilerMarkerTracing);
+            }
           }
           default:
             return m;

--- a/src/test/components/MarkerTooltipContents.test.js
+++ b/src/test/components/MarkerTooltipContents.test.js
@@ -291,6 +291,24 @@ describe('MarkerTooltipContents', function() {
           status: 'STATUS_READING',
         },
       ],
+      [
+        'ConstructRootFrame',
+        112.5,
+        {
+          type: 'tracing',
+          category: 'Frame Construction',
+          interval: 'start',
+        },
+      ],
+      [
+        'ConstructRootFrame',
+        113.3,
+        {
+          type: 'tracing',
+          category: 'Frame Construction',
+          interval: 'end',
+        },
+      ],
     ]);
     const store = storeWithProfile(profile);
     const state = store.getState();

--- a/src/test/components/__snapshots__/MarkerTooltipContents.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerTooltipContents.test.js.snap
@@ -1228,6 +1228,49 @@ Array [
         <div
           className="tooltipTiming"
         >
+          0.80ms
+        </div>
+        <div
+          className="tooltipTitle"
+        >
+          ConstructRootFrame
+        </div>
+      </div>
+      <div
+        className="tooltipDetails"
+      >
+        <div
+          className="tooltipLabel"
+        >
+          Thread:
+        </div>
+        Main Thread
+      </div>
+    </div>
+    <div
+      className="tooltipDetails"
+    >
+      <div
+        className="tooltipLabel"
+      >
+        Category
+        :
+      </div>
+      Frame Construction
+    </div>
+  </div>,
+  <div
+    className="tooltipMarker propClass"
+  >
+    <div
+      className="tooltipHeader"
+    >
+      <div
+        className="tooltipOneLine"
+      >
+        <div
+          className="tooltipTiming"
+        >
           205ms
         </div>
         <div

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -353,6 +353,16 @@ export type BHRMarkerPayload = {
   endTime: Milliseconds,
 };
 
+/*
+ * The payload for Frame Construction.
+ */
+export type FrameConstructionMarkerPayload = {
+  type: 'tracing',
+  category: 'Frame Construction',
+  interval: 'start' | 'end',
+  cause?: CauseBacktrace,
+};
+
 export type DummyForTestsMarkerPayload = {
   type: 'DummyForTests',
   startTime: Milliseconds,
@@ -377,6 +387,7 @@ export type MarkerPayload =
   | StyleMarkerPayload
   | BHRMarkerPayload
   | VsyncTimestampPayload
+  | FrameConstructionMarkerPayload
   | DummyForTestsMarkerPayload
   | null;
 
@@ -390,6 +401,7 @@ export type MarkerPayload_Gecko =
   | GCMajorMarkerPayload_Gecko
   | GCSliceMarkerPayload_Gecko
   | StyleMarkerPayload_Gecko
+  | FrameConstructionMarkerPayload
   | DummyForTestsMarkerPayload
   | VsyncTimestampPayload
   | null;


### PR DESCRIPTION
This PR is for [Bug 1414345](https://bugzilla.mozilla.org/show_bug.cgi?id=1414345). 
We added a "Frame Construction" tracing marker there, and this is for making it look better. It will look something like this:
<img width="284" alt="screen shot 2018-07-26 at 4 52 47 pm" src="https://user-images.githubusercontent.com/466239/43270004-5d68a17e-90f4-11e8-97ec-f9868f0d4863.png">
