### PR TITLE
Add the ability to isolate a process's main thread

### DIFF
--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -8,7 +8,7 @@ import { ContextMenu, MenuItem } from 'react-contextmenu';
 import {
   hideGlobalTrack,
   showGlobalTrack,
-  isolateGlobalTrack,
+  isolateProcess,
   isolateLocalTrack,
   hideLocalTrack,
   showLocalTrack,
@@ -57,7 +57,7 @@ type StateProps = {|
 type DispatchProps = {|
   +hideGlobalTrack: typeof hideGlobalTrack,
   +showGlobalTrack: typeof showGlobalTrack,
-  +isolateGlobalTrack: typeof isolateGlobalTrack,
+  +isolateProcess: typeof isolateProcess,
   +hideLocalTrack: typeof hideLocalTrack,
   +showLocalTrack: typeof showLocalTrack,
   +isolateLocalTrack: typeof isolateLocalTrack,
@@ -101,13 +101,9 @@ class TimelineTrackContextMenu extends PureComponent<Props> {
   };
 
   _isolateTrack = () => {
-    const {
-      isolateGlobalTrack,
-      isolateLocalTrack,
-      rightClickedTrack,
-    } = this.props;
+    const { isolateProcess, isolateLocalTrack, rightClickedTrack } = this.props;
     if (rightClickedTrack.type === 'global') {
-      isolateGlobalTrack(rightClickedTrack.trackIndex);
+      isolateProcess(rightClickedTrack.trackIndex);
     } else {
       const { pid, trackIndex } = rightClickedTrack;
       isolateLocalTrack(pid, trackIndex);
@@ -288,7 +284,7 @@ const options: ExplicitConnectOptions<{||}, StateProps, DispatchProps> = {
   mapDispatchToProps: {
     hideGlobalTrack,
     showGlobalTrack,
-    isolateGlobalTrack,
+    isolateProcess,
     hideLocalTrack,
     showLocalTrack,
     isolateLocalTrack,

--- a/src/components/timeline/TrackContextMenu.js
+++ b/src/components/timeline/TrackContextMenu.js
@@ -10,6 +10,7 @@ import {
   showGlobalTrack,
   isolateProcess,
   isolateLocalTrack,
+  isolateProcessMainThread,
   hideLocalTrack,
   showLocalTrack,
 } from '../../actions/profile-view';
@@ -22,6 +23,7 @@ import {
   getRightClickedThreadIndex,
   getLocalTrackNamesByPid,
   getGlobalTrackNames,
+  getLocalTracksByPid,
 } from '../../reducers/profile-view';
 import {
   getGlobalTrackOrder,
@@ -32,7 +34,11 @@ import {
 import classNames from 'classnames';
 
 import type { Thread, ThreadIndex, Pid } from '../../types/profile';
-import type { TrackIndex, GlobalTrack } from '../../types/profile-derived';
+import type {
+  TrackIndex,
+  GlobalTrack,
+  LocalTrack,
+} from '../../types/profile-derived';
 import type { State } from '../../types/reducers';
 import type { TrackReference } from '../../types/actions';
 
@@ -51,6 +57,7 @@ type StateProps = {|
   +globalTracks: GlobalTrack[],
   +rightClickedThreadIndex: ThreadIndex | null,
   +globalTrackNames: string[],
+  +localTracksByPid: Map<Pid, LocalTrack[]>,
   +localTrackNamesByPid: Map<Pid, string[]>,
 |};
 
@@ -61,6 +68,7 @@ type DispatchProps = {|
   +hideLocalTrack: typeof hideLocalTrack,
   +showLocalTrack: typeof showLocalTrack,
   +isolateLocalTrack: typeof isolateLocalTrack,
+  +isolateProcessMainThread: typeof isolateProcessMainThread,
 |};
 
 type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
@@ -100,14 +108,35 @@ class TimelineTrackContextMenu extends PureComponent<Props> {
     }
   };
 
-  _isolateTrack = () => {
-    const { isolateProcess, isolateLocalTrack, rightClickedTrack } = this.props;
-    if (rightClickedTrack.type === 'global') {
-      isolateProcess(rightClickedTrack.trackIndex);
-    } else {
-      const { pid, trackIndex } = rightClickedTrack;
-      isolateLocalTrack(pid, trackIndex);
+  _isolateProcess = () => {
+    const { isolateProcess, rightClickedTrack } = this.props;
+    if (rightClickedTrack.type === 'local') {
+      throw new Error(
+        'Attempting to isolate a process track with a local track is selected.'
+      );
     }
+    isolateProcess(rightClickedTrack.trackIndex);
+  };
+
+  _isolateProcessMainThread = () => {
+    const { isolateProcessMainThread, rightClickedTrack } = this.props;
+    if (rightClickedTrack.type === 'local') {
+      throw new Error(
+        'Attempting to isolate a process track with a local track is selected.'
+      );
+    }
+    isolateProcessMainThread(rightClickedTrack.trackIndex);
+  };
+
+  _isolateLocalTrack = () => {
+    const { isolateLocalTrack, rightClickedTrack } = this.props;
+    if (rightClickedTrack.type === 'global') {
+      throw new Error(
+        'Attempting to isolate a local track with a global track is selected.'
+      );
+    }
+    const { pid, trackIndex } = rightClickedTrack;
+    isolateLocalTrack(pid, trackIndex);
   };
 
   renderGlobalTrack(trackIndex: TrackIndex) {
@@ -194,53 +223,157 @@ class TimelineTrackContextMenu extends PureComponent<Props> {
     }
   }
 
-  renderIsolateTrack() {
+  renderIsolateProcess() {
     const {
-      threads,
-      rightClickedThreadIndex,
       rightClickedTrack,
+      globalTracks,
       globalTrackOrder,
+      hiddenGlobalTracks,
+      hiddenLocalTracksByPid,
+      localTracksByPid,
+    } = this.props;
+
+    if (rightClickedTrack.type !== 'global' || globalTracks.length === 1) {
+      // This is not a valid candidate for isolating.
+      return null;
+    }
+
+    const track = globalTracks[rightClickedTrack.trackIndex];
+    if (track.type !== 'process') {
+      // Only process tracks can be isolated.
+      return null;
+    }
+
+    // Disable this option if there is only one left global track left.
+    let isDisabled = hiddenGlobalTracks.size === globalTrackOrder.length - 1;
+
+    if (!isDisabled && track.mainThreadIndex === null) {
+      // Ensure there is a valid thread index in the local tracks to isolate, otherwise
+      // disable this track.
+      const localTracks = localTracksByPid.get(track.pid);
+      const hiddenLocalTracks = hiddenLocalTracksByPid.get(track.pid);
+      if (localTracks === undefined || hiddenLocalTracks === undefined) {
+        console.error('Local track information for the given pid.');
+        return null;
+      }
+      let hasVisibleLocalTrackWithMainThread = false;
+      for (let trackIndex = 0; trackIndex < localTracks.length; trackIndex++) {
+        const localTrack = localTracks[trackIndex];
+        if (
+          localTrack.type === 'thread' &&
+          !hiddenLocalTracks.has(trackIndex)
+        ) {
+          hasVisibleLocalTrackWithMainThread = true;
+          break;
+        }
+      }
+      if (!hasVisibleLocalTrackWithMainThread) {
+        // The process has no main thread, and there are no visible local tracks
+        // with a thread index, do not offer to isolate in this case, but just disable
+        // this button in case some threads become visible while the menu is open.
+        isDisabled = true;
+      }
+    }
+
+    return (
+      <MenuItem
+        // This attribute is used to identify this element in tests.
+        data-test-id="isolate-track-process"
+        onClick={this._isolateProcess}
+        disabled={isDisabled}
+      >
+        Only show this process
+      </MenuItem>
+    );
+  }
+
+  renderIsolateProcessMainThread() {
+    const {
+      rightClickedTrack,
+      globalTracks,
       hiddenGlobalTracks,
       hiddenLocalTracksByPid,
       localTrackOrderByPid,
     } = this.props;
 
-    if (threads.length === 1 || rightClickedThreadIndex === null) {
-      // This is not a valid candidate for hiding the thread. Either there are not
+    if (rightClickedTrack.type !== 'global') {
+      // This is not a valid candidate for isolating. Either there are not
       // enough threads, or the right clicked track didn't have an associated thread
       // index.
       return null;
     }
 
-    let isOnlyOneTrackLeft;
-    if (rightClickedTrack.type === 'global') {
-      isOnlyOneTrackLeft =
-        hiddenGlobalTracks.size === globalTrackOrder.length - 1;
-    } else {
-      const hiddenLocalTracks = hiddenLocalTracksByPid.get(
-        rightClickedTrack.pid
-      );
-      const localTrackOrder = localTrackOrderByPid.get(rightClickedTrack.pid);
-      if (hiddenLocalTracks === undefined || localTrackOrder === undefined) {
-        console.error('Expected to find hiddenLocalTracks for the given pid.');
-        return null;
-      }
-
-      isOnlyOneTrackLeft =
-        hiddenLocalTracks.size === localTrackOrder.length - 1;
+    const track = globalTracks[rightClickedTrack.trackIndex];
+    if (track.type !== 'process' || track.mainThreadIndex === null) {
+      // Only process tracks with a main thread can be isolated.
+      return null;
     }
+
+    // Look up the local track information.
+    const hiddenLocalTracks = hiddenLocalTracksByPid.get(track.pid);
+    const localTrackOrder = localTrackOrderByPid.get(track.pid);
+    if (hiddenLocalTracks === undefined || localTrackOrder === undefined) {
+      console.error(
+        'Expected to find local track information for the given pid.'
+      );
+      return null;
+    }
+
+    const isDisabled =
+      // Does it have no visible local tracks?
+      hiddenLocalTracks.size === localTrackOrder.length &&
+      // Is there only one visible global track?
+      globalTracks.length - hiddenGlobalTracks.size === 1;
+
     return (
-      <div>
-        <MenuItem
-          // This attribute is used to identify this element in tests.
-          data-test-id="isolate-track"
-          onClick={this._isolateTrack}
-          disabled={isOnlyOneTrackLeft}
-        >
-          Only show: {`"${this.getRightClickedTrackName()}"`}
-        </MenuItem>
-        <div className="react-contextmenu-separator" />
-      </div>
+      <MenuItem
+        data-test-id="isolate-process-main-thread"
+        onClick={this._isolateProcessMainThread}
+        disabled={isDisabled}
+      >
+        Only show {`"${this.getRightClickedTrackName()}"`}
+      </MenuItem>
+    );
+  }
+
+  renderIsolateLocalTrack() {
+    const {
+      rightClickedTrack,
+      globalTracks,
+      hiddenGlobalTracks,
+      hiddenLocalTracksByPid,
+      localTrackOrderByPid,
+    } = this.props;
+
+    if (rightClickedTrack.type === 'global') {
+      return null;
+    }
+
+    // Select the local track info.
+    const hiddenLocalTracks = hiddenLocalTracksByPid.get(rightClickedTrack.pid);
+    const localTrackOrder = localTrackOrderByPid.get(rightClickedTrack.pid);
+    if (hiddenLocalTracks === undefined || localTrackOrder === undefined) {
+      console.error(
+        'Expected to find local track information for the given pid.'
+      );
+      return null;
+    }
+
+    const isDisabled =
+      // Is there only one global track visible?
+      globalTracks.length - hiddenGlobalTracks.size === 1 &&
+      // Is there only one local track left?
+      localTrackOrder.length - hiddenLocalTracks.size === 1;
+
+    return (
+      <MenuItem
+        // This attribute is used to identify this element in tests.
+        data-test-id="isolate-local-track"
+        onClick={this._isolateLocalTrack}
+        disabled={isDisabled}
+      >
+        Only show {`"${this.getRightClickedTrackName()}"`}
+      </MenuItem>
     );
   }
 
@@ -249,9 +382,14 @@ class TimelineTrackContextMenu extends PureComponent<Props> {
 
     return (
       <ContextMenu id="TimelineTrackContextMenu">
-        {// This may or may not render the isolate track options, depending
-        // on whether it's actually valid to do so.
-        this.renderIsolateTrack()}
+        {
+          // The menu items header items to isolate tracks may or may not be
+          // visible depending on the current state.
+        }
+        {this.renderIsolateProcessMainThread()}
+        {this.renderIsolateProcess()}
+        {this.renderIsolateLocalTrack()}
+        <div className="react-contextmenu-separator" />
         {globalTrackOrder.map(globalTrackIndex => {
           const globalTrack = globalTracks[globalTrackIndex];
           return (
@@ -279,15 +417,17 @@ const options: ExplicitConnectOptions<{||}, StateProps, DispatchProps> = {
     localTrackOrderByPid: getLocalTrackOrderByPid(state),
     rightClickedThreadIndex: getRightClickedThreadIndex(state),
     globalTrackNames: getGlobalTrackNames(state),
+    localTracksByPid: getLocalTracksByPid(state),
     localTrackNamesByPid: getLocalTrackNamesByPid(state),
   }),
   mapDispatchToProps: {
     hideGlobalTrack,
     showGlobalTrack,
     isolateProcess,
+    isolateLocalTrack,
+    isolateProcessMainThread,
     hideLocalTrack,
     showLocalTrack,
-    isolateLocalTrack,
   },
   component: TimelineTrackContextMenu,
 };

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -84,7 +84,8 @@ function selectedThread(
   switch (action.type) {
     case 'CHANGE_SELECTED_THREAD':
     case 'VIEW_PROFILE':
-    case 'ISOLATE_GLOBAL_TRACK':
+    case 'ISOLATE_PROCESS':
+    case 'ISOLATE_PROCESS_MAIN_THREAD':
     case 'HIDE_GLOBAL_TRACK':
     case 'HIDE_LOCAL_TRACK':
     case 'ISOLATE_LOCAL_TRACK':
@@ -175,7 +176,8 @@ function hiddenGlobalTracks(
   switch (action.type) {
     case 'VIEW_PROFILE':
     case 'ISOLATE_LOCAL_TRACK':
-    case 'ISOLATE_GLOBAL_TRACK':
+    case 'ISOLATE_PROCESS':
+    case 'ISOLATE_PROCESS_MAIN_THREAD':
       return action.hiddenGlobalTracks;
     case 'HIDE_GLOBAL_TRACK': {
       const hiddenGlobalTracks = new Set(state);
@@ -213,6 +215,7 @@ function hiddenLocalTracksByPid(
       hiddenLocalTracksByPid.set(action.pid, hiddenLocalTracks);
       return hiddenLocalTracksByPid;
     }
+    case 'ISOLATE_PROCESS_MAIN_THREAD':
     case 'ISOLATE_LOCAL_TRACK': {
       const hiddenLocalTracksByPid = new Map(state);
       hiddenLocalTracksByPid.set(action.pid, action.hiddenLocalTracks);

--- a/src/test/components/__snapshots__/TrackContextMenu.test.js.snap
+++ b/src/test/components/__snapshots__/TrackContextMenu.test.js.snap
@@ -16,29 +16,38 @@ exports[`timeline/TrackContextMenu selected global track matches the snapshot of
   tabIndex="-1"
 >
   <div
-    key=".0"
+    aria-disabled="false"
+    aria-orientation={null}
+    className="react-contextmenu-item"
+    onClick={[Function]}
+    onMouseLeave={[Function]}
+    onMouseMove={[Function]}
+    onTouchEnd={[Function]}
+    role="menuitem"
+    tabIndex="-1"
   >
-    <div
-      aria-disabled="false"
-      aria-orientation={null}
-      className="react-contextmenu-item"
-      onClick={[Function]}
-      onMouseLeave={[Function]}
-      onMouseMove={[Function]}
-      onTouchEnd={[Function]}
-      role="menuitem"
-      tabIndex="-1"
-    >
-      Only show: 
-      "GeckoMain"
-    </div>
-    <div
-      className="react-contextmenu-separator"
-      key=".1"
-    />
+    Only show 
+    "Content"
   </div>
   <div
-    key=".1:$0"
+    aria-disabled="false"
+    aria-orientation={null}
+    className="react-contextmenu-item"
+    onClick={[Function]}
+    onMouseLeave={[Function]}
+    onMouseMove={[Function]}
+    onTouchEnd={[Function]}
+    role="menuitem"
+    tabIndex="-1"
+  >
+    Only show this process
+  </div>
+  <div
+    className="react-contextmenu-separator"
+    key=".3"
+  />
+  <div
+    key=".4:$0"
   >
     <div
       aria-disabled="false"
@@ -56,7 +65,7 @@ exports[`timeline/TrackContextMenu selected global track matches the snapshot of
     </div>
   </div>
   <div
-    key=".1:$1"
+    key=".4:$1"
   >
     <div
       aria-disabled="false"
@@ -120,29 +129,25 @@ exports[`timeline/TrackContextMenu selected local track matches the snapshot of 
   tabIndex="-1"
 >
   <div
-    key=".0"
+    aria-disabled="false"
+    aria-orientation={null}
+    className="react-contextmenu-item"
+    onClick={[Function]}
+    onMouseLeave={[Function]}
+    onMouseMove={[Function]}
+    onTouchEnd={[Function]}
+    role="menuitem"
+    tabIndex="-1"
   >
-    <div
-      aria-disabled="false"
-      aria-orientation={null}
-      className="react-contextmenu-item"
-      onClick={[Function]}
-      onMouseLeave={[Function]}
-      onMouseMove={[Function]}
-      onTouchEnd={[Function]}
-      role="menuitem"
-      tabIndex="-1"
-    >
-      Only show: 
-      "GeckoMain"
-    </div>
-    <div
-      className="react-contextmenu-separator"
-      key=".1"
-    />
+    Only show 
+    "DOM Worker"
   </div>
   <div
-    key=".1:$0"
+    className="react-contextmenu-separator"
+    key=".3"
+  />
+  <div
+    key=".4:$0"
   >
     <div
       aria-disabled="false"
@@ -160,7 +165,7 @@ exports[`timeline/TrackContextMenu selected local track matches the snapshot of 
     </div>
   </div>
   <div
-    key=".1:$1"
+    key=".4:$1"
   >
     <div
       aria-disabled="false"

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -119,10 +119,20 @@ type ProfileAction =
       +trackIndex: TrackIndex,
     |}
   | {|
-      +type: 'ISOLATE_GLOBAL_TRACK',
+      // Isolate only the process track, and not the local tracks.
+      +type: 'ISOLATE_PROCESS',
       +hiddenGlobalTracks: Set<TrackIndex>,
       +isolatedTrackIndex: TrackIndex,
       +selectedThreadIndex: ThreadIndex,
+    |}
+  | {|
+      // Isolate the process track, and hide the local tracks.
+      type: 'ISOLATE_PROCESS_MAIN_THREAD',
+      pid: Pid,
+      hiddenGlobalTracks: Set<TrackIndex>,
+      isolatedTrackIndex: TrackIndex,
+      selectedThreadIndex: ThreadIndex,
+      hiddenLocalTracks: Set<TrackIndex>,
     |}
   | {|
       +type: 'CHANGE_LOCAL_TRACK_ORDER',


### PR DESCRIPTION
This makes it so that you can both isolate a process and all it's tracks, or isolate just the main thread of that process.

[Deploy preview with many tracks](https://deploy-preview-1173--perf-html.netlify.com/public/91bdb2248d08174f07d9186aabbe1025e5ff9bf1/)

<img width="356" alt="image" src="https://user-images.githubusercontent.com/1588648/43650037-63db2f84-9704-11e8-9293-1a2684b21dfa.png">
