### PR TITLE
[wip] Add stylelint and prettier for css

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,7 @@
+{
+  "extends": [
+    "stylelint-config-standard",
+    "stylelint-config-idiomatic-order",
+    "stylelint-config-prettier"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -10,8 +10,14 @@
     "build-prod:quiet": "yarn build:clean && env NODE_ENV=production webpack",
     "build-prod": "yarn build-prod:quiet --progress",
     "build-prod-readable": "env UGLIFY_OPTIONS='{ \"mangle\": false }' yarn build-prod",
-    "lint": "eslint *.js bin src",
-    "lint-fix": "yarn lint --fix",
+    "lint": "run-s lint-js lint-css",
+    "lint-js": "eslint *.js bin src",
+    "lint-fix-js": "yarn lint-js --fix",
+    "lint-css": "stylelint \"src/**/*.css\"",
+    "lint-fix-css-stylelint": "yarn lint-css --fix",
+    "lint-fix-css-prettier": "prettier \"src/**/*.css\" --write",
+    "lint-fix-css": "run-s lint-fix-css-prettier lint-fix-css-stylelint",
+    "lint": "run-s lint-js lint-css",
     "flow": "flow",
     "flow-coverage": "flow-coverage-report -i 'src/**/*.js' -t html -t text",
     "flow-generate-libdefs": "flow-typed install --libdefDir src/types/libdef",
@@ -117,7 +123,11 @@
     "rimraf": "^2.6.2",
     "sinon": "^4.3.0",
     "style-loader": "^0.20.1",
+    "stylelint": "^9.4.0",
+    "stylelint-config-idiomatic-order": "^5.0.0",
+    "stylelint-config-standard": "^18.2.0",
     "uglifyjs-webpack-plugin": "^1.2.3",
+    "stylelint-config-prettier": "^3.3.0",
     "webpack": "^3.11.0",
     "webpack-dev-server": "^2.11.1",
     "workerjs": "github:jasonLaster/workerjs"
@@ -146,6 +156,11 @@
     "verbose": true
   },
   "lint-staged": {
+    "src/**/*.css": [
+      "prettier --write",
+      "stylelint --fix",
+      "git add"
+    ],
     "*.js": [
       "eslint --fix",
       "git add"

--- a/src/components/app/Details.css
+++ b/src/components/app/Details.css
@@ -1,17 +1,14 @@
 .Details {
-  flex: auto;
-
   display: flex;
+  flex: auto;
   flex-direction: column;
 }
 
 .sidebar-open-close-button {
-  flex: none;
-
-  height: 24px;
   width: 24px;
+  height: 24px;
+  flex: none;
   margin: 4px;
-
   background-position: center;
   background-repeat: no-repeat;
 }

--- a/src/components/app/DetailsContainer.css
+++ b/src/components/app/DetailsContainer.css
@@ -1,7 +1,7 @@
 .DetailsContainer .layout-pane > * {
-  box-sizing: border-box;
   width: 100%;
   height: 100%;
+  box-sizing: border-box;
 }
 
 .DetailsContainer .layout-pane:not(.layout-pane-primary) {
@@ -16,13 +16,11 @@
 }
 
 .DetailsContainer .layout-splitter {
-  background: var(--grey-10); /* Same background as sidebars */
-  border-left: 1px solid var(--grey-30);
   border-top: 1px solid var(--grey-30);
+  border-left: 1px solid var(--grey-30);
+  background: var(--grey-10); /* Same background as sidebars */
 }
 
 .DetailsContainer .layout-splitter:hover {
   background: var(--grey-30); /* same as the border above */
 }
-
-

--- a/src/components/app/FooterLinks.css
+++ b/src/components/app/FooterLinks.css
@@ -1,12 +1,10 @@
 .appFooterLinks {
   position: fixed;
-  bottom: 0;
   right: 0;
-
+  bottom: 0;
+  padding: 0 3px;
   border-top: 1px solid var(--grey-40);
   border-left: 1px solid var(--grey-40);
-  padding: 0px 3px;
-
   background-color: var(--grey-20);
 }
 
@@ -18,17 +16,17 @@
   text-decoration: none;
 }
 
-.appFooterLinksLink:hover,
-.appFooterLinksClose:hover {
-  text-decoration: underline;
-}
-
 .appFooterLinksClose {
   border: none;
   margin: 0;
-  font: inherit;
   background: none;
   cursor: pointer;
+  font: inherit;
+}
+
+.appFooterLinksLink:hover,
+.appFooterLinksClose:hover {
+  text-decoration: underline;
 }
 
 @media (max-width: 767px) {

--- a/src/components/app/Home.css
+++ b/src/components/app/Home.css
@@ -3,9 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 .home {
+  display: flex;
   width: 100%;
   min-height: 100vh;
-  display: flex;
   align-items: center;
   justify-content: center;
   line-height: 1.5;
@@ -13,31 +13,31 @@
 
 .homeDrop {
   position: absolute;
-  width: 100%;
-  height: 100%;
   top: 0;
   left: 0;
   display: flex;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
   align-items: stretch;
   justify-content: center;
-  background-color: rgba(255, 255, 255, 0.9);
   padding: 1em;
-  box-sizing: border-box;
+  background-color: rgba(255, 255, 255, 0.9);
   opacity: 0;
   pointer-events: none;
   transition: opacity 200ms;
 }
 
 .homeDropMessage {
-  width: 100%;
-  border: 2px dashed #888;
-  font-size: 30px;
-  color: #666;
-  text-align: center;
-  border-radius: 10px;
   display: flex;
+  width: 100%;
   align-items: center;
   justify-content: center;
+  border: 2px dashed #888;
+  border-radius: 10px;
+  color: #666;
+  font-size: 30px;
+  text-align: center;
 }
 
 .homeDrop.dragging {
@@ -46,42 +46,42 @@
 
 .homeSpecialMessage {
   padding: 8px 16px;
-  background-color: #798FC8;
   border: 1px solid #000;
+  margin: 17px 0;
+  background-color: #798fc8;
   border-radius: 3px;
   color: #fff;
-  margin: 17px 0;
 }
 
 .homeSection {
   position: relative;
+  overflow: hidden;
   width: 75%;
   max-width: 1200px;
   box-sizing: border-box;
-  border: 1px solid #CCC;
-  border-radius: 3px;
   padding: 8em;
-  font-size: 130%;
-  box-shadow: 0 5px 25px #0b1f50;
+  border: 1px solid #ccc;
   background-color: #fff;
-  overflow: hidden;
+  border-radius: 3px;
+  box-shadow: 0 5px 25px #0b1f50;
+  font-size: 130%;
 }
 
 .homeSection kbd {
   display: inline-block;
-  border: 1px solid #CCC;
-  border-radius: 0.2em;
+  padding: 0 0.5em;
+  border: 1px solid #ccc;
   margin: 0 0.2em;
-  padding: 0.0em 0.5em;
-  background-color: #F6F6F6;
-  box-shadow: 0.1em 0.1em 0 #BBB;
+  background-color: #f6f6f6;
+  border-radius: 0.2em;
+  box-shadow: 0.1em 0.1em 0 #bbb;
 }
 
 .homeTitle {
+  padding-bottom: 0.5em;
+  border-bottom: 1px solid #ddd;
   margin-top: 0;
   margin-bottom: 0.5em;
-  padding-bottom: 0.5em;
-  border-bottom: 1px solid #DDD;
 }
 
 .homeTitleSubtext {
@@ -110,40 +110,40 @@
 }
 
 .homeSectionButton {
-  padding: 0.5em;
-  margin: 15px 0;
   display: block;
+  padding: 0.5em;
   border: 2px solid var(--blue-50);
+  margin: 15px 0;
   color: var(--blue-50);
+  font-size: 16px;
+  font-weight: bold;
+  text-align: center;
   text-decoration: none;
   transition: background-color 300ms;
-  font-weight: bold;
-  font-size: 16px;
-  text-align: center;
 }
 
 .homeSectionButton:hover {
-  color: #fff;
   background-color: var(--blue-50);
+  color: #fff;
 }
 
 .homeSectionPlus {
-  font-size: 26px;
-  line-height: 0;
   position: relative;
   top: 2px;
   padding-right: 12px;
   padding-left: 5px;
+  font-size: 26px;
+  line-height: 0;
 }
 
 .homeSectionDocsIcon {
+  position: relative;
+  display: inline-block;
   width: 20px;
   height: 20px;
-  position: relative;
   margin: 0 10px -4px 3px;
   background: url(../../../res/img/svg/help-blue.svg);
   background-size: 100% 100%;
-  display: inline-block;
 }
 
 .homeSectionButton:hover .homeSectionDocsIcon {
@@ -196,8 +196,8 @@
 
 @media (max-width: 1100px) {
   .homeSection {
-    padding: 3em;
     max-width: 80%;
+    padding: 3em;
   }
   .homeInstructions {
     display: block;
@@ -217,8 +217,7 @@
 @media (max-width: 767px) {
   .homeSection {
     width: 80%;
-    padding-left: 1em;
     padding-right: 1em;
+    padding-left: 1em;
   }
-
 }

--- a/src/components/app/MenuButtons.css
+++ b/src/components/app/MenuButtons.css
@@ -3,23 +3,33 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 .menuButtons {
-  --internal-share-button-background-color: var(--share-button-background-color, hsl(137,81%,44%));
-  --internal-uploading-button-background-color: var(--uploading-button-background-color, #38445f);
-  --internal-uploading-progress-fill-color: var(--uploading-progress-fill-color, #7990c8);
-  height: 100%;
+  --internal-share-button-background-color: var(
+    --share-button-background-color,
+    hsl(137, 81%, 44%)
+  );
+  --internal-uploading-button-background-color: var(
+    --uploading-button-background-color,
+    #38445f
+  );
+  --internal-uploading-progress-fill-color: var(
+    --uploading-progress-fill-color,
+    #7990c8
+  );
+
   display: flex;
+  height: 100%;
   flex-flow: row nowrap;
 }
 
 .menuButtonsLink {
-  height: 24px;
   position: relative;
+  height: 24px;
   padding: 0 10px;
   border-left: 1px solid var(--grey-30);
-  text-decoration: none;
-  line-height: 24px;
-  cursor: default;
   color: var(--grey-90);
+  cursor: default;
+  line-height: 24px;
+  text-decoration: none;
 }
 
 .menuButtonsLink:hover {
@@ -29,8 +39,8 @@
 .menuButtonsCompositeButtonContainer {
   display: flex;
   flex-flow: column nowrap;
-  border-left: 1px solid var(--grey-30);
   border-right: 1px solid var(--grey-30);
+  border-left: 1px solid var(--grey-30);
 }
 
 .menuButtonsShareButton,
@@ -48,28 +58,28 @@
 
 .menuButtonsUploadingButtonInner {
   display: flex;
+  overflow: hidden;
+  height: 100%;
   flex-flow: column nowrap;
   align-items: stretch;
-  height: 100%;
-  overflow: hidden;
 }
 
 .menuButtonsUploadingButtonLabel {
+  position: relative;
   padding: 0 10px;
+  color: hsla(0, 0%, 100%, 0.7);
+  cursor: default;
   line-height: 24px;
   text-align: center;
-  color: hsla(0,0%,100%,0.7);
-  position: relative;
   -moz-user-select: none;
-  cursor: default;
 }
 
 .menuButtonsUploadingButtonProgress {
-  height: 24px;
-  margin-bottom: -24px;
   width: 100%;
-  background: var(--internal-uploading-button-background-color);
+  height: 24px;
   border: 0;
+  margin-bottom: -24px;
+  background: var(--internal-uploading-button-background-color);
   transform-origin: bottom left;
 }
 
@@ -77,17 +87,16 @@
   background: var(--internal-uploading-progress-fill-color);
 }
 
-.menuButtonsShareButtonButton:not([disabled]),
-.menuButtonsSecondaryShareButtonButton:not([disabled]) {
-  background-color: var(--internal-share-button-background-color);
-  color: white;
-}
-
-.menuButtonsCompositeButtonContainer:not(.currentButtonIsShareButton) > .menuButtonsShareButton,
-.menuButtonsCompositeButtonContainer:not(.currentButtonIsUploadingButton) > .menuButtonsUploadingButton,
-.menuButtonsCompositeButtonContainer:not(.currentButtonIsPermalinkButton) > .menuButtonsPermalinkButton,
-.menuButtonsCompositeButtonContainer:not(.currentButtonIsUploadErrorButton) > .menuButtonsUploadErrorButton,
-.menuButtonsCompositeButtonContainer:not(.currentButtonIsSecondaryShareButton) > .menuButtonsSecondaryShareButton {
+.menuButtonsCompositeButtonContainer:not(.currentButtonIsShareButton)
+  > .menuButtonsShareButton,
+.menuButtonsCompositeButtonContainer:not(.currentButtonIsUploadingButton)
+  > .menuButtonsUploadingButton,
+.menuButtonsCompositeButtonContainer:not(.currentButtonIsPermalinkButton)
+  > .menuButtonsPermalinkButton,
+.menuButtonsCompositeButtonContainer:not(.currentButtonIsUploadErrorButton)
+  > .menuButtonsUploadErrorButton,
+.menuButtonsCompositeButtonContainer:not(.currentButtonIsSecondaryShareButton)
+  > .menuButtonsSecondaryShareButton {
   pointer-events: none;
 }
 
@@ -99,24 +108,48 @@
   transition: transform 200ms ease-in-out, margin-left 200ms ease-in-out;
 }
 
-.menuButtonsCompositeButtonContainer:not(.currentButtonIsShareButton) > .menuButtonsShareButton > .buttonWithPanelButtonWrapper > .menuButtonsShareButtonButton,
-.menuButtonsCompositeButtonContainer.currentButtonIsPermalinkButton > .menuButtonsUploadingButton > .menuButtonsUploadingButtonInner,
-.menuButtonsCompositeButtonContainer.currentButtonIsUploadErrorButton > .menuButtonsUploadingButton > .menuButtonsUploadingButtonInner,
-.menuButtonsCompositeButtonContainer:not(.currentButtonIsSecondaryShareButton) .menuButtonsSecondaryShareButtonButton {
+.menuButtonsShareButtonButton:not([disabled]),
+.menuButtonsSecondaryShareButtonButton:not([disabled]) {
+  background-color: var(--internal-share-button-background-color);
+  color: white;
+}
+
+.menuButtonsCompositeButtonContainer:not(.currentButtonIsShareButton)
+  > .menuButtonsShareButton
+  > .buttonWithPanelButtonWrapper
+  > .menuButtonsShareButtonButton,
+.menuButtonsCompositeButtonContainer.currentButtonIsPermalinkButton
+  > .menuButtonsUploadingButton
+  > .menuButtonsUploadingButtonInner,
+.menuButtonsCompositeButtonContainer.currentButtonIsUploadErrorButton
+  > .menuButtonsUploadingButton
+  > .menuButtonsUploadingButtonInner,
+.menuButtonsCompositeButtonContainer:not(.currentButtonIsSecondaryShareButton)
+  .menuButtonsSecondaryShareButtonButton {
   transform: translateY(-24px);
 }
 
-.menuButtonsCompositeButtonContainer.currentButtonIsShareButton > .menuButtonsUploadingButton > .menuButtonsUploadingButtonInner,
-.menuButtonsCompositeButtonContainer:not(.currentButtonIsPermalinkButton) > .menuButtonsPermalinkButton > .buttonWithPanelButtonWrapper > .menuButtonsPermalinkButtonButton,
-.menuButtonsCompositeButtonContainer:not(.currentButtonIsUploadErrorButton) > .menuButtonsUploadErrorButton > .buttonWithPanelButtonWrapper > .menuButtonsUploadErrorButtonButton {
+.menuButtonsCompositeButtonContainer.currentButtonIsShareButton
+  > .menuButtonsUploadingButton
+  > .menuButtonsUploadingButtonInner,
+.menuButtonsCompositeButtonContainer:not(.currentButtonIsPermalinkButton)
+  > .menuButtonsPermalinkButton
+  > .buttonWithPanelButtonWrapper
+  > .menuButtonsPermalinkButtonButton,
+.menuButtonsCompositeButtonContainer:not(.currentButtonIsUploadErrorButton)
+  > .menuButtonsUploadErrorButton
+  > .buttonWithPanelButtonWrapper
+  > .menuButtonsUploadErrorButtonButton {
   transform: translateY(24px);
 }
 
-.currentButtonIsPermalinkButton.currentButtonIsSecondaryShareButton .menuButtonsPermalinkButton {
+.currentButtonIsPermalinkButton.currentButtonIsSecondaryShareButton
+  .menuButtonsPermalinkButton {
   width: 112px;
 }
 
-.currentButtonIsPermalinkButton.currentButtonIsSecondaryShareButton .menuButtonsSecondaryShareButton {
+.currentButtonIsPermalinkButton.currentButtonIsSecondaryShareButton
+  .menuButtonsSecondaryShareButton {
   margin-left: 112px;
 }
 
@@ -146,7 +179,7 @@
 }
 
 .menuButtonsShareNetworkUrlsCheckbox {
-  vertical-align: middle;
   position: relative;
   bottom: 1px;
+  vertical-align: middle;
 }

--- a/src/components/app/ProfileViewer.css
+++ b/src/components/app/ProfileViewer.css
@@ -8,32 +8,31 @@
 }
 
 .profileViewer {
-  background-color: #fff;
-  animation-name: profileViewerFadeIn;
   animation-duration: 200ms;
+  animation-name: profileViewerFadeIn;
+  background-color: #fff;
 }
 
 .profileViewerName {
   height: 24px;
   padding: 0 6px 0 2px;
   border-right: 1px solid var(--grey-30);
-  line-height: 24px;
-  font-weight: bold;
   color: var(--grey-60);
+  font-weight: bold;
+  line-height: 24px;
 }
 
 .profileViewerZipButton {
   width: 18px;
   height: 18px;
-
-  margin: 3px;
+  flex: none;
   padding: 0;
   border: 1px solid var(--green-60);
-  background: var(--green-50) url(../../../res/img/svg/back-arrow.svg) center center no-repeat;
-  flex: none;
-  
-  color: #000;
+  margin: 3px;
+  background: var(--green-50) url(../../../res/img/svg/back-arrow.svg) center
+    center no-repeat;
   border-radius: 3px;
+  color: #000;
 }
 
 .profileViewerZipButton:hover {

--- a/src/components/app/Root.css
+++ b/src/components/app/Root.css
@@ -2,27 +2,28 @@
   position: absolute;
   top: 0;
   left: 0;
+  display: flex;
   width: 100%;
   height: 100%;
-  display: flex;
-  justify-content: center;
   align-items: center;
+  justify-content: center;
 }
 
 .rootMessage {
-  background-color: #fff;
-  max-width: 600px;
-  width: 80%;
-  padding: 3em;
-  box-sizing: border-box;
-  border: 1px solid #ccc;
-  border-radius: 3px;
-  font-size: 130%;
-  box-shadow: 0 5px 25px #0b1f50;
   overflow: hidden;
+  width: 80%;
+  max-width: 600px;
+  box-sizing: border-box;
+  padding: 3em;
+  border: 1px solid #ccc;
+  background-color: #fff;
+  border-radius: 3px;
+  box-shadow: 0 5px 25px #0b1f50;
+  font-size: 130%;
 }
 
-.rootMessageText, .rootMessageAdditional {
+.rootMessageText,
+.rootMessageAdditional {
   line-height: 1.5;
 }
 
@@ -31,8 +32,8 @@
 }
 
 .rootMessageAdditional {
-  border-top: 1px solid #ccc;
   padding-top: 1em;
+  border-top: 1px solid #ccc;
   margin-top: 1em;
   font-size: 12px;
 }
@@ -46,11 +47,10 @@
 .loading-div {
   position: absolute;
   height: 8px;
-  border-radius: 2px;
-  animation-name: loadingdiv;
-
   animation-duration: 4000ms;
   animation-iteration-count: infinite;
+  animation-name: loadingdiv;
+  border-radius: 2px;
 }
 
 .loading-row-1 {
@@ -70,97 +70,97 @@
 }
 
 .loading-div-1 {
+  width: 100%;
   animation-delay: -900ms;
   background-color: var(--red-50);
-  width: 100%;
 }
 
 .loading-div-2 {
-  animation-delay: -800ms;
-  background-color: var(--blue-50);
   left: 1%;
   width: 97%;
+  animation-delay: -800ms;
+  background-color: var(--blue-50);
 }
 
 .loading-div-3 {
-  animation-delay: -700ms;
-  width: 30%;
   left: 5%;
+  width: 30%;
+  animation-delay: -700ms;
   background-color: var(--orange-50);
 }
 
 .loading-div-4 {
-  animation-delay: -600ms;
-  width: 53%;
   left: 43%;
+  width: 53%;
+  animation-delay: -600ms;
   background-color: var(--purple-50);
 }
 
 .loading-div-5 {
-  animation-delay: -500ms;
-  width: 14%;
   left: 8%;
+  width: 14%;
+  animation-delay: -500ms;
   background-color: var(--purple-50);
 }
 
 .loading-div-6 {
-  animation-delay: -400ms;
-  width: 11%;
   left: 23%;
+  width: 11%;
+  animation-delay: -400ms;
   background-color: var(--green-50);
 }
 
 .loading-div-7 {
-  animation-delay: -300ms;
-  width: 15%;
   left: 44%;
+  width: 15%;
+  animation-delay: -300ms;
   background-color: var(--orange-50);
 }
 
 .loading-div-8 {
-  animation-delay: -200ms;
-  width: 17%;
   left: 60%;
+  width: 17%;
+  animation-delay: -200ms;
   background-color: var(--orange-50);
 }
 
 .loading-div-9 {
-  animation-delay: -100ms;
-  width: 2%;
   left: 78%;
+  width: 2%;
+  animation-delay: -100ms;
   background-color: var(--blue-50);
 }
 
 .loading-div-10 {
-  animation-delay: 0ms;
-  width: 11%;
   left: 81%;
+  width: 11%;
+  animation-delay: 0ms;
   background-color: var(--green-60);
 }
 
 @keyframes loadingdiv {
   0% {
-    transform: translateX(100px);
     opacity: 0;
+    transform: translateX(100px);
   }
 
   20% {
-    transform: translateX(100px);
     opacity: 0;
+    transform: translateX(100px);
   }
 
   45% {
-    transform: translateX(0);
     opacity: 1;
+    transform: translateX(0);
   }
 
   65% {
-    transform: translateX(0);
     opacity: 1;
+    transform: translateX(0);
   }
 
   100% {
-    transform: translateX(-100px);
     opacity: 0;
+    transform: translateX(-100px);
   }
 }

--- a/src/components/app/ZipFileViewer.css
+++ b/src/components/app/ZipFileViewer.css
@@ -3,34 +3,32 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 .zipFileViewer {
-  width: 100%;
   display: flex;
-  justify-content: center;
+  width: 100%;
   min-height: 100vh;
   align-items: center;
+  justify-content: center;
   line-height: 1.5;
 }
 
 .zipFileViewerHeader {
-  font-size: 130%;
   padding: 0 20px;
+  font-size: 130%;
 }
 
 .zipFileViewerSection {
   position: relative;
-  width: 75vw;
-  height: 75vh;
-  max-width: 1200px;
-
   display: flex;
-  box-sizing: border-box;
-  border: 1px solid #ccc;
-  border-radius: 3px;
-
-  flex-direction: column;
-  box-shadow: 0 5px 25px #0b1f50;
-  background-color: #fff;
   overflow: hidden;
+  width: 75vw;
+  max-width: 1200px;
+  height: 75vh;
+  box-sizing: border-box;
+  flex-direction: column;
+  border: 1px solid #ccc;
+  background-color: #fff;
+  border-radius: 3px;
+  box-shadow: 0 5px 25px #0b1f50;
 }
 
 .zipFileViewerSection > .treeView {
@@ -44,10 +42,9 @@
 .zipFileViewerMessage {
   display: flex;
   flex: 1;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  flex-direction: column;
-
   border-top: 1px solid var(--grey-30);
   background-color: #f5f5f5;
   font-size: 14px;
@@ -58,16 +55,17 @@
 }
 
 .zipFileViewerUntrustedFilePath {
+  display: inline-block;
+  overflow: hidden;
+
   /**
    * Make the max width 50% so that some random user can't spam a bunch of misleading
    * content into an error message on perf.html.
    */
   max-width: 70%;
-  background-color: var(--grey-30);
   padding: 0 5px;
-  display: inline-block;
-  font-family: monospace;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  background-color: var(--grey-30);
   border-radius: 3px;
+  font-family: monospace;
+  text-overflow: ellipsis;
 }

--- a/src/components/flame-graph/Canvas.css
+++ b/src/components/flame-graph/Canvas.css
@@ -18,11 +18,11 @@
 
 .flameGraphCanvasTooltip > .tooltipHeader {
   display: grid;
-  grid-template-columns: min-content auto;
   grid-gap: 2px 0;
+  grid-template-columns: min-content auto;
 }
 
 .flameGraphCanvasTooltip .tooltipTitle {
-  white-space: nowrap;
   overflow: visible;
+  white-space: nowrap;
 }

--- a/src/components/flame-graph/FlameGraph.css
+++ b/src/components/flame-graph/FlameGraph.css
@@ -3,16 +3,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 .flameGraph {
-  flex: 1;
   display: flex;
-  flex-flow: column;
   overflow: hidden;
+  flex: 1;
+  flex-flow: column;
 }
 
 .flameGraphContent {
   display: flex;
-  flex-direction: row;
   flex: 1;
+  flex-direction: row;
   border-top: 1px solid var(--grey-30);
 }
 
@@ -26,9 +26,9 @@
 }
 
 .flameGraphLabels > span {
+  overflow: hidden;
   flex: 1;
   cursor: default;
-  white-space: nowrap;
-  overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/src/components/flame-graph/MaybeFlameGraph.css
+++ b/src/components/flame-graph/MaybeFlameGraph.css
@@ -1,11 +1,11 @@
 .flameGraphDisabledMessage {
-  flex: 1;
   display: flex;
+  flex: 1;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  flex-direction: column;
+  padding: 10px;
   background-color: var(--grey-20);
   box-shadow: inset 0 0 150px rgba(0, 0, 0, 0.1);
-  padding: 10px;
   font-size: 120%;
 }

--- a/src/components/marker-chart/index.css
+++ b/src/components/marker-chart/index.css
@@ -4,13 +4,13 @@
 
 .markerChart {
   display: flex;
-  flex-direction: row;
   flex: 1;
+  flex-direction: row;
 }
 
 .markerChartLabels {
-  width: 135px;
   display: flex;
+  width: 135px;
   padding: 9px 0 9px 14px;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -19,9 +19,9 @@
 }
 
 .markerChartLabelsName {
+  overflow: hidden;
   flex: 1;
   cursor: default;
-  white-space: nowrap;
-  overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/src/components/marker-table/Settings.css
+++ b/src/components/marker-table/Settings.css
@@ -3,11 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 .markerTableSettings {
+  display: flex;
   height: 25px;
+  flex-flow: row nowrap;
   padding: 0;
   line-height: 25px;
-  display: flex;
-  flex-flow: row nowrap;
 }
 
 .markerTableSettingsSpacer {
@@ -15,13 +15,13 @@
 }
 
 .markerTableSettingsLabel {
+  display: inline-flex;
+  height: 25px;
+  flex-flow: row nowrap;
+  align-items: center;
   -webkit-user-select: none;
   -moz-user-select: none;
   user-select: none;
-  display: inline-flex;
-  flex-flow: row nowrap;
-  align-items: center;
-  height: 25px;
 }
 
 .markerTableSettingsSearchbar {

--- a/src/components/marker-table/index.css
+++ b/src/components/marker-table/index.css
@@ -4,10 +4,10 @@
 
 .markerTable {
   display: flex;
-  flex-flow: column nowrap;
   flex: 1;
+  flex-flow: column nowrap;
+  cursor: default;
   -webkit-user-select: none;
   -moz-user-select: none;
   user-select: none;
-  cursor: default;
 }

--- a/src/components/shared/ArrowPanel.css
+++ b/src/components/shared/ArrowPanel.css
@@ -5,8 +5,8 @@
 .arrowPanelAnchor {
   position: absolute;
   z-index: 10;
-  left: 50%;
   top: 75%;
+  left: 50%;
 }
 
 .arrowPanel {
@@ -16,96 +16,102 @@
   --internal-button-height: 30px;
   --internal-ok-button-background: var(--ok-button-background, #7990c8);
   --internal-ok-button-color: var(--ok-button-color, white);
+
   position: absolute;
   top: var(--internal-offset-from-top);
-  right: calc(0px - var(--internal-offset-from-right));
+  right: calc(0 - var(--internal-offset-from-right));
   min-width: var(--internal-width);
-  filter: drop-shadow(0 0 0.5px rgba(0,0,0,0.4)) drop-shadow(0 4px 5px rgba(0,0,0,0.4));
-  filter: url(../../../res/img/svg/shadowfilter.svg#menushadow);
-  color: black;
-  text-align: left;
-  line-height: 1.3;
   background: hsla(0, 0%, 97%, 0.95);
   border-radius: 5px;
+  color: black;
+  filter: drop-shadow(0 0 0.5px rgba(0, 0, 0, 0.4))
+    drop-shadow(0 4px 5px rgba(0, 0, 0, 0.4));
+  filter: url(../../../res/img/svg/shadowfilter.svg#menushadow);
+  line-height: 1.3;
+  text-align: left;
   transform-origin: calc(100% - var(--internal-offset-from-right))
-                    calc(0px - var(--internal-offset-from-top));
+    calc(0 - var(--internal-offset-from-top));
 }
 
 .arrowPanel:not(.open) {
+  opacity: 0;
   pointer-events: none;
   transition: opacity 200ms ease-out;
-  opacity: 0;
 }
 
 .arrowPanel.open {
-  transition: none;
   animation: arrowPanelAppear 400ms;
   opacity: 1;
+  transition: none;
 }
 
 @keyframes arrowPanelAppear {
   from {
+    animation-timing-function: ease-out;
     opacity: 0;
     transform: scale(0);
-    animation-timing-function: ease-out;
   }
 
   40% {
+    animation-timing-function: ease-in-out;
     opacity: 0.6;
     transform: scale(1);
-    animation-timing-function: ease-in-out;
   }
 
   60% {
+    animation-timing-function: cubic-bezier(0.3, 0, 0.3, 1);
     opacity: 0.9;
     transform: scale(0.96);
-    animation-timing-function: cubic-bezier(.3,0,0.3,1);
   }
 }
 
 .arrowPanelArrow {
   position: absolute;
-  left: 0;
+  top: calc(0 - var(--internal-offset-from-top));
   right: 0;
-  top: calc(0px - var(--internal-offset-from-top));
-  height: var(--internal-offset-from-top);
+  left: 0;
   overflow: hidden;
+  height: var(--internal-offset-from-top);
 }
 
 .arrowPanelArrow::before {
-  content: '';
-  display: block;
   position: absolute;
+  z-index: -1;
   top: 0;
   left: calc(100% - var(--internal-offset-from-right));
+  display: block;
   width: calc(1.42 * var(--internal-offset-from-top));
   height: calc(1.42 * var(--internal-offset-from-top));
   background: hsla(0, 0%, 97%, 0.95);
+  content: '';
   transform: rotate(45deg);
   transform-origin: top left;
-  z-index: -1;
 }
 
 .arrowPanelTitle {
-  font-size: 1.2em;
   padding: 10px;
   margin: 0;
+  font-size: 1.2em;
 }
 
 .arrowPanelContent {
-  padding: 0 10px;
   overflow: auto;
+  max-height: calc(
+    100vh - var(--internal-approx-distance-from-top) -
+      var(--internal-button-height) - var(--internal-approx-distance-to-top)
+  );
+  padding: 0 10px;
+
   --internal-approx-distance-from-top: 60px;
   --internal-approx-distance-to-bottom: 100px;
-  max-height: calc(100vh - var(--internal-approx-distance-from-top) - var(--internal-button-height) - var(--internal-approx-distance-to-top));
 }
 
 .arrowPanel.hasTitle > .arrowPanelContent {
-  border-top: 1px solid rgba(0,0,0,0.05);
+  border-top: 1px solid rgba(0, 0, 0, 0.05);
 }
 
 .arrowPanel.hasButtons > .arrowPanelContent {
-  border-bottom: 1px solid rgba(0,0,0,0.05);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
 }
 
 .arrowPanel ul {
@@ -113,27 +119,27 @@
 }
 
 .arrowPanelButtons {
-  height: 35px;
-  line-height: 35px;
   display: flex;
+  height: 35px;
   flex-flow: row nowrap;
   align-items: stretch;
+  line-height: 35px;
 }
 
 .arrowPanelOkButton,
 .arrowPanelCancelButton {
-  border: 0;
-  background: none;
-  padding: 0;
-  margin: 0;
   flex: 1;
-  text-align: center;
+  padding: 0;
+  border: 0;
+  margin: 0;
+  background: none;
   font-size: 1.2em;
+  text-align: center;
 }
 
 .arrowPanelOkButton {
-  border-bottom-right-radius: 5px;
   background: var(--internal-ok-button-background);
+  border-bottom-right-radius: 5px;
   color: var(--internal-ok-button-color);
 }
 
@@ -143,10 +149,10 @@
 
 .arrowPanelOkButton:hover,
 .arrowPanelCancelButton:hover {
-  background-image: linear-gradient(rgba(0,0,0,0.1), rgba(0,0,0,0.1));
+  background-image: linear-gradient(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.1));
 }
 
 .arrowPanelOkButton:hover:active,
 .arrowPanelCancelButton:hover:active {
-  background-image: linear-gradient(rgba(0,0,0,0.2), rgba(0,0,0,0.2));
+  background-image: linear-gradient(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.2));
 }

--- a/src/components/shared/Backtrace.css
+++ b/src/components/shared/Backtrace.css
@@ -2,35 +2,43 @@
   --max-height: 30em;
   --gradient-height: calc(var(--max-height) - 5em);
 
-  margin: 5px;
-  padding: 0;
-  max-height: var(--max-height);
   overflow: hidden;
-
-  font-size: .9em;
+  max-height: var(--max-height);
+  padding: 0;
+  margin: 5px;
+  font-size: 0.9em;
   line-height: 1.5;
 
   /* The gradient is defined towards the bottom so that we hide the end of the
    * backtrace only when the element is tall enough, which is when the backtrace
    * is long. */
-  -webkit-mask-image: linear-gradient(to bottom, white, white var(--gradient-height), transparent);
-  mask-image: linear-gradient(to bottom, white, white var(--gradient-height), transparent);
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    white,
+    white var(--gradient-height),
+    transparent
+  );
+  mask-image: linear-gradient(
+    to bottom,
+    white,
+    white var(--gradient-height),
+    transparent
+  );
 }
 
 .backtraceStackFrame {
   display: block;
-  margin: 0;
-  padding: 0;
+  overflow: hidden;
   max-width: 35em;
-
+  padding: 0;
+  margin: 0;
   list-style: none;
   text-overflow: ellipsis;
-  overflow: hidden;
   white-space: nowrap;
 }
 
 .backtraceStackFrameOrigin {
-  color: rgba(0,0,0,0.4);
   margin-left: 10px;
+  color: rgba(0, 0, 0, 0.4);
   font-style: normal;
 }

--- a/src/components/shared/ButtonWithPanel.css
+++ b/src/components/shared/ButtonWithPanel.css
@@ -3,10 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 .buttonWithPanel {
+  position: relative;
   display: flex;
   flex-flow: column nowrap;
   align-items: stretch;
-  position: relative;
 }
 
 /**
@@ -17,26 +17,26 @@
  * .buttonWithPanel because the latter would clip the panel. */
 .buttonWithPanelButtonWrapper {
   display: flex;
+  overflow: hidden;
+  height: 100%;
   flex-flow: column nowrap;
   align-items: stretch;
-  height: 100%;
-  overflow: hidden;
 }
 
 .buttonWithPanelButton {
+  height: 100%;
+  padding: 0 10px;
   border: 0;
   margin: 0;
-  padding: 0 10px;
   background: none;
-  height: 100%;
   font-size: 100%;
 }
 
 .buttonWithPanelButton:not([disabled]):hover {
-  background-image: linear-gradient(rgba(0,0,0,0.1), rgba(0,0,0,0.1));
+  background-image: linear-gradient(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.1));
 }
 
 .buttonWithPanel.open > * > .buttonWithPanelButton,
 .buttonWithPanelButton:not([disabled]):hover:active {
-  background-image: linear-gradient(rgba(0,0,0,0.2), rgba(0,0,0,0.2));
+  background-image: linear-gradient(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.2));
 }

--- a/src/components/shared/CallNodeContextMenu.css
+++ b/src/components/shared/CallNodeContextMenu.css
@@ -1,11 +1,11 @@
 .callNodeContextMenuIcon {
+  position: relative;
+  top: 2px;
+  display: inline-block;
   width: 16px;
   height: 16px;
-  pointer-events: auto;
-  position: relative;
-  display: inline-block;
   margin-inline-end: 8px;
-  top: 2px;
+  pointer-events: auto;
 }
 .react-contextmenu-item--selected > .callNodeContextMenuIcon {
   filter: invert(1);
@@ -16,7 +16,8 @@
 }
 
 .callNodeContextMenuIconCollapse {
-  background: url(../../../res/img/svg/collapse-icon.svg) center center no-repeat;
+  background: url(../../../res/img/svg/collapse-icon.svg) center center
+    no-repeat;
 }
 
 .callNodeContextMenuIconFocus {

--- a/src/components/shared/EmptyReasons.css
+++ b/src/components/shared/EmptyReasons.css
@@ -1,11 +1,11 @@
 .EmptyReasons {
-  flex: 1;
   display: flex;
+  flex: 1;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  flex-direction: column;
+  padding: 10px;
   background-color: var(--grey-20);
   box-shadow: inset 0 0 15px rgba(0, 0, 0, 0.1);
-  padding: 10px;
   font-size: 120%;
 }

--- a/src/components/shared/FilterNavigatorBar.css
+++ b/src/components/shared/FilterNavigatorBar.css
@@ -4,41 +4,42 @@
 
 .filterNavigatorBar {
   --internal-selected-color: var(--selected-color, var(--blue-60));
-  height: 24px;
-  margin: 0;
-  padding: 0;
-  flex-shrink: 0;
+
   display: flex;
-  flex-flow: row nowrap;
-  -moz-user-select: none;
-  cursor: default;
   overflow: hidden;
+  height: 24px;
+  flex-flow: row nowrap;
+  flex-shrink: 0;
+  padding: 0;
+  margin: 0;
+  cursor: default;
+  -moz-user-select: none;
 }
 
 .filterNavigatorBarItem {
-  display: flex;
-  flex-flow: row nowrap;
-  min-width: 0;
   position: relative;
-  height: 24px;
-  line-height: 24px;
-  border: solid transparent;
-  border-width: 0 8px 0 6px;
-  border-right-color: transparent !important;
-  padding: 0 6px 0 8px;
-  background-clip: padding-box;
+  display: flex;
+  min-width: 0;
   max-width: 20%;
+  height: 24px;
+  flex-flow: row nowrap;
+  padding: 0 6px 0 8px;
+  border: solid transparent;
+  background-clip: padding-box;
+  border-right-color: transparent !important;
+  border-width: 0 8px 0 6px;
+  line-height: 24px;
 }
 
 .filterNavigatorBarRootItem {
-  margin-left: -8px;
   flex-shrink: 0;
+  margin-left: -8px;
 }
 
 .filterNavigatorBarItemContent {
-  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .filterNavigatorBarLeafItem {
@@ -48,14 +49,14 @@
 
 .filterNavigatorBarItem::before,
 .filterNavigatorBarItem::after {
-  content: '';
-  display: block;
   position: absolute;
   top: 0;
   bottom: 0;
+  display: block;
   width: 0;
   border: 12px solid transparent;
   border-right-width: 2px;
+  content: '';
   pointer-events: none;
 }
 
@@ -66,15 +67,15 @@
 
 .filterNavigatorBarItem::after {
   right: -14px;
-  border-top-color: transparent !important;
-  border-right-color: transparent !important;
   border-bottom-color: transparent !important;
+  border-right-color: transparent !important;
+  border-top-color: transparent !important;
 }
 
 .filterNavigatorBarItem:not(.filterNavigatorBarLeafItem)::after {
   background-image: url(../../../res/img/svg/scope-bar-separator.svg);
-  background-repeat: no-repeat;
   background-position: -18px -12px;
+  background-repeat: no-repeat;
   background-size: 24px 24px;
 }
 
@@ -109,9 +110,9 @@
 /* Animation */
 
 .filterNavigatorBarTransition-enter {
+  z-index: 0;
   opacity: 0.1;
   transform: translateX(-100%);
-  z-index:0;
 }
 
 .filterNavigatorBarTransition-enter.filterNavigatorBarTransition-enter-active {

--- a/src/components/shared/IdleSearchField.css
+++ b/src/components/shared/IdleSearchField.css
@@ -3,40 +3,41 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 .idleSearchField {
-  display: inline-flex;
   position: relative; /* to properly position the button */
+  display: inline-flex;
   flex-flow: row nowrap;
   align-items: center;
 }
 
 .idleSearchFieldInput {
-  flex: 1;
-  height: 19px;
   position: relative;
-  -moz-appearance: none;
-  border: 0.5px solid #AAA;
-  margin: 0;
+  height: 19px;
+  flex: 1;
   padding: 0 18px 0 17px; /* right padding for the reset button, left padding for the search icon */
-  border-radius: 2px;
-  box-shadow: inset 0 0 0.5px rgba(0,0,0,0.15), 0 0 0.5px rgba(0,0,0,0.1);
-  background: url(../../../res/img/svg/searchfield-icon.svg) 3px center no-repeat white;
+  border: 0.5px solid #aaa;
+  margin: 0;
+  -moz-appearance: none;
+  background: url(../../../res/img/svg/searchfield-icon.svg) 3px center
+    no-repeat white;
   background-size: 11px 11px;
+  border-radius: 2px;
+  box-shadow: inset 0 0 0.5px rgba(0, 0, 0, 0.15), 0 0 0.5px rgba(0, 0, 0, 0.1);
 }
 
 .idleSearchFieldButton {
   position: absolute;
   right: 5px;
+  overflow: hidden;
   width: 11px;
   height: 11px;
-
-  overflow: hidden;
-  background: url(../../../res/img/svg/searchfield-cancel.svg) top left no-repeat;
-  background-size: contain;
-  border: 0;
   padding: 0;
-  vertical-align: middle;
+  border: 0;
+  background: url(../../../res/img/svg/searchfield-cancel.svg) top left
+    no-repeat;
+  background-size: contain;
   color: transparent;
   -moz-user-focus: ignore;
+  vertical-align: middle;
 }
 
 .idleSearchFieldInput:invalid + .idleSearchFieldButton {

--- a/src/components/shared/StackSearchField.css
+++ b/src/components/shared/StackSearchField.css
@@ -1,8 +1,8 @@
 .stackSearchField {
-  padding: 0 5px;
   /* so that the introduction is on top of other panels, _but_ still keep it
    * below the input field (see below) */
   z-index: 1;
+  padding: 0 5px;
 }
 
 .stackSearchFieldLabel {
@@ -16,15 +16,14 @@
 }
 
 .stackSearchFieldIntroduction {
-  transform: translate(2px, -2px);
-  padding: 0 5px;
   z-index: -1; /* it needs to be below the input field */
-
-  box-shadow: 0 1px 4px rgba(12, 12, 13, .10); /* This is grey-90 with 10% opacity, according to the photon design document */
+  padding: 0 5px;
   background-color: white;
+  box-shadow: 0 1px 4px rgba(12, 12, 13, 0.1); /* This is grey-90 with 10% opacity, according to the photon design document */
   color: var(--grey-50);
   font-size: 0.9em;
   line-height: 2;
+  transform: translate(2px, -2px);
 }
 
 .stackSearchFieldIntroduction.isDisplayed {

--- a/src/components/shared/StackSettings.css
+++ b/src/components/shared/StackSettings.css
@@ -3,37 +3,37 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 .stackSettings {
-  height: 25px;
-  padding: 0;
-  line-height: 25px;
   display: flex;
+  height: 25px;
   flex-flow: row nowrap;
+  padding: 0;
   color: var(--ink-70);
+  line-height: 25px;
 }
 
 .stackSettingsList {
   display: block;
-  flex: 1;
-  list-style: none;
-  margin: 0;
-  padding: 0;
   display: flex;
+  flex: 1;
   align-items: flex-start;
+  padding: 0;
+  margin: 0;
+  list-style: none;
 }
 
 .stackSettingsListItem {
-  margin: 0 5px;
   padding: 0;
+  margin: 0 5px;
 }
 
 .stackSettingsLabel {
+  display: inline-flex;
+  height: 25px;
+  flex-flow: row nowrap;
+  align-items: center;
   -webkit-user-select: none;
   -moz-user-select: none;
   user-select: none;
-  display: inline-flex;
-  flex-flow: row nowrap;
-  align-items: center;
-  height: 25px;
 }
 
 .stackSettingsSelect {

--- a/src/components/shared/Tooltip.css
+++ b/src/components/shared/Tooltip.css
@@ -1,23 +1,22 @@
 .tooltipMount {
-  pointer-events: none;
   /* Stack the tooltip mounting point above the #root element. */
   z-index: 1;
+  pointer-events: none;
 }
 
 .tooltip {
   position: fixed;
+  display: inline-block;
+  overflow: hidden;
   max-width: 100%;
   box-sizing: border-box;
-  display: inline-block;
   padding: 5px;
   border: 1px solid #ccc;
   background-color: var(--grey-10);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
   text-align: left;
-  overflow: hidden;
   text-overflow: ellipsis;
   transition: opacity 250ms;
-  box-sizing: border-box;
 }
 
 .tooltipTiming {
@@ -29,68 +28,68 @@
 .tooltipOneLine {
   display: flex;
   max-width: 100%;
-  white-space: nowrap;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .tooltipTitle {
+  overflow: hidden;
   flex: 1;
   text-overflow: ellipsis;
-  overflow: hidden;
 }
 
 .tooltipSwatch {
+  display: inline-block;
   width: 10px;
   height: 10px;
-  display: inline-block;
   border: 1px solid #888;
   margin-right: 3px;
 }
 
 .tooltipIcon {
   display: inline-block;
-  margin-right: 3px;
   align-self: flex-end;
+  margin-right: 3px;
 }
 
 .tooltipIcon > .nodeIcon {
   width: 14px;
-  margin-left: auto;
   padding-right: 0.5em;
+  margin-left: auto;
 }
 .tooltipHeader {
   padding-bottom: 5px;
-  margin-bottom: 5px;
   border-bottom: 1px solid var(--grey-40);
+  margin-bottom: 5px;
 }
 
 .tooltipDetails {
   display: grid;
-  grid-template-columns: min-content auto;
   grid-gap: 2px 5px;
+  grid-template-columns: min-content auto;
 }
 
 .tooltipLabel {
   color: var(--grey-50);
-  white-space: nowrap;
   text-align: right;
+  white-space: nowrap;
 }
 
 .tooltipBackTraceTitle {
-  color: var(--grey-50);
-  font-weight: normal;
   margin: 0;
+  color: var(--grey-50);
   font-size: 100%;
+  font-weight: normal;
 }
 
 .tooltipDetails + .tooltipDetailsBackTrace {
   padding-top: 5px;
-  margin-top: 5px;
   border-top: 1px solid var(--grey-40);
+  margin-top: 5px;
 }
 
 .tooltipLib {
+  align-self: flex-end;
   color: var(--grey-50);
   white-space: nowrap;
-  align-self: flex-end;
 }

--- a/src/components/shared/chart/Viewport.css
+++ b/src/components/shared/chart/Viewport.css
@@ -3,31 +3,32 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 .chartViewport {
-  flex: 1;
   position: relative;
-  margin-top: 0;
   overflow: hidden;
+  flex: 1;
+  margin-top: 0;
 }
 
 .chartViewport.expanded {
-  cursor: -webkit-grab;
-  cursor: grab;
   border-top: 1px solid var(--grey-30);
   border-bottom: 1px solid var(--grey-30);
   margin-bottom: 5px;
+  cursor: -webkit-grab;
+  cursor: grab;
 }
 
 .chartViewport.expanded::after {
-  content: "";
-  pointer-events: none;
   position: absolute;
+  z-index: 1;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
+
   /* Slight blue shadow. */
   box-shadow: inset 0 0 20px rgba(64, 115, 140, 0.2);
-  z-index:1;
+  content: '';
+  pointer-events: none;
 }
 
 .chartViewport.dragging {
@@ -37,20 +38,20 @@
 
 .chartViewportShiftScroll {
   position: absolute;
-  pointer-events: none;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  will-change: opacity, transform;
   bottom: 0;
   left: 0;
-  padding: 3px 10px;;
+  overflow: hidden;
+  padding: 3px 10px;
+  background: rgba(0, 0, 0, 0.07);
   border-radius: 0 5px 0 0;
-  opacity: 1;
-  background: rgba(0,0,0,0.07);
+  box-shadow: 0 0 0 0.5px rgba(0, 0, 0, 0.1), 0 2px 4px rgba(0, 0, 0, 0.1);
   line-height: 20px;
-  transition: transform .2s ease-in-out, opacity .2s ease-in-out;
-  box-shadow: 0 0 0 0.5px rgba(0,0,0,0.1), 0 2px 4px rgba(0,0,0,0.1);
+  opacity: 1;
+  pointer-events: none;
+  text-overflow: ellipsis;
+  transition: transform 0.2s ease-in-out, opacity 0.2s ease-in-out;
+  white-space: nowrap;
+  will-change: opacity, transform;
 }
 
 .chartViewportShiftScroll.hidden {
@@ -59,14 +60,14 @@
 }
 
 .chartViewportShiftScrollKbd {
-  background-color: #f6f6f6;
-  border: 1px solid #ccc;
-  border-radius: .2em;
-  display: inline-block;
-  padding: 0 .5em;
-  box-shadow: -.1em .1em 0 #bbb;
-  margin: 0 .2em;
-  top: -1px;
   position: relative;
+  top: -1px;
+  display: inline-block;
+  padding: 0 0.5em;
+  border: 1px solid #ccc;
+  margin: 0 0.2em;
+  background-color: #f6f6f6;
+  border-radius: 0.2em;
+  box-shadow: -0.1em 0.1em 0 #bbb;
   color: #000;
 }

--- a/src/components/sidebar/sidebar.css
+++ b/src/components/sidebar/sidebar.css
@@ -1,51 +1,50 @@
 .sidebar {
   padding: 1em;
-  overflow-x: hidden;
-
-  font-size: 11px;
-  background: var(--grey-10);
   border-top: 1px solid var(--grey-30);
+  background: var(--grey-10);
+  font-size: 11px;
+  overflow-x: hidden;
 }
 
 .sidebar-titlegroup {
-  margin: 0 0 1em 0;
-  line-height: 1.2;
   min-height: 8em; /* This allows for a more stable sidebar when navigating the call tree */
+  margin: 0 0 1em;
+  line-height: 1.2;
 }
 
-.sidebar-title, .sidebar-subtitle {
-  margin: 0;
+.sidebar-title,
+.sidebar-subtitle {
   padding: 0;
+  margin: 0;
   font-weight: normal;
-
   overflow-wrap: break-word;
 }
 
 .sidebar-title {
+  margin-bottom: 0.3em;
   font-size: 12px;
-  margin-bottom: .3em;
 }
 
-.sidebar-title2, .sidebar-title3 {
+.sidebar-title2,
+.sidebar-title3 {
   font-weight: normal;
 }
 
 .sidebar-subtitle {
-  font-size: inherit; /* reset browser styles */
   color: var(--grey-50);
+  font-size: inherit; /* reset browser styles */
 }
 
 .sidebar-details {
   display: grid;
-  grid-template-columns: min-content auto;
-  grid-gap: 2px 5px;
   justify-content: center;
-
+  grid-gap: 2px 5px;
+  grid-template-columns: min-content auto;
   line-height: 1.5;
 }
 
 .sidebar-label {
   color: var(--grey-50);
-  white-space: nowrap;
   text-align: right;
+  white-space: nowrap;
 }

--- a/src/components/stack-chart/index.css
+++ b/src/components/stack-chart/index.css
@@ -3,16 +3,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 .stackChart {
-  flex: 1;
   display: flex;
-  flex-flow: column;
   overflow: hidden;
+  flex: 1;
+  flex-flow: column;
 }
 
 .stackChartGraph {
   display: flex;
-  flex-direction: row;
   flex: 1;
+  flex-direction: row;
   border-top: 1px solid var(--grey-30);
 }
 
@@ -26,9 +26,9 @@
 }
 
 .stackChartLabels > span {
+  overflow: hidden;
   flex: 1;
   cursor: default;
-  white-space: nowrap;
-  overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/src/components/timeline/EmptyThreadIndicator.css
+++ b/src/components/timeline/EmptyThreadIndicator.css
@@ -5,6 +5,7 @@
 .timelineEmptyThreadIndicator {
   --empty-buffer-color1: rgba(69, 160, 255, 0.225);
   --empty-buffer-color2: rgba(69, 160, 255, 0.075);
+
   /* The following color is based off grey-20, but uses opacity instead. */
   --shutdown-startup-color: rgba(0, 0, 50, 0.07);
 }
@@ -13,6 +14,7 @@
   position: absolute;
   top: 0;
   bottom: 0;
+
   /* Don't add the border to the width, as this causes the block to overflow. */
   box-sizing: border-box;
 }

--- a/src/components/timeline/OverflowEdgeIndicator.css
+++ b/src/components/timeline/OverflowEdgeIndicator.css
@@ -8,12 +8,12 @@
 
 .overflowEdgeIndicatorEdge {
   position: absolute;
-  pointer-events: none;
-  visibility: hidden;
   z-index: 3;
   opacity: 0;
+  pointer-events: none;
   transition: 150ms ease-in-out;
   transition-property: opacity, visibility;
+  visibility: hidden;
 }
 
 .overflowEdgeIndicatorEdge.topEdge,
@@ -50,26 +50,43 @@
   height: 15px;
 }
 
-.overflowEdgeIndicator.overflowsOnTop > .overflowEdgeIndicatorEdge.topEdge,
-.overflowEdgeIndicator.overflowsOnRight > .overflowEdgeIndicatorEdge.rightEdge,
-.overflowEdgeIndicator.overflowsOnBottom > .overflowEdgeIndicatorEdge.bottomEdge,
-.overflowEdgeIndicator.overflowsOnLeft > .overflowEdgeIndicatorEdge.leftEdge {
-  visibility: visible;
-  opacity: 1;
-}
-
 .overflowEdgeIndicatorEdge.topEdge {
-  background: radial-gradient(ellipse at center top, rgba(0,0,0,0.4), transparent 60%)
+  background: radial-gradient(
+    ellipse at center top,
+    rgba(0, 0, 0, 0.4),
+    transparent 60%
+  );
 }
 
 .overflowEdgeIndicatorEdge.rightEdge {
-  background: radial-gradient(ellipse at right center, rgba(0,0,0,0.4), transparent 60%)
+  background: radial-gradient(
+    ellipse at right center,
+    rgba(0, 0, 0, 0.4),
+    transparent 60%
+  );
 }
 
 .overflowEdgeIndicatorEdge.bottomEdge {
-  background: radial-gradient(ellipse at center bottom, rgba(0,0,0,0.4), transparent 60%)
+  background: radial-gradient(
+    ellipse at center bottom,
+    rgba(0, 0, 0, 0.4),
+    transparent 60%
+  );
 }
 
 .overflowEdgeIndicatorEdge.leftEdge {
-  background: radial-gradient(ellipse at left center, rgba(0,0,0,0.4), transparent 60%)
+  background: radial-gradient(
+    ellipse at left center,
+    rgba(0, 0, 0, 0.4),
+    transparent 60%
+  );
+}
+
+.overflowEdgeIndicator.overflowsOnTop > .overflowEdgeIndicatorEdge.topEdge,
+.overflowEdgeIndicator.overflowsOnRight > .overflowEdgeIndicatorEdge.rightEdge,
+.overflowEdgeIndicator.overflowsOnBottom
+  > .overflowEdgeIndicatorEdge.bottomEdge,
+.overflowEdgeIndicator.overflowsOnLeft > .overflowEdgeIndicatorEdge.leftEdge {
+  opacity: 1;
+  visibility: visible;
 }

--- a/src/components/timeline/Ruler.css
+++ b/src/components/timeline/Ruler.css
@@ -3,51 +3,56 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 .timelineRuler {
-  height: 20px;
   overflow: hidden;
+  height: 20px;
 }
 
 .timelineRuler::after {
-  content: '';
   position: absolute;
+  z-index: 3;
   top: 20px;
-  left: -150px;
   right: 0;
+  left: -150px;
   height: 1px;
   background: var(--grey-30);
-  z-index: 3;
+  content: '';
 }
 
 .timelineRulerContainer {
-  overflow: hidden;
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: block;
   position: absolute;
+  z-index: 1; /* between .timelineThread background and .timelineThreadDetails */
   top: 0;
-  left: 0;
   right: 0;
   bottom: 0;
-  -moz-user-select: none;
-  user-select: none;
-  line-height: 20px;
-  font-size: 9px;
+  left: 0;
+  display: block;
+  overflow: hidden;
+  padding: 0;
+  margin: 0;
   color: #888;
   cursor: default;
-  z-index: 1; /* between .timelineThread background and .timelineThreadDetails */
+  font-size: 9px;
+  line-height: 20px;
+  list-style: none;
+  -moz-user-select: none;
+  user-select: none;
 }
 
 .timelineRulerNotch {
-  display: block;
   position: absolute;
   top: 0;
   bottom: 0;
+  display: block;
   width: 1px;
   margin-left: -1px;
-  white-space: nowrap;
+  background: linear-gradient(
+    transparent,
+    var(--grey-30) 19px,
+    var(--grey-30) 20px,
+    #d7d7db66 0
+  );
   text-align: right;
-  background: linear-gradient(transparent, var(--grey-30) 19px, var(--grey-30) 20px, #d7d7db66 0);
+  white-space: nowrap;
 }
 
 .timelineRulerNotchText {

--- a/src/components/timeline/Selection.css
+++ b/src/components/timeline/Selection.css
@@ -4,20 +4,20 @@
 
 .timelineSelection {
   position: relative;
-  margin-left: 149px;
   border-left: 1px solid var(--grey-30);
+  margin-left: 149px;
   -moz-user-focus: ignore;
 }
 
 .timelineSelectionHoverLine {
   position: absolute;
-  pointer-events: none;
-  visibility: hidden;
+  z-index: 1;
   top: 0;
   bottom: 0;
   width: 1px;
-  background: rgba(0,0,0,0.4);
-  z-index: 1;
+  background: rgba(0, 0, 0, 0.4);
+  pointer-events: none;
+  visibility: hidden;
 }
 
 .timelineSelection:hover > .timelineSelectionHoverLine {
@@ -27,22 +27,22 @@
 .timelineSelectionOverlay {
   position: absolute;
   z-index: 2;
-  display: flex;
-  flex-flow: row nowrap;
   top: 0;
-  left: 0;
   right: 0;
   bottom: 0;
-  pointer-events: none;
-  margin-left: -5px;
-  padding-left: 5px;
+  left: 0;
+  display: flex;
   overflow: hidden;
+  flex-flow: row nowrap;
+  padding-left: 5px;
+  margin-left: -5px;
+  pointer-events: none;
 }
 
 .timelineSelectionDimmerBefore,
 .timelineSelectionDimmerAfter {
-  background: rgba(12, 12, 13, .1);
   flex-shrink: 0;
+  background: rgba(12, 12, 13, 0.1);
 }
 
 .timelineSelectionDimmerAfter {
@@ -55,23 +55,23 @@
 }
 
 .timelineSelectionGrippy {
-  height: 20px;
-  pointer-events: auto;
   display: flex;
+  height: 20px;
   flex-flow: row nowrap;
+  pointer-events: auto;
 }
 
 .timelineSelectionGrippyRangeStart,
 .timelineSelectionGrippyRangeEnd {
-  width: 0px;
-  padding: 3px;
-  background: #AAA;
-  border: 1px solid white;
-  margin: 0 -4px;
-  cursor: ew-resize;
-  border-radius: 5px;
   position: relative;
   z-index: 3;
+  width: 0;
+  padding: 3px;
+  border: 1px solid white;
+  margin: 0 -4px;
+  background: #aaa;
+  border-radius: 5px;
+  cursor: ew-resize;
 }
 
 .timelineSelectionGrippyRangeStart:hover,
@@ -92,26 +92,25 @@
   cursor: grabbing;
 }
 
-
 .timelineSelectionOverlayInner {
-  flex: 1;
-  justify-content: center;
-  align-items: center;
   display: flex;
   min-width: 0;
   min-height: 0;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
 }
 
 .timelineSelectionOverlayRange {
-  top: 20px;
   position: absolute;
+  top: 20px;
   padding: 4px 8px;
-  color: #fff;
   background-color: var(--blue-50);
   border-radius: 0 0 4px 4px;
   box-shadow: 0 2px 2px rgba(0, 0, 0, 0.2);
-  pointer-events: none;
+  color: #fff;
   opacity: 1;
+  pointer-events: none;
   transition: opacity 200ms;
 }
 
@@ -120,33 +119,33 @@
 }
 
 .timelineSelectionOverlayZoomButton {
+  position: relative;
   width: 30px;
   height: 30px;
-  pointer-events: auto;
   box-sizing: border-box;
-  border-radius: 100%;
-  margin: -15px;
-  position: relative;
   border: 1px solid rgba(0, 0, 0, 0.2);
-  background: url(../../../res/img/svg/zoom-icon.svg) center center no-repeat rgba(255, 255, 255, 0.6);
+  margin: -15px;
+  background: url(../../../res/img/svg/zoom-icon.svg) center center no-repeat
+    rgba(255, 255, 255, 0.6);
+  border-radius: 100%;
+  opacity: 0.5;
+  pointer-events: auto;
   transition: opacity 200ms ease-in-out;
   will-change: opacity;
-  opacity: 0.5;
 }
 
 .timelineSelectionOverlayZoomButton.hidden {
-  opacity: 0.0 !important;
+  opacity: 0 !important;
   pointer-events: none;
   transition: unset;
 }
 
-.timelineSelection:hover .timelineSelectionOverlayZoomButton,
-.timelineSelectionOverlayZoomButton:active {
-  opacity: 1.0;
-}
-
 .timelineSelectionOverlayZoomButton:hover {
   background-color: rgba(255, 255, 255, 0.9);
+}
+.timelineSelectionOverlayZoomButton:active,
+.timelineSelection:hover .timelineSelectionOverlayZoomButton {
+  opacity: 1;
 }
 
 .timelineSelectionOverlayZoomButton:active:hover {

--- a/src/components/timeline/StackGraph.css
+++ b/src/components/timeline/StackGraph.css
@@ -8,6 +8,6 @@
 
 .timelineStackGraphCanvas {
   display: block;
-  height: 25px;
   width: 100%;
+  height: 25px;
 }

--- a/src/components/timeline/Thread.css
+++ b/src/components/timeline/Thread.css
@@ -3,11 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 .timelineThread {
-  margin: 0;
-  padding: 0;
   display: flex;
   flex-flow: row nowrap;
+  padding: 0;
   border-top: 1px solid var(--grey-30);
+  margin: 0;
   box-shadow: 0 1px var(--grey-30);
 }
 
@@ -21,44 +21,44 @@
 }
 
 .timelineThreadLabel {
-  box-sizing: border-box;
-  width: 150px;
-  border-right: 1px solid var(--grey-30);
-  padding-left: 14px;
-  cursor: default;
   display: flex;
+  width: 150px;
+  box-sizing: border-box;
   flex-flow: row nowrap;
   align-items: center;
+  padding-left: 14px;
+  border-right: 1px solid var(--grey-30);
+  cursor: default;
 }
 
 .timelineThreadName {
-  font-weight: normal;
-  font: message-box;
-  font-size: 100%;
-  margin: 0;
-  white-space: nowrap;
   overflow: hidden;
+  margin: 0;
+  font: message-box; /* stylelint-disable-line */
+  font-size: 100%;
+  font-weight: normal;
   text-overflow: ellipsis;
   -webkit-user-select: none;
   -moz-user-select: none;
   user-select: none;
+  white-space: nowrap;
 }
 
 .timelineThreadDetails {
-  flex: 1;
   position: relative;
   z-index: 1;
   display: flex;
+  flex: 1;
   flex-flow: column nowrap;
 }
 
 .timelineThreadIntervalMarkerOverview {
-  list-style: none;
-  display: block;
-  margin: 0;
-  height: 6px;
   position: relative;
+  display: block;
   overflow: hidden;
+  height: 6px;
+  margin: 0;
+  list-style: none;
   opacity: 0.75;
 }
 

--- a/src/components/timeline/index.css
+++ b/src/components/timeline/index.css
@@ -2,17 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-
 .timelineOverflowEdgeIndicatorScrollbox {
-  margin: 0 0 0 -150px;
-  padding-left: 150px;
-  max-height: 250px;
   overflow: auto;
+  max-height: 250px;
+  padding-left: 150px;
+  margin: 0 0 0 -150px;
 }
 
 .timelineThreadList {
-  list-style: none;
-  margin: 0 0 0 -150px;
   padding: 0;
+  margin: 0 0 0 -150px;
   box-shadow: inset 0 1px var(--grey-30);
+  list-style: none;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -72,6 +72,17 @@
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@koa/cors/-/cors-2.2.1.tgz#c06a1c34d787e3cee79c0d4c20e8952d1b6d75c5"
 
+"@mrmlnc/readdir-enhanced@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
+  dependencies:
+    call-me-maybe "^1.0.1"
+    glob-to-regexp "^0.3.0"
+
+"@nodelib/fs.stat@^1.0.1":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.0.tgz#50c1e2260ac0ed9439a181de3725a0168d59c48a"
+
 "@sinonjs/formatio@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-2.0.0.tgz#84db7e9eb5531df18a8c5e0bfb6e449e55e654b2"
@@ -81,6 +92,13 @@
 "@types/node@*":
   version "9.4.7"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.4.7.tgz#57d81cd98719df2c9de118f2d5f3b1120dcd7275"
+
+JSONStream@^0.8.4:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-0.8.4.tgz#91657dfe6ff857483066132b4618b62e8f4887bd"
+  dependencies:
+    jsonparse "0.0.5"
+    through ">=2.2.7 <3"
 
 JSONStream@^1.3.1:
   version "1.3.1"
@@ -366,6 +384,10 @@ array-back@^2.0.0:
   dependencies:
     typical "^2.6.1"
 
+array-differ@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-1.0.0.tgz#eff52e3758249d33be402b8bb8e564bb2b5d4031"
+
 array-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
@@ -392,6 +414,10 @@ array-includes@^3.0.3:
   dependencies:
     define-properties "^1.1.2"
     es-abstract "^1.7.0"
+
+array-iterate@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/array-iterate/-/array-iterate-1.1.2.tgz#f66a57e84426f8097f4197fbb6c051b8e5cdf7d8"
 
 array-map@~0.0.0:
   version "0.0.0"
@@ -512,7 +538,7 @@ atob@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.0.3.tgz#19c7a760473774468f20b2d2d03372ad7d4cbf5d"
 
-autoprefixer@^6.3.1:
+autoprefixer@^6.0.0, autoprefixer@^6.3.1:
   version "6.7.7"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-6.7.7.tgz#1dbd1c835658e35ce3f9984099db00585c782014"
   dependencies:
@@ -521,6 +547,17 @@ autoprefixer@^6.3.1:
     normalize-range "^0.1.2"
     num2fraction "^1.2.2"
     postcss "^5.2.16"
+    postcss-value-parser "^3.2.3"
+
+autoprefixer@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.0.1.tgz#b5b74aba3fa60b4f1403729e46a6a1246f16818f"
+  dependencies:
+    browserslist "^4.0.1"
+    caniuse-lite "^1.0.30000865"
+    normalize-range "^0.1.2"
+    num2fraction "^1.2.2"
+    postcss "^7.0.1"
     postcss-value-parser "^3.2.3"
 
 aws-sign2@~0.6.0:
@@ -1229,7 +1266,11 @@ badge-up@2.3.0:
     dot "~1.0.2"
     svgo "~0.4.5"
 
-balanced-match@^0.4.2:
+bail@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.3.tgz#63cfb9ddbac829b02a3128cd53224be78e6c21a3"
+
+balanced-match@^0.4.0, balanced-match@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
 
@@ -1475,7 +1516,7 @@ browserify-zlib@^0.1.4:
   dependencies:
     pako "~0.2.0"
 
-browserslist@^1.3.6, browserslist@^1.5.2, browserslist@^1.7.6:
+browserslist@^1.1.1, browserslist@^1.1.3, browserslist@^1.3.6, browserslist@^1.5.2, browserslist@^1.7.6:
   version "1.7.7"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-1.7.7.tgz#0bd76704258be829b2398bb50e4b62d1a166b0b9"
   dependencies:
@@ -1488,6 +1529,14 @@ browserslist@^2.1.2:
   dependencies:
     caniuse-lite "^1.0.30000684"
     electron-to-chromium "^1.3.14"
+
+browserslist@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.0.1.tgz#61c05ce2a5843c7d96166408bc23d58b5416e818"
+  dependencies:
+    caniuse-lite "^1.0.30000865"
+    electron-to-chromium "^1.3.52"
+    node-releases "^1.0.0-alpha.10"
 
 bser@^2.0.0:
   version "2.0.0"
@@ -1583,6 +1632,10 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
+call-me-maybe@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.1.tgz#26d208ea89e37b5cbde60250a15f031c16a4d66b"
+
 caller-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
@@ -1611,11 +1664,19 @@ camelcase-keys@^2.0.0:
     camelcase "^2.0.0"
     map-obj "^1.0.0"
 
+camelcase-keys@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-4.2.0.tgz#a2aa5fb1af688758259c32c141426d78923b9b77"
+  dependencies:
+    camelcase "^4.1.0"
+    map-obj "^2.0.0"
+    quick-lru "^1.0.0"
+
 camelcase@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
 
-camelcase@^2.0.0:
+camelcase@^2.0.0, camelcase@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
 
@@ -1636,6 +1697,10 @@ caniuse-api@^1.5.2:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
+caniuse-db@^1.0.30000187:
+  version "1.0.30000871"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000871.tgz#f1995c1fe31892649a7605957a80c92518423d4d"
+
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
   version "1.0.30000696"
   resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000696.tgz#e71f5c61e1f96c7a3af4e791ac5db55e11737604"
@@ -1643,6 +1708,10 @@ caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
 caniuse-lite@^1.0.30000684:
   version "1.0.30000696"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000696.tgz#30f2695d2a01a0dfd779a26ab83f4d134b3da5cc"
+
+caniuse-lite@^1.0.30000865:
+  version "1.0.30000865"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000865.tgz#70026616e8afe6e1442f8bb4e1092987d81a2f25"
 
 capture-exit@^1.2.0:
   version "1.2.0"
@@ -1657,6 +1726,10 @@ capture-stack-trace@^1.0.0:
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
+
+ccount@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.3.tgz#f1cec43f332e2ea5a569fd46f9f5bde4e6102aff"
 
 center-align@^0.1.1:
   version "0.1.3"
@@ -1685,7 +1758,7 @@ chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
@@ -1710,6 +1783,22 @@ chalk@~0.5.1:
     has-ansi "^0.1.0"
     strip-ansi "^0.3.0"
     supports-color "^0.2.0"
+
+character-entities-html4@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/character-entities-html4/-/character-entities-html4-1.1.2.tgz#c44fdde3ce66b52e8d321d6c1bf46101f0150610"
+
+character-entities-legacy@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.2.tgz#7c6defb81648498222c9855309953d05f4d63a9c"
+
+character-entities@^1.0.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-1.2.2.tgz#58c8f371c0774ef0ba9b2aca5f00d8f100e6e363"
+
+character-reference-invalid@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz#21e421ad3d84055952dab4a43a04e73cd425d3ed"
 
 chardet@^0.4.0:
   version "0.4.2"
@@ -1864,7 +1953,7 @@ cliui@^2.1.0:
     right-align "^0.1.1"
     wordwrap "0.0.2"
 
-cliui@^3.2.0:
+cliui@^3.0.3, cliui@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-3.2.0.tgz#120601537a916d29940f934da3b48d585a39213d"
   dependencies:
@@ -1879,6 +1968,13 @@ cliui@^4.0.0:
     string-width "^2.1.1"
     strip-ansi "^4.0.0"
     wrap-ansi "^2.0.0"
+
+clone-regexp@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/clone-regexp/-/clone-regexp-1.0.1.tgz#051805cd33173375d82118fc0918606da39fd60f"
+  dependencies:
+    is-regexp "^1.0.0"
+    is-supported-regexp-flag "^1.0.0"
 
 clone@^1.0.2:
   version "1.0.2"
@@ -1913,6 +2009,10 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
+collapse-white-space@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.4.tgz#ce05cf49e54c3277ae573036a26851ba430a0091"
+
 collection-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
@@ -1931,6 +2031,10 @@ color-convert@^1.9.0:
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.1.tgz#c1261107aeb2f294ebffec9ed9ecad529a6097ed"
   dependencies:
     color-name "^1.1.1"
+
+color-diff@^0.1.3:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/color-diff/-/color-diff-0.1.7.tgz#6db78cd9482a8e459d40821eaf4b503283dcb8e2"
 
 color-name@^1.0.0:
   version "1.1.2"
@@ -1953,6 +2057,21 @@ color@^0.11.0:
     clone "^1.0.2"
     color-convert "^1.3.0"
     color-string "^0.3.0"
+
+colorguard@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/colorguard/-/colorguard-1.2.1.tgz#249647c9702481d9143384fc9813662311afde98"
+  dependencies:
+    chalk "^1.1.1"
+    color-diff "^0.1.3"
+    log-symbols "^1.0.2"
+    object-assign "^4.0.1"
+    pipetteur "^2.0.0"
+    plur "^2.0.0"
+    postcss "^5.0.4"
+    postcss-reporter "^1.2.1"
+    text-table "^0.2.0"
+    yargs "^1.2.6"
 
 colormin@^1.0.5:
   version "1.1.2"
@@ -2233,6 +2352,18 @@ corser@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/corser/-/corser-2.0.1.tgz#8eda252ecaab5840dcd975ceb90d9370c819ff87"
 
+cosmiconfig@^2.1.1:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-2.2.2.tgz#6173cebd56fac042c1f4390edf7af6c07c7cb892"
+  dependencies:
+    is-directory "^0.3.1"
+    js-yaml "^3.4.3"
+    minimist "^1.2.0"
+    object-assign "^4.1.0"
+    os-homedir "^1.0.1"
+    parse-json "^2.2.0"
+    require-from-string "^1.1.0"
+
 cosmiconfig@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-4.0.0.tgz#760391549580bbd2df1e562bc177b13c290972dc"
@@ -2241,6 +2372,14 @@ cosmiconfig@^4.0.0:
     js-yaml "^3.9.0"
     parse-json "^4.0.0"
     require-from-string "^2.0.1"
+
+cosmiconfig@^5.0.0:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.0.5.tgz#a809e3c2306891ce17ab70359dc8bdf661fe2cd0"
+  dependencies:
+    is-directory "^0.3.1"
+    js-yaml "^3.9.0"
+    parse-json "^4.0.0"
 
 cp-file@^4.1.1:
   version "4.2.0"
@@ -2322,6 +2461,10 @@ crypto-random-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
 
+css-color-names@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.3.tgz#de0cef16f4d8aa8222a320d5b6d7e9bbada7b9f6"
+
 css-color-names@0.0.4, css-color-names@~0.0.3:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
@@ -2345,6 +2488,15 @@ css-loader@^0.28.9:
     postcss-value-parser "^3.3.0"
     source-list-map "^2.0.0"
 
+css-rule-stream@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/css-rule-stream/-/css-rule-stream-1.1.0.tgz#3786e7198983d965a26e31957e09078cbb7705a2"
+  dependencies:
+    css-tokenize "^1.0.1"
+    duplexer2 "0.0.2"
+    ldjson-stream "^1.2.1"
+    through2 "^0.6.3"
+
 css-select@^1.1.0, css-select@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
@@ -2361,6 +2513,13 @@ css-selector-tokenizer@^0.7.0:
     cssesc "^0.1.0"
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
+
+css-tokenize@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/css-tokenize/-/css-tokenize-1.0.1.tgz#4625cb1eda21c143858b7f81d6803c1d26fc14be"
+  dependencies:
+    inherits "^2.0.1"
+    readable-stream "^1.0.33"
 
 css-what@2.1:
   version "2.1.0"
@@ -2468,13 +2627,13 @@ debug@*, debug@2.6.8, debug@^2.6.6:
   dependencies:
     ms "2.0.0"
 
-debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.3, debug@^2.6.8, debug@^2.6.9:
+debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.1, debug@^3.1.0:
+debug@^3.0.0, debug@^3.0.1, debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
@@ -2490,7 +2649,14 @@ debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
 
-decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
+decamelize-keys@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.0.tgz#d171a87933252807eb3cb61dc1c1445d078df2d9"
+  dependencies:
+    decamelize "^1.1.0"
+    map-obj "^1.0.0"
+
+decamelize@^1.0.0, decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
@@ -2753,6 +2919,23 @@ doctrine@^2.0.2, doctrine@^2.1.0:
   dependencies:
     esutils "^2.0.2"
 
+doiuse@^2.4.1:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/doiuse/-/doiuse-2.6.0.tgz#1892d10b61a9a356addbf2b614933e81f8bb3834"
+  dependencies:
+    browserslist "^1.1.1"
+    caniuse-db "^1.0.30000187"
+    css-rule-stream "^1.1.0"
+    duplexer2 "0.0.2"
+    jsonfilter "^1.1.2"
+    ldjson-stream "^1.2.1"
+    lodash "^4.0.0"
+    multimatch "^2.0.0"
+    postcss "^5.0.8"
+    source-map "^0.4.2"
+    through2 "^0.6.3"
+    yargs "^3.5.4"
+
 dom-converter@~0.1:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.1.4.tgz#a45ef5727b890c9bffe6d7c876e7b19cb0e17f3b"
@@ -2820,7 +3003,7 @@ domutils@^1.5.1:
     dom-serializer "0"
     domelementtype "1"
 
-dot-prop@^4.1.0:
+dot-prop@^4.1.0, dot-prop@^4.1.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.0.tgz#1f19e0c2e1aa0e32797c49799f2837ac6af69c57"
   dependencies:
@@ -2829,6 +3012,12 @@ dot-prop@^4.1.0:
 dot@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/dot/-/dot-1.0.3.tgz#f8750bfb6b03c7664eb0e6cb1eb4c66419af9427"
+
+duplexer2@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.0.2.tgz#c614dcf67e2fb14995a91711e5a617e8a60a31db"
+  dependencies:
+    readable-stream "~1.1.9"
 
 duplexer2@~0.1.4:
   version "0.1.4"
@@ -2883,6 +3072,10 @@ ejs@^2.3.4:
 electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.14:
   version "1.3.15"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.15.tgz#08397934891cbcfaebbd18b82a95b5a481138369"
+
+electron-to-chromium@^1.3.52:
+  version "1.3.52"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.52.tgz#d2d9f1270ba4a3b967b831c40ef71fb4d9ab5ce0"
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -3362,6 +3555,12 @@ execa@^0.8.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+execall@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/execall/-/execall-1.0.0.tgz#73d0904e395b3cab0658b08d09ec25307f29bb73"
+  dependencies:
+    clone-regexp "^1.0.0"
+
 exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
@@ -3459,6 +3658,10 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
+extend@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+
 extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
@@ -3521,6 +3724,17 @@ fast-deep-equal@^1.0.0:
 fast-diff@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.1.1.tgz#0aea0e4e605b6a2189f0e936d4b7fbaf1b7cfd9b"
+
+fast-glob@^2.0.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-2.2.2.tgz#71723338ac9b4e0e2fff1d6748a2a13d5ed352bf"
+  dependencies:
+    "@mrmlnc/readdir-enhanced" "^2.2.1"
+    "@nodelib/fs.stat" "^1.0.1"
+    glob-parent "^3.1.0"
+    is-glob "^4.0.0"
+    merge2 "^1.2.1"
+    micromatch "^3.1.10"
 
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
@@ -3913,6 +4127,10 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
 
+gather-stream@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gather-stream/-/gather-stream-1.0.0.tgz#b33994af457a8115700d410f317733cbe7a0904b"
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -3938,9 +4156,13 @@ get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
 
-get-stdin@^5.0.1:
+get-stdin@^5.0.0, get-stdin@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
+
+get-stdin@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
 
 get-stream@^3.0.0:
   version "3.0.0"
@@ -3981,6 +4203,10 @@ glob-parent@^3.1.0:
   dependencies:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
+
+glob-to-regexp@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
 
 glob@7.1.1:
   version "7.1.1"
@@ -4045,7 +4271,7 @@ globby@^5.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-globby@^6.1.0:
+globby@^6.0.0, globby@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c"
   dependencies:
@@ -4065,6 +4291,28 @@ globby@^7.1.1:
     ignore "^3.3.5"
     pify "^3.0.0"
     slash "^1.0.0"
+
+globby@^8.0.0:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-8.0.1.tgz#b5ad48b8aa80b35b814fc1281ecc851f1d2b5b50"
+  dependencies:
+    array-union "^1.0.1"
+    dir-glob "^2.0.0"
+    fast-glob "^2.0.2"
+    glob "^7.1.2"
+    ignore "^3.3.5"
+    pify "^3.0.0"
+    slash "^1.0.0"
+
+globjoin@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/globjoin/-/globjoin-0.1.4.tgz#2f4494ac8919e3767c5cbb691e9f463324285d43"
+
+gonzales-pe@4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/gonzales-pe/-/gonzales-pe-4.2.3.tgz#41091703625433285e0aee3aa47829fc1fbeb6f2"
+  dependencies:
+    minimist "1.1.x"
 
 good-listener@^1.2.2:
   version "1.2.2"
@@ -4329,6 +4577,10 @@ html-minifier@^3.2.3:
     relateurl "0.2.x"
     uglify-js "3.0.x"
 
+html-tags@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-2.0.0.tgz#10b30a386085f43cede353cc8fa7cb0deeea668b"
+
 html-webpack-plugin@^2.30.1:
   version "2.30.1"
   resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-2.30.1.tgz#7f9c421b7ea91ec460f56527d78df484ee7537d5"
@@ -4340,7 +4592,7 @@ html-webpack-plugin@^2.30.1:
     pretty-error "^2.0.2"
     toposort "^1.0.0"
 
-htmlparser2@^3.9.1:
+htmlparser2@^3.9.1, htmlparser2@^3.9.2:
   version "3.9.2"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
   dependencies:
@@ -4483,9 +4735,17 @@ ignore-walk@^3.0.1:
   dependencies:
     minimatch "^3.0.4"
 
+ignore@^3.2.0:
+  version "3.3.10"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
+
 ignore@^3.3.3, ignore@^3.3.5:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
+
+ignore@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.2.tgz#0a8dd228947ec78c2d7f736b1642a9f7317c1905"
 
 immediate@~3.0.5:
   version "3.0.6"
@@ -4494,6 +4754,10 @@ immediate@~3.0.5:
 import-lazy@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
+
+import-lazy@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-3.1.0.tgz#891279202c8a2280fdbd6674dbd8da1a1dfc67cc"
 
 import-local@^1.0.0:
   version "1.0.0"
@@ -4622,6 +4886,10 @@ ipaddr.js@1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.5.2.tgz#d4b505bde9946987ccf0fc58d9010ff9607e3fa0"
 
+irregular-plurals@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/irregular-plurals/-/irregular-plurals-1.4.0.tgz#2ca9b033651111855412f16be5d77c62a458a766"
+
 is-absolute-url@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-absolute-url/-/is-absolute-url-2.1.0.tgz#50530dfb84fcc9aa7dbe7852e83a37b93b9f2aa6"
@@ -4638,6 +4906,21 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
+is-alphabetical@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.2.tgz#1fa6e49213cb7885b75d15862fb3f3d96c884f41"
+
+is-alphanumeric@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz#4a9cef71daf4c001c1d81d63d140cf53fd6889f4"
+
+is-alphanumerical@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz#1138e9ae5040158dc6ff76b820acd6b7a181fd40"
+  dependencies:
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -4652,7 +4935,7 @@ is-boolean-object@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.0.0.tgz#98f8b28030684219a95f375cfbd88ce3405dff93"
 
-is-buffer@^1.1.5, is-buffer@~1.1.1:
+is-buffer@^1.1.4, is-buffer@^1.1.5, is-buffer@~1.1.1:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
 
@@ -4687,6 +4970,10 @@ is-data-descriptor@^1.0.0:
 is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+
+is-decimal@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.2.tgz#894662d6a8709d307f3a276ca4339c8fa5dff0ff"
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -4777,6 +5064,10 @@ is-glob@^4.0.0:
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.0.tgz#9521c76845cc2610a85203ddf080a958c2ffabc0"
   dependencies:
     is-extglob "^2.1.1"
+
+is-hexadecimal@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz#b6e710d7d07bb66b98cb8cece5c9b4921deeb835"
 
 is-installed-globally@^0.1.0:
   version "0.1.0"
@@ -4907,6 +5198,10 @@ is-subset@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-subset/-/is-subset-0.1.1.tgz#8a59117d932de1de00f245fcdd39ce43f1e939a6"
 
+is-supported-regexp-flag@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.1.tgz#21ee16518d2c1dd3edd3e9a0d57e50207ac364ca"
+
 is-svg@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-svg/-/is-svg-2.1.0.tgz#cf61090da0d9efbcab8722deba6f032208dbb0e9"
@@ -4925,6 +5220,10 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
+is-whitespace-character@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.2.tgz#ede53b4c6f6fb3874533751ec9280d01928d03ed"
+
 is-windows@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-0.2.0.tgz#de1aa6d63ea29dd248737b69f1ff8b8002d2108c"
@@ -4932,6 +5231,10 @@ is-windows@^0.2.0:
 is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
+
+is-word-character@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-word-character/-/is-word-character-1.0.2.tgz#46a5dac3f2a1840898b91e576cd40d493f3ae553"
 
 is-wsl@^1.1.0:
   version "1.1.0"
@@ -5339,6 +5642,13 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
+js-yaml@^3.4.3:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 js-yaml@^3.7.0:
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.11.0.tgz#597c1a8bd57152f26d622ce4117851a51f5ebaef"
@@ -5466,9 +5776,22 @@ jsonfile@^4.0.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonfilter@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/jsonfilter/-/jsonfilter-1.1.2.tgz#21ef7cedc75193813c75932e96a98be205ba5a11"
+  dependencies:
+    JSONStream "^0.8.4"
+    minimist "^1.1.0"
+    stream-combiner "^0.2.1"
+    through2 "^0.6.3"
+
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
+
+jsonparse@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-0.0.5.tgz#330542ad3f0a654665b778f3eb2d9a9fa507ac64"
 
 jsonparse@^1.2.0:
   version "1.3.1"
@@ -5530,6 +5853,14 @@ kind-of@^5.0.0, kind-of@^5.0.2:
 kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
+
+known-css-properties@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.2.0.tgz#899c94be368e55b42d7db8d5be7d73a4a4a41454"
+
+known-css-properties@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.6.1.tgz#31b5123ad03d8d1a3f36bd4155459c981173478b"
 
 koa-bodyparser@^4.2.0:
   version "4.2.0"
@@ -5686,6 +6017,13 @@ lcid@^1.0.0:
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
   dependencies:
     invert-kv "^1.0.0"
+
+ldjson-stream@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ldjson-stream/-/ldjson-stream-1.2.1.tgz#91beceda5ac4ed2b17e649fb777e7abfa0189c2b"
+  dependencies:
+    split2 "^0.2.1"
+    through2 "^0.6.1"
 
 left-pad@^1.2.0:
   version "1.3.0"
@@ -5952,7 +6290,7 @@ lodash@3.x:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.10, lodash@^4.17.4:
+lodash@^4.0.0, lodash@^4.1.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.10, lodash@^4.17.4:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -5990,6 +6328,10 @@ loglevel@^1.4.1:
 lolex@^2.2.0, lolex@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.3.2.tgz#85f9450425103bf9e7a60668ea25dc43274ca807"
+
+longest-streak@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.2.tgz#2421b6ba939a443bb9ffebf596585a50b4c38e2e"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -6185,6 +6527,10 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
+map-obj@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-2.0.0.tgz#a65cd29087a92598b8791257a523e021222ac1f9"
+
 map-stream@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
@@ -6194,6 +6540,14 @@ map-visit@^1.0.0:
   resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
   dependencies:
     object-visit "^1.0.0"
+
+markdown-escapes@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.2.tgz#e639cbde7b99c841c0bacc8a07982873b46d2122"
+
+markdown-table@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.2.tgz#c78db948fa879903a41bce522e3b96f801c63786"
 
 marked@^0.3.12:
   version "0.3.19"
@@ -6207,6 +6561,10 @@ math-random@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.1.tgz#8b3aac588b8a66e4975e3cdea67f7bb329601fac"
 
+mathml-tag-names@^2.0.0, mathml-tag-names@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mathml-tag-names/-/mathml-tag-names-2.1.0.tgz#490b70e062ee24636536e3d9481e333733d00f2c"
+
 md5@^2.1.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/md5/-/md5-2.2.1.tgz#53ab38d5fe3c8891ba465329ea23fac0540126f9"
@@ -6214,6 +6572,13 @@ md5@^2.1.0:
     charenc "~0.0.1"
     crypt "~0.0.1"
     is-buffer "~1.1.1"
+
+mdast-util-compact@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-compact/-/mdast-util-compact-1.0.1.tgz#cdb5f84e2b6a2d3114df33bd05d9cb32e3c4083a"
+  dependencies:
+    unist-util-modify-children "^1.0.0"
+    unist-util-visit "^1.1.0"
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -6266,6 +6631,20 @@ meow@^3.3.0:
     redent "^1.0.0"
     trim-newlines "^1.0.0"
 
+meow@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/meow/-/meow-5.0.0.tgz#dfc73d63a9afc714a5e371760eb5c88b91078aa4"
+  dependencies:
+    camelcase-keys "^4.0.0"
+    decamelize-keys "^1.0.0"
+    loud-rejection "^1.0.0"
+    minimist-options "^3.0.1"
+    normalize-package-data "^2.3.4"
+    read-pkg-up "^3.0.0"
+    redent "^2.0.0"
+    trim-newlines "^2.0.0"
+    yargs-parser "^10.0.0"
+
 merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
@@ -6275,6 +6654,10 @@ merge-stream@^1.0.1:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-1.0.1.tgz#4041202d508a342ba00174008df0c251b8c135e1"
   dependencies:
     readable-stream "^2.0.1"
+
+merge2@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.2.2.tgz#03212e3da8d86c4d8523cebd6318193414f94e34"
 
 merge@^1.1.3:
   version "1.2.0"
@@ -6302,6 +6685,24 @@ micromatch@^2.1.5, micromatch@^2.3.11:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
+micromatch@^3.1.10, micromatch@^3.1.8:
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
+  dependencies:
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    braces "^2.3.1"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    extglob "^2.0.4"
+    fragment-cache "^0.2.1"
+    kind-of "^6.0.2"
+    nanomatch "^1.2.9"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.2"
+
 micromatch@^3.1.4:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.5.tgz#d05e168c206472dfbca985bfef4f57797b4cd4ba"
@@ -6319,24 +6720,6 @@ micromatch@^3.1.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
-
-micromatch@^3.1.8:
-  version "3.1.10"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
-  dependencies:
-    arr-diff "^4.0.0"
-    array-unique "^0.3.2"
-    braces "^2.3.1"
-    define-property "^2.0.2"
-    extend-shallow "^3.0.2"
-    extglob "^2.0.4"
-    fragment-cache "^0.2.1"
-    kind-of "^6.0.2"
-    nanomatch "^1.2.9"
-    object.pick "^1.3.0"
-    regex-not "^1.0.0"
-    snapdragon "^0.8.1"
-    to-regex "^3.0.2"
 
 miller-rabin@^4.0.0:
   version "4.0.0"
@@ -6405,9 +6788,20 @@ minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch
   dependencies:
     brace-expansion "^1.1.7"
 
+minimist-options@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-3.0.2.tgz#fba4c8191339e13ecf4d61beb03f070103f3d954"
+  dependencies:
+    arrify "^1.0.1"
+    is-plain-obj "^1.1.0"
+
 minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+
+minimist@1.1.x:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.1.3.tgz#3bedfd91a92d39016fcfaa1c681e8faa1a1efda8"
 
 minimist@1.2.0, minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
@@ -6509,6 +6903,15 @@ multicast-dns@^6.0.1:
   dependencies:
     dns-packet "^1.0.1"
     thunky "^0.1.0"
+
+multimatch@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/multimatch/-/multimatch-2.1.0.tgz#9c7906a22fb4c02919e2f5f75161b4cdbd4b2a2b"
+  dependencies:
+    array-differ "^1.0.0"
+    array-union "^1.0.1"
+    arrify "^1.0.0"
+    minimatch "^3.0.0"
 
 mute-stream@0.0.7:
   version "0.0.7"
@@ -6704,6 +7107,12 @@ node-pre-gyp@^0.6.36:
     tar "^2.2.1"
     tar-pack "^3.4.0"
 
+node-releases@^1.0.0-alpha.10:
+  version "1.0.0-alpha.10"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.0.0-alpha.10.tgz#61c8d5f9b5b2e05d84eba941d05b6f5202f68a2a"
+  dependencies:
+    semver "^5.3.0"
+
 nomnom@~1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.6.2.tgz#84a66a260174408fc5b77a18f888eccc44fb6971"
@@ -6746,6 +7155,10 @@ normalize-path@^2.0.0, normalize-path@^2.0.1, normalize-path@^2.1.1:
 normalize-range@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
+
+normalize-selector@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/normalize-selector/-/normalize-selector-0.2.0.tgz#d0b145eb691189c63a78d201dc4fdb1293ef0c03"
 
 normalize-url@^1.4.0:
   version "1.9.1"
@@ -6938,6 +7351,10 @@ once@^1.3.0, once@^1.3.1, once@^1.3.3, once@^1.4.0:
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
     wrappy "1"
+
+onecolor@^3.0.4:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/onecolor/-/onecolor-3.0.5.tgz#36eff32201379efdf1180fb445e51a8e2425f9f6"
 
 onetime@^1.0.0:
   version "1.1.0"
@@ -7146,6 +7563,17 @@ parse-asn1@^5.0.0:
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
 
+parse-entities@^1.0.2, parse-entities@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.1.2.tgz#9eaf719b29dc3bd62246b4332009072e01527777"
+  dependencies:
+    character-entities "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    character-reference-invalid "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-hexadecimal "^1.0.0"
+
 parse-glob@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/parse-glob/-/parse-glob-3.0.4.tgz#b2c376cfb11f35513badd173ef0bb6e3a388391c"
@@ -7304,6 +7732,13 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
+pipetteur@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/pipetteur/-/pipetteur-2.0.3.tgz#1955760959e8d1a11cb2a50ec83eec470633e49f"
+  dependencies:
+    onecolor "^3.0.4"
+    synesthesia "^1.0.1"
+
 pkg-dir@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4"
@@ -7315,6 +7750,12 @@ pkg-dir@^2.0.0:
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
   dependencies:
     find-up "^2.1.0"
+
+plur@^2.0.0, plur@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/plur/-/plur-2.1.2.tgz#7482452c1a0f508e3e344eaec312c91c29dc655a"
+  dependencies:
+    irregular-plurals "^1.0.0"
 
 pluralize@^7.0.0:
   version "7.0.0"
@@ -7396,6 +7837,35 @@ postcss-filter-plugins@^2.0.0:
   dependencies:
     postcss "^5.0.4"
     uniqid "^4.0.0"
+
+postcss-html@^0.31.0:
+  version "0.31.0"
+  resolved "https://registry.yarnpkg.com/postcss-html/-/postcss-html-0.31.0.tgz#ea6ae2e95df60a03032e9ab5aba72143d8ca0325"
+  dependencies:
+    htmlparser2 "^3.9.2"
+
+postcss-less@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/postcss-less/-/postcss-less-0.14.0.tgz#c631b089c6cce422b9a10f3a958d2bedd3819324"
+  dependencies:
+    postcss "^5.0.21"
+
+postcss-less@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-less/-/postcss-less-2.0.0.tgz#5d190b8e057ca446d60fe2e2587ad791c9029fb8"
+  dependencies:
+    postcss "^5.2.16"
+
+postcss-markdown@^0.31.0:
+  version "0.31.0"
+  resolved "https://registry.yarnpkg.com/postcss-markdown/-/postcss-markdown-0.31.0.tgz#e4c699ad34b14a29ad5d47132bb1b3100b60ef75"
+  dependencies:
+    remark "^9.0.0"
+    unist-util-find-all-after "^1.0.2"
+
+postcss-media-query-parser@^0.2.0, postcss-media-query-parser@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz#27b39c6f4d94f81b1a73b8f76351c609e5cef244"
 
 postcss-merge-idents@^2.1.5:
   version "2.1.7"
@@ -7528,13 +7998,88 @@ postcss-reduce-transforms@^1.0.3:
     postcss "^5.0.8"
     postcss-value-parser "^3.0.1"
 
-postcss-selector-parser@^2.0.0, postcss-selector-parser@^2.2.2:
+postcss-reporter@^1.2.1, postcss-reporter@^1.3.3:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/postcss-reporter/-/postcss-reporter-1.4.1.tgz#c136f0a5b161915f379dd3765c61075f7e7b9af2"
+  dependencies:
+    chalk "^1.0.0"
+    lodash "^4.1.0"
+    log-symbols "^1.0.2"
+    postcss "^5.0.0"
+
+postcss-reporter@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-reporter/-/postcss-reporter-3.0.0.tgz#09ea0f37a444c5693878606e09b018ebeff7cf8f"
+  dependencies:
+    chalk "^1.0.0"
+    lodash "^4.1.0"
+    log-symbols "^1.0.2"
+    postcss "^5.0.0"
+
+postcss-reporter@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-reporter/-/postcss-reporter-5.0.0.tgz#a14177fd1342829d291653f2786efd67110332c3"
+  dependencies:
+    chalk "^2.0.1"
+    lodash "^4.17.4"
+    log-symbols "^2.0.0"
+    postcss "^6.0.8"
+
+postcss-resolve-nested-selector@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz#29ccbc7c37dedfac304e9fff0bf1596b3f6a0e4e"
+
+postcss-safe-parser@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-safe-parser/-/postcss-safe-parser-4.0.1.tgz#8756d9e4c36fdce2c72b091bbc8ca176ab1fcdea"
+  dependencies:
+    postcss "^7.0.0"
+
+postcss-sass@^0.3.0:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/postcss-sass/-/postcss-sass-0.3.2.tgz#17f3074cecb28128b156f1a4407c6ad075d7e00c"
+  dependencies:
+    gonzales-pe "4.2.3"
+    postcss "6.0.22"
+
+postcss-scss@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-0.4.1.tgz#ad771b81f0f72f5f4845d08aa60f93557653d54c"
+  dependencies:
+    postcss "^5.2.13"
+
+postcss-scss@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-2.0.0.tgz#248b0a28af77ea7b32b1011aba0f738bda27dea1"
+  dependencies:
+    postcss "^7.0.0"
+
+postcss-selector-parser@^2.0.0, postcss-selector-parser@^2.1.1, postcss-selector-parser@^2.2.2:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz#f9437788606c3c9acee16ffe8d8b16297f27bb90"
   dependencies:
     flatten "^1.0.2"
     indexes-of "^1.0.1"
     uniq "^1.0.1"
+
+postcss-selector-parser@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz#4f875f4afb0c96573d5cf4d74011aee250a7e865"
+  dependencies:
+    dot-prop "^4.1.1"
+    indexes-of "^1.0.1"
+    uniq "^1.0.1"
+
+postcss-sorting@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-sorting/-/postcss-sorting-3.1.0.tgz#af7c90ee73ad12569a57664eaf06735c2e25bec0"
+  dependencies:
+    lodash "^4.17.4"
+    postcss "^6.0.13"
+
+postcss-styled@^0.31.0:
+  version "0.31.0"
+  resolved "https://registry.yarnpkg.com/postcss-styled/-/postcss-styled-0.31.0.tgz#ab532a2b3c469dfcca306a7623c4d4a98bb077d5"
 
 postcss-svgo@^2.1.1:
   version "2.1.6"
@@ -7544,6 +8089,10 @@ postcss-svgo@^2.1.1:
     postcss "^5.0.14"
     postcss-value-parser "^3.2.3"
     svgo "^0.7.0"
+
+postcss-syntax@^0.31.0:
+  version "0.31.0"
+  resolved "https://registry.yarnpkg.com/postcss-syntax/-/postcss-syntax-0.31.0.tgz#13d955c705d339595d10a19efa4a1bee82dfb78f"
 
 postcss-unique-selectors@^2.0.2:
   version "2.0.2"
@@ -7565,6 +8114,23 @@ postcss-zindex@^2.0.1:
     postcss "^5.0.4"
     uniqs "^2.0.0"
 
+postcss@6.0.22:
+  version "6.0.22"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.22.tgz#e23b78314905c3b90cbd61702121e7a78848f2a3"
+  dependencies:
+    chalk "^2.4.1"
+    source-map "^0.6.1"
+    supports-color "^5.4.0"
+
+postcss@^5.0.0, postcss@^5.0.18, postcss@^5.0.20, postcss@^5.0.21, postcss@^5.2.13, postcss@^5.2.4:
+  version "5.2.18"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.18.tgz#badfa1497d46244f6390f58b319830d9107853c5"
+  dependencies:
+    chalk "^1.1.3"
+    js-base64 "^2.1.9"
+    source-map "^0.5.6"
+    supports-color "^3.2.3"
+
 postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0.14, postcss@^5.0.16, postcss@^5.0.2, postcss@^5.0.4, postcss@^5.0.5, postcss@^5.0.6, postcss@^5.0.8, postcss@^5.2.16:
   version "5.2.17"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.17.tgz#cf4f597b864d65c8a492b2eabe9d706c879c388b"
@@ -7581,6 +8147,22 @@ postcss@^6.0.1:
     chalk "^1.1.3"
     source-map "^0.5.6"
     supports-color "^4.0.0"
+
+postcss@^6.0.13, postcss@^6.0.14, postcss@^6.0.8:
+  version "6.0.23"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"
+  dependencies:
+    chalk "^2.4.1"
+    source-map "^0.6.1"
+    supports-color "^5.4.0"
+
+postcss@^7.0.0, postcss@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.1.tgz#db20ca4fc90aa56809674eea75864148c66b67fa"
+  dependencies:
+    chalk "^2.4.1"
+    source-map "^0.6.1"
+    supports-color "^5.4.0"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -7795,6 +8377,10 @@ querystringify@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-1.0.0.tgz#6286242112c5b712fa654e526652bf6a13ff05cb"
 
+quick-lru@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
+
 raf@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.0.tgz#a28876881b4bc2ca9117d4138163ddb80f781575"
@@ -7947,6 +8533,12 @@ react@^16.2.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
+read-file-stdin@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/read-file-stdin/-/read-file-stdin-0.2.1.tgz#25eccff3a153b6809afacb23ee15387db9e0ee61"
+  dependencies:
+    gather-stream "^1.0.0"
+
 read-installed@~4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/read-installed/-/read-installed-4.0.3.tgz#ff9b8b67f187d1e4c29b9feb31f6b223acd19067"
@@ -7984,6 +8576,13 @@ read-pkg-up@^2.0.0:
     find-up "^2.0.0"
     read-pkg "^2.0.0"
 
+read-pkg-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-3.0.0.tgz#3ed496685dba0f8fe118d0691dc51f4a1ff96f07"
+  dependencies:
+    find-up "^2.0.0"
+    read-pkg "^3.0.0"
+
 read-pkg@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
@@ -8020,7 +8619,7 @@ read-pkg@^3.0.0:
     string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
 
-readable-stream@1.0:
+readable-stream@1.0, "readable-stream@>=1.0.33-1 <1.1.0-0":
   version "1.0.34"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
   dependencies:
@@ -8040,6 +8639,15 @@ readable-stream@2, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stre
     safe-buffer "~5.1.1"
     string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
+
+readable-stream@^1.0.33, readable-stream@~1.1.9:
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
 
 readable-stream@^2.0.1, readable-stream@^2.0.6, readable-stream@^2.1.4:
   version "2.3.6"
@@ -8127,6 +8735,13 @@ redent@^1.0.0:
   dependencies:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
+
+redent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-2.0.0.tgz#c1b2007b42d57eb1389079b3c8333639d5e1ccaa"
+  dependencies:
+    indent-string "^3.0.0"
+    strip-indent "^2.0.0"
 
 reduce-css-calc@^1.2.6:
   version "1.3.0"
@@ -8247,6 +8862,53 @@ relateurl@0.2.x:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
 
+remark-parse@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-5.0.0.tgz#4c077f9e499044d1d5c13f80d7a98cf7b9285d95"
+  dependencies:
+    collapse-white-space "^1.0.2"
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    is-word-character "^1.0.0"
+    markdown-escapes "^1.0.0"
+    parse-entities "^1.1.0"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    trim "0.0.1"
+    trim-trailing-lines "^1.0.0"
+    unherit "^1.0.4"
+    unist-util-remove-position "^1.0.0"
+    vfile-location "^2.0.0"
+    xtend "^4.0.1"
+
+remark-stringify@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-5.0.0.tgz#336d3a4d4a6a3390d933eeba62e8de4bd280afba"
+  dependencies:
+    ccount "^1.0.0"
+    is-alphanumeric "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    longest-streak "^2.0.1"
+    markdown-escapes "^1.0.0"
+    markdown-table "^1.1.0"
+    mdast-util-compact "^1.0.0"
+    parse-entities "^1.0.2"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    stringify-entities "^1.0.1"
+    unherit "^1.0.4"
+    xtend "^4.0.1"
+
+remark@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/remark/-/remark-9.0.0.tgz#c5cfa8ec535c73a67c4b0f12bfdbd3a67d8b2f60"
+  dependencies:
+    remark-parse "^5.0.0"
+    remark-stringify "^5.0.0"
+    unified "^6.0.0"
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -8265,7 +8927,7 @@ repeat-element@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.2.tgz#ef089a178d1483baae4d93eb98b4f9e4e11d990a"
 
-repeat-string@^1.5.2, repeat-string@^1.6.1:
+repeat-string@^1.5.2, repeat-string@^1.5.4, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
 
@@ -8274,6 +8936,10 @@ repeating@^2.0.0:
   resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
   dependencies:
     is-finite "^1.0.0"
+
+replace-ext@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
 
 req-then@^0.6.4:
   version "0.6.4"
@@ -8355,6 +9021,10 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
 
+require-from-string@^1.1.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-1.2.1.tgz#529c9ccef27380adfec9a2f965b649bbee636418"
+
 require-from-string@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.1.tgz#c545233e9d7da6616e9d59adfb39fc9f588676ff"
@@ -8398,6 +9068,10 @@ resolve-from@^1.0.0:
 resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
+
+resolve-from@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
 
 resolve-path@^1.3.3:
   version "1.3.3"
@@ -8882,7 +9556,7 @@ source-map@0.5.x, source-map@~0.5.3:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
-source-map@^0.4.4:
+source-map@^0.4.2, source-map@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
   dependencies:
@@ -8941,11 +9615,25 @@ spdy@^3.4.1:
     select-hose "^2.0.0"
     spdy-transport "^2.0.18"
 
+specificity@^0.3.0:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/specificity/-/specificity-0.3.2.tgz#99e6511eceef0f8d9b57924937aac2cb13d13c42"
+
+specificity@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/specificity/-/specificity-0.4.0.tgz#301b1ab5455987c37d6d94f8c956ef9d9fb48c1d"
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
   dependencies:
     extend-shallow "^3.0.0"
+
+split2@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/split2/-/split2-0.2.1.tgz#02ddac9adc03ec0bb78c1282ec079ca6e85ae900"
+  dependencies:
+    through2 "~0.6.1"
 
 split@0.3:
   version "0.3.3"
@@ -8985,6 +9673,10 @@ staged-git-files@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/staged-git-files/-/staged-git-files-0.0.4.tgz#d797e1b551ca7a639dec0237dc6eb4bb9be17d35"
 
+state-toggle@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.1.tgz#c3cb0974f40a6a0f8e905b96789eb41afa1cde3a"
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -9010,6 +9702,13 @@ stream-browserify@^2.0.1:
   dependencies:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
+
+stream-combiner@^0.2.1:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.2.2.tgz#aec8cbac177b56b6f4fa479ced8c1912cee52858"
+  dependencies:
+    duplexer "~0.1.1"
+    through "~2.3.4"
 
 stream-combiner@~0.0.4:
   version "0.0.4"
@@ -9125,6 +9824,15 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
+stringify-entities@^1.0.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/stringify-entities/-/stringify-entities-1.3.2.tgz#a98417e5471fd227b3e45d3db1861c11caf668f7"
+  dependencies:
+    character-entities-html4 "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-hexadecimal "^1.0.0"
+
 stringify-object@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.2.0.tgz#94370a135e41bc048358813bf99481f1315c6aa6"
@@ -9190,6 +9898,168 @@ style-loader@^0.20.1:
     loader-utils "^1.1.0"
     schema-utils "^0.4.3"
 
+style-search@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
+
+stylehacks@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/stylehacks/-/stylehacks-2.3.2.tgz#64c83e0438a68c9edf449e8c552a7d9ab6009b0b"
+  dependencies:
+    browserslist "^1.1.3"
+    chalk "^1.1.1"
+    log-symbols "^1.0.2"
+    minimist "^1.2.0"
+    plur "^2.1.2"
+    postcss "^5.0.18"
+    postcss-reporter "^1.3.3"
+    postcss-selector-parser "^2.0.0"
+    read-file-stdin "^0.2.1"
+    text-table "^0.2.0"
+    write-file-stdout "0.0.2"
+
+stylelint-config-idiomatic-order@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-idiomatic-order/-/stylelint-config-idiomatic-order-5.0.0.tgz#512b2d603a83f159ea3be8639261f63cd82caee6"
+  dependencies:
+    stylelint "^7.0.3"
+    stylelint-config-standard "^16.0.0"
+    stylelint-order "^0.5.0"
+
+stylelint-config-prettier@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-prettier/-/stylelint-config-prettier-3.3.0.tgz#cc22a4b5310c1919cee77131d6e220c60a62a480"
+  dependencies:
+    stylelint "^9.1.1"
+
+stylelint-config-recommended@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-2.1.0.tgz#f526d5c771c6811186d9eaedbed02195fee30858"
+
+stylelint-config-standard@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-standard/-/stylelint-config-standard-16.0.0.tgz#bb7387bff1d7dd7186a52b3ebf885b2405d691bf"
+
+stylelint-config-standard@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-standard/-/stylelint-config-standard-18.2.0.tgz#6283149aba7f64f18731aef8f0abfb35cf619e06"
+  dependencies:
+    stylelint-config-recommended "^2.1.0"
+
+stylelint-order@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/stylelint-order/-/stylelint-order-0.5.0.tgz#6e34bbd755341216488d3af4b43237eb5ac40b6e"
+  dependencies:
+    lodash "^4.17.4"
+    postcss "^6.0.1"
+    postcss-sorting "^3.0.0"
+    stylelint "^7.11.0"
+
+stylelint@^7.0.3, stylelint@^7.11.0:
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-7.13.0.tgz#111f97b6da72e775c80800d6bb6f5f869997785d"
+  dependencies:
+    autoprefixer "^6.0.0"
+    balanced-match "^0.4.0"
+    chalk "^2.0.1"
+    colorguard "^1.2.0"
+    cosmiconfig "^2.1.1"
+    debug "^2.6.0"
+    doiuse "^2.4.1"
+    execall "^1.0.0"
+    file-entry-cache "^2.0.0"
+    get-stdin "^5.0.0"
+    globby "^6.0.0"
+    globjoin "^0.1.4"
+    html-tags "^2.0.0"
+    ignore "^3.2.0"
+    imurmurhash "^0.1.4"
+    known-css-properties "^0.2.0"
+    lodash "^4.17.4"
+    log-symbols "^1.0.2"
+    mathml-tag-names "^2.0.0"
+    meow "^3.3.0"
+    micromatch "^2.3.11"
+    normalize-selector "^0.2.0"
+    pify "^2.3.0"
+    postcss "^5.0.20"
+    postcss-less "^0.14.0"
+    postcss-media-query-parser "^0.2.0"
+    postcss-reporter "^3.0.0"
+    postcss-resolve-nested-selector "^0.1.1"
+    postcss-scss "^0.4.0"
+    postcss-selector-parser "^2.1.1"
+    postcss-value-parser "^3.1.1"
+    resolve-from "^3.0.0"
+    specificity "^0.3.0"
+    string-width "^2.0.0"
+    style-search "^0.1.0"
+    stylehacks "^2.3.2"
+    sugarss "^0.2.0"
+    svg-tags "^1.0.0"
+    table "^4.0.1"
+
+stylelint@^9.1.1, stylelint@^9.4.0:
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-9.4.0.tgz#2f2b82ae9db53a06735ae0724f41b134fdb84a10"
+  dependencies:
+    autoprefixer "^9.0.0"
+    balanced-match "^1.0.0"
+    chalk "^2.4.1"
+    cosmiconfig "^5.0.0"
+    debug "^3.0.0"
+    execall "^1.0.0"
+    file-entry-cache "^2.0.0"
+    get-stdin "^6.0.0"
+    globby "^8.0.0"
+    globjoin "^0.1.4"
+    html-tags "^2.0.0"
+    ignore "^4.0.0"
+    import-lazy "^3.1.0"
+    imurmurhash "^0.1.4"
+    known-css-properties "^0.6.0"
+    lodash "^4.17.4"
+    log-symbols "^2.0.0"
+    mathml-tag-names "^2.0.1"
+    meow "^5.0.0"
+    micromatch "^2.3.11"
+    normalize-selector "^0.2.0"
+    pify "^3.0.0"
+    postcss "^7.0.0"
+    postcss-html "^0.31.0"
+    postcss-less "^2.0.0"
+    postcss-markdown "^0.31.0"
+    postcss-media-query-parser "^0.2.3"
+    postcss-reporter "^5.0.0"
+    postcss-resolve-nested-selector "^0.1.1"
+    postcss-safe-parser "^4.0.0"
+    postcss-sass "^0.3.0"
+    postcss-scss "^2.0.0"
+    postcss-selector-parser "^3.1.0"
+    postcss-styled "^0.31.0"
+    postcss-syntax "^0.31.0"
+    postcss-value-parser "^3.3.0"
+    resolve-from "^4.0.0"
+    signal-exit "^3.0.2"
+    specificity "^0.4.0"
+    string-width "^2.1.0"
+    style-search "^0.1.0"
+    sugarss "^1.0.0"
+    svg-tags "^1.0.0"
+    table "^4.0.1"
+
+sugarss@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/sugarss/-/sugarss-0.2.0.tgz#ac34237563327c6ff897b64742bf6aec190ad39e"
+  dependencies:
+    postcss "^5.2.4"
+
+sugarss@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/sugarss/-/sugarss-1.0.1.tgz#be826d9003e0f247735f92365dc3fd7f1bae9e44"
+  dependencies:
+    postcss "^6.0.14"
+
 supports-color@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-0.2.0.tgz#d92de2694eb3f67323973d7ae3d8b55b4c22190a"
@@ -9222,11 +10092,15 @@ supports-color@^5.1.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^5.3.0:
+supports-color@^5.3.0, supports-color@^5.4.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
   dependencies:
     has-flag "^3.0.0"
+
+svg-tags@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/svg-tags/-/svg-tags-1.0.0.tgz#58f71cee3bd519b59d4b2a843b6c7de64ac04764"
 
 svgo@^0.7.0:
   version "0.7.2"
@@ -9265,6 +10139,12 @@ symbol-observable@^1.0.3:
 symbol-tree@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
+
+synesthesia@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/synesthesia/-/synesthesia-1.0.1.tgz#5ef95ea548c0d5c6e6f9bb4b0d0731dff864a777"
+  dependencies:
+    css-color-names "0.0.3"
 
 table-layout@^0.4.2, table-layout@~0.4.0:
   version "0.4.2"
@@ -9383,7 +10263,7 @@ text-encoding@^0.6.4:
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
 
-text-table@~0.2.0:
+text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 
@@ -9403,6 +10283,13 @@ throat@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
 
+through2@^0.6.1, through2@^0.6.3, through2@~0.6.1:
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-0.6.5.tgz#41ab9c67b29d57209071410e1d7a7a968cd3ad48"
+  dependencies:
+    readable-stream ">=1.0.33-1 <1.1.0-0"
+    xtend ">=4.0.0 <4.1.0-0"
+
 through2@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
@@ -9410,7 +10297,7 @@ through2@^2.0.0:
     readable-stream "^2.1.5"
     xtend "~4.0.1"
 
-through@2, "through@>=2.2.7 <3", through@^2.3.6, through@^2.3.8, through@~2.3, through@~2.3.1:
+through@2, "through@>=2.2.7 <3", through@^2.3.6, through@^2.3.8, through@~2.3, through@~2.3.1, through@~2.3.4:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
@@ -9524,9 +10411,25 @@ trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
 
+trim-newlines@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-2.0.0.tgz#b403d0b91be50c331dfc4b82eeceb22c3de16d20"
+
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
+
+trim-trailing-lines@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.1.tgz#e0ec0810fd3c3f1730516b45f49083caaf2774d9"
+
+trim@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
+
+trough@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.2.tgz#7f1663ec55c480139e2de5e486c6aef6cc24a535"
 
 tty-browserify@0.0.0:
   version "0.0.0"
@@ -9668,6 +10571,24 @@ underscore@~1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.7.0.tgz#6bbaf0877500d36be34ecaa584e0db9fef035209"
 
+unherit@^1.0.4:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/unherit/-/unherit-1.1.1.tgz#132748da3e88eab767e08fabfbb89c5e9d28628c"
+  dependencies:
+    inherits "^2.0.1"
+    xtend "^4.0.1"
+
+unified@^6.0.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-6.2.0.tgz#7fbd630f719126d67d40c644b7e3f617035f6dba"
+  dependencies:
+    bail "^1.0.0"
+    extend "^3.0.0"
+    is-plain-obj "^1.1.0"
+    trough "^1.0.0"
+    vfile "^2.0.0"
+    x-is-string "^0.1.0"
+
 union-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
@@ -9714,6 +10635,44 @@ unique-string@^1.0.0:
   resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-1.0.0.tgz#9e1057cca851abb93398f8b33ae187b99caec11a"
   dependencies:
     crypto-random-string "^1.0.0"
+
+unist-util-find-all-after@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/unist-util-find-all-after/-/unist-util-find-all-after-1.0.2.tgz#9be49cfbae5ca1566b27536670a92836bf2f8d6d"
+  dependencies:
+    unist-util-is "^2.0.0"
+
+unist-util-is@^2.0.0, unist-util-is@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-2.1.2.tgz#1193fa8f2bfbbb82150633f3a8d2eb9a1c1d55db"
+
+unist-util-modify-children@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-modify-children/-/unist-util-modify-children-1.1.2.tgz#c7f1b91712554ee59c47a05b551ed3e052a4e2d1"
+  dependencies:
+    array-iterate "^1.0.0"
+
+unist-util-remove-position@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-1.1.2.tgz#86b5dad104d0bbfbeb1db5f5c92f3570575c12cb"
+  dependencies:
+    unist-util-visit "^1.1.0"
+
+unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz#3f37fcf351279dcbca7480ab5889bb8a832ee1c6"
+
+unist-util-visit-parents@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-2.0.1.tgz#63fffc8929027bee04bfef7d2cce474f71cb6217"
+  dependencies:
+    unist-util-is "^2.1.2"
+
+unist-util-visit@^1.1.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.0.tgz#1cb763647186dc26f5e1df5db6bd1e48b3cc2fb1"
+  dependencies:
+    unist-util-visit-parents "^2.0.0"
 
 universalify@^0.1.0:
   version "0.1.1"
@@ -9911,6 +10870,25 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+vfile-location@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-2.0.3.tgz#083ba80e50968e8d420be49dd1ea9a992131df77"
+
+vfile-message@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-1.0.1.tgz#51a2ccd8a6b97a7980bb34efb9ebde9632e93677"
+  dependencies:
+    unist-util-stringify-position "^1.1.1"
+
+vfile@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-2.3.0.tgz#e62d8e72b20e83c324bc6c67278ee272488bf84a"
+  dependencies:
+    is-buffer "^1.1.4"
+    replace-ext "1.0.0"
+    unist-util-stringify-position "^1.0.0"
+    vfile-message "^1.0.0"
 
 vm-browserify@0.0.4:
   version "0.0.4"
@@ -10132,6 +11110,10 @@ window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
 
+window-size@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.4.tgz#f8e1aa1ee5a53ec5bf151ffa09742a6ad7697876"
+
 window-size@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.2.0.tgz#b4315bb4214a3d7058ebeee892e13fa24d98b075"
@@ -10186,6 +11168,10 @@ write-file-atomic@^2.0.0, write-file-atomic@^2.1.0:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
 
+write-file-stdout@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/write-file-stdout/-/write-file-stdout-0.0.2.tgz#c252d7c7c5b1b402897630e3453c7bfe690d9ca1"
+
 write@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
@@ -10214,6 +11200,10 @@ ws@^4.0.0:
     async-limiter "~1.0.0"
     safe-buffer "~5.1.0"
 
+x-is-string@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/x-is-string/-/x-is-string-0.1.0.tgz#474b50865af3a49a9c4657f05acd145458f77d82"
+
 xdg-basedir@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
@@ -10226,11 +11216,11 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
 
-xtend@^4.0.0, xtend@~4.0.1:
+"xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 
-y18n@^3.2.1:
+y18n@^3.2.0, y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
 
@@ -10253,6 +11243,12 @@ yargonaut@^1.1.2:
     chalk "^1.1.1"
     figlet "^1.1.1"
     parent-require "^1.0.0"
+
+yargs-parser@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
+  dependencies:
+    camelcase "^4.1.0"
 
 yargs-parser@^2.4.1:
   version "2.4.1"
@@ -10321,6 +11317,10 @@ yargs@8.0.1:
     y18n "^3.2.1"
     yargs-parser "^7.0.0"
 
+yargs@^1.2.6:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-1.3.3.tgz#054de8b61f22eefdb7207059eaef9d6b83fb931a"
+
 yargs@^10.0.3:
   version "10.1.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-10.1.2.tgz#454d074c2b16a51a43e2fb7807e4f9de69ccb5c5"
@@ -10337,6 +11337,18 @@ yargs@^10.0.3:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^8.1.0"
+
+yargs@^3.5.4:
+  version "3.32.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.32.0.tgz#03088e9ebf9e756b69751611d2a5ef591482c995"
+  dependencies:
+    camelcase "^2.0.1"
+    cliui "^3.0.3"
+    decamelize "^1.1.1"
+    os-locale "^1.4.0"
+    string-width "^1.0.1"
+    window-size "^0.1.4"
+    y18n "^3.2.0"
 
 yargs@^4.2.0:
   version "4.8.1"


### PR DESCRIPTION
Here is a quick pass at setting up CSS linting. I'd like to evaluate using it to help with consistent, simple CSS, and to ease the review process for common lintable requests, like the idiomatic css ordering.

Right now I'd like to wait to land my tracks work first to avoid rebase issues, and there is some issues with licensing of some dependent modules that needs to be sorted out (both look compatible but they are being flagged by the license checker).