### PR TITLE
Rename and disambiguate range and profile selections

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -617,33 +617,10 @@ export function commitRange(start: number, end: number): Action {
   };
 }
 
-export function commitRangeAndUnsetSelection(
-  start: number,
-  end: number
-): ThunkAction<void> {
-  return dispatch => {
-    dispatch(commitRange(start, end));
-    dispatch(
-      updatePreviewSelection({ hasSelection: false, isModifying: false })
-    );
-  };
-}
-
 export function popCommittedRanges(firstPoppedFilterIndex: number): Action {
   return {
     type: 'POP_COMMITTED_RANGES',
     firstPoppedFilterIndex,
-  };
-}
-
-export function popCommittedRangesAndUnsetSelection(
-  firstPoppedFilterIndex: number
-): ThunkAction<void> {
-  return dispatch => {
-    dispatch(popCommittedRanges(firstPoppedFilterIndex));
-    dispatch(
-      updatePreviewSelection({ hasSelection: false, isModifying: false })
-    );
   };
 }
 

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -607,38 +607,38 @@ export function updateProfileSelection(selection: ProfileSelection): Action {
   };
 }
 
-export function addRangeFilter(start: number, end: number): Action {
+export function commitRange(start: number, end: number): Action {
   return {
-    type: 'ADD_RANGE_FILTER',
+    type: 'COMMIT_RANGE',
     start,
     end,
   };
 }
 
-export function addRangeFilterAndUnsetSelection(
+export function commitRangeAndUnsetSelection(
   start: number,
   end: number
 ): ThunkAction<void> {
   return dispatch => {
-    dispatch(addRangeFilter(start, end));
+    dispatch(commitRange(start, end));
     dispatch(
       updateProfileSelection({ hasSelection: false, isModifying: false })
     );
   };
 }
 
-export function popRangeFilters(firstRemovedFilterIndex: number): Action {
+export function popCommittedRanges(firstPoppedFilterIndex: number): Action {
   return {
-    type: 'POP_RANGE_FILTERS',
-    firstRemovedFilterIndex,
+    type: 'POP_COMMITTED_RANGES',
+    firstPoppedFilterIndex,
   };
 }
 
-export function popRangeFiltersAndUnsetSelection(
-  firstRemovedFilterIndex: number
+export function popCommittedRangesAndUnsetSelection(
+  firstPoppedFilterIndex: number
 ): ThunkAction<void> {
   return dispatch => {
-    dispatch(popRangeFilters(firstRemovedFilterIndex));
+    dispatch(popCommittedRanges(firstPoppedFilterIndex));
     dispatch(
       updateProfileSelection({ hasSelection: false, isModifying: false })
     );
@@ -670,14 +670,14 @@ export function addTransformToStack(
 }
 
 export function popTransformsFromStack(
-  firstRemovedFilterIndex: number
+  firstPoppedFilterIndex: number
 ): ThunkAction<void> {
   return (dispatch, getState) => {
     const threadIndex = getSelectedThreadIndex(getState());
     dispatch({
       type: 'POP_TRANSFORMS_FROM_STACK',
       threadIndex,
-      firstRemovedFilterIndex,
+      firstPoppedFilterIndex,
     });
   };
 }

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -23,7 +23,7 @@ import { ensureExists } from '../utils/flow';
 import { sendAnalytics } from '../utils/analytics';
 
 import type {
-  ProfileSelection,
+  PreviewSelection,
   ImplementationFilter,
   TrackReference,
 } from '../types/actions';
@@ -600,10 +600,12 @@ export function changeInvertCallstack(
   };
 }
 
-export function updateProfileSelection(selection: ProfileSelection): Action {
+export function updatePreviewSelection(
+  previewSelection: PreviewSelection
+): Action {
   return {
-    type: 'UPDATE_PROFILE_SELECTION',
-    selection,
+    type: 'UPDATE_PREVIEW_SELECTION',
+    previewSelection,
   };
 }
 
@@ -622,7 +624,7 @@ export function commitRangeAndUnsetSelection(
   return dispatch => {
     dispatch(commitRange(start, end));
     dispatch(
-      updateProfileSelection({ hasSelection: false, isModifying: false })
+      updatePreviewSelection({ hasSelection: false, isModifying: false })
     );
   };
 }
@@ -640,7 +642,7 @@ export function popCommittedRangesAndUnsetSelection(
   return dispatch => {
     dispatch(popCommittedRanges(firstPoppedFilterIndex));
     dispatch(
-      updateProfileSelection({ hasSelection: false, isModifying: false })
+      updatePreviewSelection({ hasSelection: false, isModifying: false })
     );
   };
 }

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -5,9 +5,9 @@
 // @flow
 import queryString from 'query-string';
 import {
-  stringifyRangeFilters,
-  parseRangeFilters,
-} from '../profile-logic/range-filters';
+  stringifyCommittedRanges,
+  parseCommittedRanges,
+} from '../profile-logic/committed-ranges';
 import {
   stringifyTransforms,
   parseTransforms,
@@ -108,7 +108,8 @@ export function urlStateToUrlObject(urlState: UrlState): UrlObject {
   // Start with the query parameters that are shown regardless of the active tab.
   const query: Object = {
     range:
-      stringifyRangeFilters(urlState.profileSpecific.rangeFilters) || undefined,
+      stringifyCommittedRanges(urlState.profileSpecific.committedRanges) ||
+      undefined,
     thread: urlState.profileSpecific.selectedThread,
     globalTrackOrder: urlState.profileSpecific.globalTrackOrder.join('-'),
     file: urlState.pathInZipFile || undefined,
@@ -266,7 +267,7 @@ export function stateFromLocation(location: Location): UrlState {
     profileSpecific: {
       implementation,
       invertCallstack: query.invertCallstack !== undefined,
-      rangeFilters: query.range ? parseRangeFilters(query.range) : [],
+      committedRanges: query.range ? parseCommittedRanges(query.range) : [],
       selectedThread: selectedThread,
       callTreeSearchString: query.search || '',
       globalTrackOrder: query.globalTrackOrder

--- a/src/components/app/ProfileFilterNavigator.js
+++ b/src/components/app/ProfileFilterNavigator.js
@@ -5,7 +5,7 @@
 // @flow
 
 import explicitConnect from '../../utils/connect';
-import { popCommittedRangesAndUnsetSelection } from '../../actions/profile-view';
+import { popCommittedRanges } from '../../actions/profile-view';
 import { getPreviewSelection } from '../../reducers/profile-view';
 import { getCommittedRangeLabels } from '../../reducers/url-state';
 import { getFormattedTimeLength } from '../../profile-logic/committed-ranges';
@@ -37,7 +37,7 @@ const options: ExplicitConnectOptions<{||}, StateProps, DispatchProps> = {
     };
   },
   mapDispatchToProps: {
-    onPop: popCommittedRangesAndUnsetSelection,
+    onPop: popCommittedRanges,
   },
   component: FilterNavigatorBar,
 };

--- a/src/components/app/ProfileFilterNavigator.js
+++ b/src/components/app/ProfileFilterNavigator.js
@@ -6,7 +6,7 @@
 
 import explicitConnect from '../../utils/connect';
 import { popCommittedRangesAndUnsetSelection } from '../../actions/profile-view';
-import { getSelection } from '../../reducers/profile-view';
+import { getPreviewSelection } from '../../reducers/profile-view';
 import { getCommittedRangeLabels } from '../../reducers/url-state';
 import { getFormattedTimeLength } from '../../profile-logic/committed-ranges';
 import FilterNavigatorBar from '../shared/FilterNavigatorBar';
@@ -23,10 +23,10 @@ type StateProps = $ReadOnly<$Exact<$Diff<Props, DispatchProps>>>;
 const options: ExplicitConnectOptions<{||}, StateProps, DispatchProps> = {
   mapStateToProps: state => {
     const items = getCommittedRangeLabels(state);
-    const profileSelection = getSelection(state);
-    const uncommittedItem = profileSelection.hasSelection
+    const previewSelection = getPreviewSelection(state);
+    const uncommittedItem = previewSelection.hasSelection
       ? getFormattedTimeLength(
-          profileSelection.selectionEnd - profileSelection.selectionStart
+          previewSelection.selectionEnd - previewSelection.selectionStart
         )
       : undefined;
     return {

--- a/src/components/app/ProfileFilterNavigator.js
+++ b/src/components/app/ProfileFilterNavigator.js
@@ -5,10 +5,10 @@
 // @flow
 
 import explicitConnect from '../../utils/connect';
-import { popRangeFiltersAndUnsetSelection } from '../../actions/profile-view';
+import { popCommittedRangesAndUnsetSelection } from '../../actions/profile-view';
 import { getSelection } from '../../reducers/profile-view';
-import { getRangeFilterLabels } from '../../reducers/url-state';
-import { getFormattedTimeLength } from '../../profile-logic/range-filters';
+import { getCommittedRangeLabels } from '../../reducers/url-state';
+import { getFormattedTimeLength } from '../../profile-logic/committed-ranges';
 import FilterNavigatorBar from '../shared/FilterNavigatorBar';
 
 import type { ExplicitConnectOptions } from '../../utils/connect';
@@ -22,7 +22,7 @@ type StateProps = $ReadOnly<$Exact<$Diff<Props, DispatchProps>>>;
 
 const options: ExplicitConnectOptions<{||}, StateProps, DispatchProps> = {
   mapStateToProps: state => {
-    const items = getRangeFilterLabels(state);
+    const items = getCommittedRangeLabels(state);
     const profileSelection = getSelection(state);
     const uncommittedItem = profileSelection.hasSelection
       ? getFormattedTimeLength(
@@ -37,7 +37,7 @@ const options: ExplicitConnectOptions<{||}, StateProps, DispatchProps> = {
     };
   },
   mapDispatchToProps: {
-    onPop: popRangeFiltersAndUnsetSelection,
+    onPop: popCommittedRangesAndUnsetSelection,
   },
   component: FilterNavigatorBar,
 };

--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -19,7 +19,7 @@ import {
   selectedThreadSelectors,
   getScrollToSelectionGeneration,
   getFocusCallTreeGeneration,
-  getProfileViewOptions,
+  getPreviewSelection,
 } from '../../reducers/profile-view';
 import { getIconsWithClassNames } from '../../reducers/icons';
 import {
@@ -218,7 +218,7 @@ const options: ExplicitConnectOptions<{||}, StateProps, DispatchProps> = {
       state
     ),
     searchStringsRegExp: getSearchStringsAsRegExp(state),
-    disableOverscan: getProfileViewOptions(state).selection.isModifying,
+    disableOverscan: getPreviewSelection(state).isModifying,
     invertCallstack: getInvertCallstack(state),
     implementationFilter: getImplementationFilter(state),
     icons: getIconsWithClassNames(state),

--- a/src/components/flame-graph/FlameGraph.js
+++ b/src/components/flame-graph/FlameGraph.js
@@ -10,6 +10,7 @@ import {
   selectedThreadSelectors,
   getCommittedRange,
   getProfileViewOptions,
+  getPreviewSelection,
   getScrollToSelectionGeneration,
 } from '../../reducers/profile-view';
 import { getSelectedThreadIndex } from '../../reducers/url-state';
@@ -22,7 +23,7 @@ import { BackgroundImageStyleDef } from '../shared/StyleDef';
 import type { Thread } from '../../types/profile';
 import type { Milliseconds } from '../../types/units';
 import type { FlameGraphTiming } from '../../profile-logic/flame-graph';
-import type { ProfileSelection } from '../../types/actions';
+import type { PreviewSelection } from '../../types/actions';
 import type {
   CallNodeInfo,
   IndexIntoCallNodeTable,
@@ -43,7 +44,7 @@ type StateProps = {|
   +thread: Thread,
   +maxStackDepth: number,
   +timeRange: { start: Milliseconds, end: Milliseconds },
-  +selection: ProfileSelection,
+  +previewSelection: PreviewSelection,
   +flameGraphTiming: FlameGraphTiming,
   +threadName: string,
   +processDetails: string,
@@ -80,7 +81,7 @@ class FlameGraph extends React.PureComponent<Props> {
       callTree,
       callNodeInfo,
       timeRange,
-      selection,
+      previewSelection,
       threadName,
       processDetails,
       selectedCallNodeIndex,
@@ -116,7 +117,7 @@ class FlameGraph extends React.PureComponent<Props> {
               timeRange,
               maxViewportHeight,
               maximumZoom: 1,
-              selection,
+              previewSelection,
               startsAtBottom: true,
               disableHorizontalMovement: true,
               viewportNeedsUpdate,
@@ -159,7 +160,7 @@ const options: ExplicitConnectOptions<{||}, StateProps, DispatchProps> = {
       flameGraphTiming: selectedThreadSelectors.getFlameGraphTiming(state),
       callTree: selectedThreadSelectors.getCallTree(state),
       timeRange: getCommittedRange(state),
-      selection: getProfileViewOptions(state).selection,
+      previewSelection: getPreviewSelection(state),
       threadName: selectedThreadSelectors.getFriendlyThreadName(state),
       processDetails: selectedThreadSelectors.getThreadProcessDetails(state),
       callNodeInfo: selectedThreadSelectors.getCallNodeInfo(state),

--- a/src/components/flame-graph/FlameGraph.js
+++ b/src/components/flame-graph/FlameGraph.js
@@ -8,7 +8,7 @@ import explicitConnect from '../../utils/connect';
 import FlameGraphCanvas from './Canvas';
 import {
   selectedThreadSelectors,
-  getDisplayRange,
+  getCommittedRange,
   getProfileViewOptions,
   getScrollToSelectionGeneration,
 } from '../../reducers/profile-view';
@@ -158,7 +158,7 @@ const options: ExplicitConnectOptions<{||}, StateProps, DispatchProps> = {
       ),
       flameGraphTiming: selectedThreadSelectors.getFlameGraphTiming(state),
       callTree: selectedThreadSelectors.getCallTree(state),
-      timeRange: getDisplayRange(state),
+      timeRange: getCommittedRange(state),
       selection: getProfileViewOptions(state).selection,
       threadName: selectedThreadSelectors.getFriendlyThreadName(state),
       processDetails: selectedThreadSelectors.getThreadProcessDetails(state),

--- a/src/components/marker-chart/Canvas.js
+++ b/src/components/marker-chart/Canvas.js
@@ -11,7 +11,7 @@ import {
 import ChartCanvas from '../shared/chart/Canvas';
 import MarkerTooltipContents from '../shared/MarkerTooltipContents';
 import TextMeasurement from '../../utils/text-measurement';
-import { updateProfileSelection } from '../../actions/profile-view';
+import { updatePreviewSelection } from '../../actions/profile-view';
 import { BLUE_40 } from '../../utils/colors';
 
 import type {
@@ -42,7 +42,7 @@ type OwnProps = {|
   +rowHeight: CssPixels,
   +markers: TracingMarker[],
   +threadIndex: ThreadIndex,
-  +updateProfileSelection: typeof updateProfileSelection,
+  +updatePreviewSelection: typeof updatePreviewSelection,
 |};
 
 type Props = {|
@@ -323,9 +323,9 @@ class MarkerChartCanvas extends React.PureComponent<Props, State> {
     if (markerIndex === null) {
       return;
     }
-    const { markers, updateProfileSelection } = this.props;
+    const { markers, updatePreviewSelection } = this.props;
     const marker = markers[markerIndex];
-    updateProfileSelection({
+    updatePreviewSelection({
       hasSelection: true,
       isModifying: false,
       selectionStart: marker.start,

--- a/src/components/marker-chart/index.js
+++ b/src/components/marker-chart/index.js
@@ -12,10 +12,10 @@ import {
   selectedThreadSelectors,
   getCommittedRange,
   getProfileInterval,
-  getProfileViewOptions,
+  getPreviewSelection,
 } from '../../reducers/profile-view';
 import { getSelectedThreadIndex } from '../../reducers/url-state';
-import { updateProfileSelection } from '../../actions/profile-view';
+import { updatePreviewSelection } from '../../actions/profile-view';
 
 import type {
   TracingMarker,
@@ -25,7 +25,7 @@ import type {
   Milliseconds,
   UnitIntervalOfProfileRange,
 } from '../../types/units';
-import type { ProfileSelection } from '../../types/actions';
+import type { PreviewSelection } from '../../types/actions';
 import type {
   ExplicitConnectOptions,
   ConnectedProps,
@@ -36,7 +36,7 @@ require('./index.css');
 const ROW_HEIGHT = 16;
 
 type DispatchProps = {|
-  +updateProfileSelection: typeof updateProfileSelection,
+  +updatePreviewSelection: typeof updatePreviewSelection,
 |};
 
 type StateProps = {|
@@ -46,7 +46,7 @@ type StateProps = {|
   +timeRange: { start: Milliseconds, end: Milliseconds },
   +interval: Milliseconds,
   +threadIndex: number,
-  +selection: ProfileSelection,
+  +previewSelection: PreviewSelection,
   +threadName: string,
   +processDetails: string,
 |};
@@ -69,10 +69,10 @@ class MarkerChart extends React.PureComponent<Props> {
       threadIndex,
       markerTimingRows,
       markers,
-      selection,
+      previewSelection,
       threadName,
       processDetails,
-      updateProfileSelection,
+      updatePreviewSelection,
     } = this.props;
 
     if (!markers.length) {
@@ -92,7 +92,7 @@ class MarkerChart extends React.PureComponent<Props> {
           key={threadIndex}
           viewportProps={{
             timeRange,
-            selection,
+            previewSelection,
             maxViewportHeight,
             viewportNeedsUpdate,
             maximumZoom: this.getMaximumZoom(),
@@ -100,7 +100,7 @@ class MarkerChart extends React.PureComponent<Props> {
           chartProps={{
             markerTimingRows,
             markers,
-            updateProfileSelection,
+            updatePreviewSelection,
             rangeStart: timeRange.start,
             rangeEnd: timeRange.end,
             rowHeight: ROW_HEIGHT,
@@ -133,12 +133,12 @@ const options: ExplicitConnectOptions<{||}, StateProps, DispatchProps> = {
       timeRange: getCommittedRange(state),
       interval: getProfileInterval(state),
       threadIndex: getSelectedThreadIndex(state),
-      selection: getProfileViewOptions(state).selection,
+      previewSelection: getPreviewSelection(state),
       threadName,
       processDetails: selectedThreadSelectors.getThreadProcessDetails(state),
     };
   },
-  mapDispatchToProps: { updateProfileSelection },
+  mapDispatchToProps: { updatePreviewSelection },
   component: MarkerChart,
 };
 export default explicitConnect(options);

--- a/src/components/marker-chart/index.js
+++ b/src/components/marker-chart/index.js
@@ -10,7 +10,7 @@ import MarkerChartEmptyReasons from './MarkerChartEmptyReasons';
 
 import {
   selectedThreadSelectors,
-  getDisplayRange,
+  getCommittedRange,
   getProfileInterval,
   getProfileViewOptions,
 } from '../../reducers/profile-view';
@@ -130,7 +130,7 @@ const options: ExplicitConnectOptions<{||}, StateProps, DispatchProps> = {
       markers,
       markerTimingRows,
       maxMarkerRows: markerTimingRows.length,
-      timeRange: getDisplayRange(state),
+      timeRange: getCommittedRange(state),
       interval: getProfileInterval(state),
       threadIndex: getSelectedThreadIndex(state),
       selection: getProfileViewOptions(state).selection,

--- a/src/components/marker-table/ContextMenu.js
+++ b/src/components/marker-table/ContextMenu.js
@@ -10,7 +10,7 @@ import { updateProfileSelection } from '../../actions/profile-view';
 import {
   selectedThreadSelectors,
   getProfileViewOptions,
-  getDisplayRange,
+  getCommittedRange,
 } from '../../reducers/profile-view';
 import copy from 'copy-to-clipboard';
 
@@ -30,7 +30,7 @@ type StateProps = {|
   +thread: Thread,
   +markers: MarkersTable,
   +selection: ProfileSelection,
-  +displayRange: StartEndRange,
+  +committedRange: StartEndRange,
   +selectedMarker: IndexIntoMarkersTable,
 |};
 
@@ -52,12 +52,12 @@ class MarkersContextMenu extends PureComponent<Props> {
       markers,
       updateProfileSelection,
       selection,
-      displayRange,
+      committedRange,
     } = this.props;
 
     const selectionEnd = selection.hasSelection
       ? selection.selectionEnd
-      : displayRange.end;
+      : committedRange.end;
 
     updateProfileSelection({
       hasSelection: true,
@@ -72,13 +72,13 @@ class MarkersContextMenu extends PureComponent<Props> {
       selectedMarker,
       markers,
       updateProfileSelection,
-      displayRange,
+      committedRange,
       selection,
     } = this.props;
 
     const selectionStart = selection.hasSelection
       ? selection.selectionStart
-      : displayRange.start;
+      : committedRange.start;
 
     updateProfileSelection({
       hasSelection: true,
@@ -143,7 +143,7 @@ const options: ExplicitConnectOptions<{||}, StateProps, DispatchProps> = {
     thread: selectedThreadSelectors.getThread(state),
     markers: selectedThreadSelectors.getSearchFilteredMarkers(state),
     selection: getProfileViewOptions(state).selection,
-    displayRange: getDisplayRange(state),
+    committedRange: getCommittedRange(state),
     selectedMarker: selectedThreadSelectors.getViewOptions(state)
       .selectedMarker,
   }),

--- a/src/components/marker-table/ContextMenu.js
+++ b/src/components/marker-table/ContextMenu.js
@@ -6,10 +6,10 @@
 import React, { PureComponent } from 'react';
 import { ContextMenu, MenuItem } from 'react-contextmenu';
 import explicitConnect from '../../utils/connect';
-import { updateProfileSelection } from '../../actions/profile-view';
+import { updatePreviewSelection } from '../../actions/profile-view';
 import {
   selectedThreadSelectors,
-  getProfileViewOptions,
+  getPreviewSelection,
   getCommittedRange,
 } from '../../reducers/profile-view';
 import copy from 'copy-to-clipboard';
@@ -20,7 +20,7 @@ import type {
   IndexIntoMarkersTable,
   MarkersTable,
 } from '../../types/profile';
-import type { ProfileSelection } from '../../types/actions';
+import type { PreviewSelection } from '../../types/actions';
 import type {
   ExplicitConnectOptions,
   ConnectedProps,
@@ -29,13 +29,13 @@ import type {
 type StateProps = {|
   +thread: Thread,
   +markers: MarkersTable,
-  +selection: ProfileSelection,
+  +previewSelection: PreviewSelection,
   +committedRange: StartEndRange,
   +selectedMarker: IndexIntoMarkersTable,
 |};
 
 type DispatchProps = {|
-  +updateProfileSelection: typeof updateProfileSelection,
+  +updatePreviewSelection: typeof updatePreviewSelection,
 |};
 
 type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
@@ -50,16 +50,16 @@ class MarkersContextMenu extends PureComponent<Props> {
     const {
       selectedMarker,
       markers,
-      updateProfileSelection,
-      selection,
+      updatePreviewSelection,
+      previewSelection,
       committedRange,
     } = this.props;
 
-    const selectionEnd = selection.hasSelection
-      ? selection.selectionEnd
+    const selectionEnd = previewSelection.hasSelection
+      ? previewSelection.selectionEnd
       : committedRange.end;
 
-    updateProfileSelection({
+    updatePreviewSelection({
       hasSelection: true,
       isModifying: false,
       selectionStart: markers.time[selectedMarker],
@@ -71,16 +71,16 @@ class MarkersContextMenu extends PureComponent<Props> {
     const {
       selectedMarker,
       markers,
-      updateProfileSelection,
+      updatePreviewSelection,
       committedRange,
-      selection,
+      previewSelection,
     } = this.props;
 
-    const selectionStart = selection.hasSelection
-      ? selection.selectionStart
+    const selectionStart = previewSelection.hasSelection
+      ? previewSelection.selectionStart
       : committedRange.start;
 
-    updateProfileSelection({
+    updatePreviewSelection({
       hasSelection: true,
       isModifying: false,
       selectionStart,
@@ -142,12 +142,12 @@ const options: ExplicitConnectOptions<{||}, StateProps, DispatchProps> = {
   mapStateToProps: state => ({
     thread: selectedThreadSelectors.getThread(state),
     markers: selectedThreadSelectors.getSearchFilteredMarkers(state),
-    selection: getProfileViewOptions(state).selection,
+    previewSelection: getPreviewSelection(state),
     committedRange: getCommittedRange(state),
     selectedMarker: selectedThreadSelectors.getViewOptions(state)
       .selectedMarker,
   }),
-  mapDispatchToProps: { updateProfileSelection },
+  mapDispatchToProps: { updatePreviewSelection },
   component: MarkersContextMenu,
 };
 export default explicitConnect(options);

--- a/src/components/marker-table/index.js
+++ b/src/components/marker-table/index.js
@@ -197,7 +197,7 @@ class MarkerTable extends PureComponent<Props> {
 const options: ExplicitConnectOptions<{||}, StateProps, DispatchProps> = {
   mapStateToProps: state => ({
     threadIndex: getSelectedThreadIndex(state),
-    thread: selectedThreadSelectors.getRangeSelectionFilteredThread(state),
+    thread: selectedThreadSelectors.getPreviewFilteredThread(state),
     markers: selectedThreadSelectors.getSearchFilteredMarkers(state),
     selectedMarker: selectedThreadSelectors.getViewOptions(state)
       .selectedMarker,

--- a/src/components/shared/chart/Viewport.js
+++ b/src/components/shared/chart/Viewport.js
@@ -8,14 +8,14 @@ import classNames from 'classnames';
 import explicitConnect from '../../../utils/connect';
 import { getHasZoomedViaMousewheel } from '../../../reducers/app';
 import { setHasZoomedViaMousewheel } from '../../../actions/stack-chart';
-import { updateProfileSelection } from '../../../actions/profile-view';
+import { updatePreviewSelection } from '../../../actions/profile-view';
 
 import type {
   CssPixels,
   UnitIntervalOfProfileRange,
   StartEndRange,
 } from '../../../types/units';
-import type { ProfileSelection } from '../../../types/actions';
+import type { PreviewSelection } from '../../../types/actions';
 import type {
   ExplicitConnectOptions,
   ConnectedProps,
@@ -73,7 +73,7 @@ type ViewportStateProps = {|
 |};
 
 type ViewportDispatchProps = {|
-  +updateProfileSelection: typeof updateProfileSelection,
+  +updatePreviewSelection: typeof updatePreviewSelection,
   +setHasZoomedViaMousewheel?: typeof setHasZoomedViaMousewheel,
 |};
 
@@ -85,7 +85,7 @@ type ViewportOwnProps<ChartProps> = {|
     +maxViewportHeight: number,
     +startsAtBottom?: boolean,
     +maximumZoom: UnitIntervalOfProfileRange,
-    +selection: ProfileSelection,
+    +previewSelection: PreviewSelection,
     +disableHorizontalMovement?: boolean,
     // These props are defined by the generic variables passed into to the type
     // WithChartViewport when calling withChartViewport. This is how the relationship
@@ -182,9 +182,9 @@ export const withChartViewport: WithChartViewport<*, *> =
       }
 
       getHorizontalViewport(props: ViewportProps) {
-        const { selection, timeRange } = props.viewportProps;
-        if (selection.hasSelection) {
-          const { selectionStart, selectionEnd } = selection;
+        const { previewSelection, timeRange } = props.viewportProps;
+        if (previewSelection.hasSelection) {
+          const { selectionStart, selectionEnd } = previewSelection;
           const timeRangeLength = timeRange.end - timeRange.start;
           return {
             viewportLeft: (selectionStart - timeRange.start) / timeRangeLength,
@@ -248,8 +248,8 @@ export const withChartViewport: WithChartViewport<*, *> =
           this.setState(this.getDefaultState(newProps));
           this._setSizeNextFrame();
         } else if (
-          this.props.viewportProps.selection !==
-            newProps.viewportProps.selection ||
+          this.props.viewportProps.previewSelection !==
+            newProps.viewportProps.previewSelection ||
           this.props.viewportProps.timeRange !==
             newProps.viewportProps.timeRange
         ) {
@@ -373,7 +373,7 @@ export const withChartViewport: WithChartViewport<*, *> =
             }
 
             const {
-              updateProfileSelection,
+              updatePreviewSelection,
               viewportProps: { timeRange },
             } = this.props;
             if (newViewportLeft === 0 && newViewportRight === 1) {
@@ -381,13 +381,13 @@ export const withChartViewport: WithChartViewport<*, *> =
                 // Do not update if at the maximum bounds.
                 return;
               }
-              updateProfileSelection({
+              updatePreviewSelection({
                 hasSelection: false,
                 isModifying: false,
               });
             } else {
               const timeRangeLength = timeRange.end - timeRange.start;
-              updateProfileSelection({
+              updatePreviewSelection({
                 hasSelection: true,
                 isModifying: false,
                 selectionStart:
@@ -432,7 +432,7 @@ export const withChartViewport: WithChartViewport<*, *> =
 
       moveViewport(offsetX: CssPixels, offsetY: CssPixels): boolean {
         const {
-          updateProfileSelection,
+          updatePreviewSelection,
           viewportProps: {
             maxViewportHeight,
             timeRange,
@@ -491,7 +491,7 @@ export const withChartViewport: WithChartViewport<*, *> =
         const viewportVerticalChanged = newViewportTop !== viewportTop;
 
         if (viewportHorizontalChanged && !disableHorizontalMovement) {
-          updateProfileSelection({
+          updatePreviewSelection({
             hasSelection: true,
             isModifying: false,
             selectionStart: timeRange.start + timeRangeLength * newViewportLeft,
@@ -599,7 +599,7 @@ export const withChartViewport: WithChartViewport<*, *> =
       mapStateToProps: state => ({
         hasZoomedViaMousewheel: getHasZoomedViaMousewheel(state),
       }),
-      mapDispatchToProps: { setHasZoomedViaMousewheel, updateProfileSelection },
+      mapDispatchToProps: { setHasZoomedViaMousewheel, updatePreviewSelection },
       component: ChartViewport,
     };
     return explicitConnect(options);

--- a/src/components/stack-chart/Canvas.js
+++ b/src/components/stack-chart/Canvas.js
@@ -11,7 +11,7 @@ import {
 import ChartCanvas from '../shared/chart/Canvas';
 import TextMeasurement from '../../utils/text-measurement';
 import { formatNumber } from '../../utils/format-numbers';
-import { updateProfileSelection } from '../../actions/profile-view';
+import { updatePreviewSelection } from '../../actions/profile-view';
 
 import type { Thread } from '../../types/profile';
 import type {
@@ -37,7 +37,7 @@ type OwnProps = {|
   +stackFrameHeight: CssPixels,
   +getCategory: GetCategory,
   +getLabel: GetLabel,
-  +updateProfileSelection: typeof updateProfileSelection,
+  +updatePreviewSelection: typeof updatePreviewSelection,
 |};
 
 type Props = $ReadOnly<{|
@@ -267,8 +267,8 @@ class StackChartCanvas extends React.PureComponent<Props> {
       return;
     }
     const { depth, stackTableIndex } = hoveredItem;
-    const { stackTimingByDepth, updateProfileSelection } = this.props;
-    updateProfileSelection({
+    const { stackTimingByDepth, updatePreviewSelection } = this.props;
+    updatePreviewSelection({
       hasSelection: true,
       isModifying: false,
       selectionStart: stackTimingByDepth[depth].start[stackTableIndex],

--- a/src/components/stack-chart/index.js
+++ b/src/components/stack-chart/index.js
@@ -10,14 +10,14 @@ import {
   selectedThreadSelectors,
   getCommittedRange,
   getProfileInterval,
-  getProfileViewOptions,
+  getPreviewSelection,
 } from '../../reducers/profile-view';
 import {
   getCategoryColorStrategy,
   getLabelingStrategy,
 } from '../../reducers/stack-chart';
 import StackSettings from '../shared/StackSettings';
-import { updateProfileSelection } from '../../actions/profile-view';
+import { updatePreviewSelection } from '../../actions/profile-view';
 
 import type { Thread } from '../../types/profile';
 import type {
@@ -27,7 +27,7 @@ import type {
 import type { StackTimingByDepth } from '../../profile-logic/stack-timing';
 import type { GetCategory } from '../../profile-logic/color-categories';
 import type { GetLabel } from '../../profile-logic/labeling-strategies';
-import type { ProfileSelection } from '../../types/actions';
+import type { PreviewSelection } from '../../types/actions';
 import type {
   ExplicitConnectOptions,
   ConnectedProps,
@@ -45,13 +45,13 @@ type StateProps = {|
   +interval: Milliseconds,
   +getCategory: GetCategory,
   +getLabel: GetLabel,
-  +selection: ProfileSelection,
+  +previewSelection: PreviewSelection,
   +threadName: string,
   +processDetails: string,
 |};
 
 type DispatchProps = {|
-  +updateProfileSelection: typeof updateProfileSelection,
+  +updatePreviewSelection: typeof updatePreviewSelection,
 |};
 
 type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
@@ -74,10 +74,10 @@ class StackChartGraph extends React.PureComponent<Props> {
       interval,
       getCategory,
       getLabel,
-      selection,
+      previewSelection,
       threadName,
       processDetails,
-      updateProfileSelection,
+      updatePreviewSelection,
     } = this.props;
 
     const maxViewportHeight = maxStackDepth * STACK_FRAME_HEIGHT;
@@ -91,7 +91,7 @@ class StackChartGraph extends React.PureComponent<Props> {
           </div>
           <StackChartCanvas
             viewportProps={{
-              selection,
+              previewSelection,
               timeRange,
               maxViewportHeight,
               viewportNeedsUpdate,
@@ -103,7 +103,7 @@ class StackChartGraph extends React.PureComponent<Props> {
               getCategory,
               getLabel,
               stackTimingByDepth,
-              updateProfileSelection,
+              updatePreviewSelection,
               rangeStart: timeRange.start,
               rangeEnd: timeRange.end,
               stackFrameHeight: STACK_FRAME_HEIGHT,
@@ -129,12 +129,12 @@ const options: ExplicitConnectOptions<{||}, StateProps, DispatchProps> = {
       interval: getProfileInterval(state),
       getCategory: getCategoryColorStrategy(state),
       getLabel: getLabelingStrategy(state),
-      selection: getProfileViewOptions(state).selection,
+      previewSelection: getPreviewSelection(state),
       threadName: selectedThreadSelectors.getFriendlyThreadName(state),
       processDetails: selectedThreadSelectors.getThreadProcessDetails(state),
     };
   },
-  mapDispatchToProps: { updateProfileSelection },
+  mapDispatchToProps: { updatePreviewSelection },
   component: StackChartGraph,
 };
 export default explicitConnect(options);

--- a/src/components/stack-chart/index.js
+++ b/src/components/stack-chart/index.js
@@ -8,7 +8,7 @@ import explicitConnect from '../../utils/connect';
 import StackChartCanvas from './Canvas';
 import {
   selectedThreadSelectors,
-  getDisplayRange,
+  getCommittedRange,
   getProfileInterval,
   getProfileViewOptions,
 } from '../../reducers/profile-view';
@@ -125,7 +125,7 @@ const options: ExplicitConnectOptions<{||}, StateProps, DispatchProps> = {
       thread: selectedThreadSelectors.getFilteredThread(state),
       maxStackDepth: selectedThreadSelectors.getCallNodeMaxDepth(state),
       stackTimingByDepth,
-      timeRange: getDisplayRange(state),
+      timeRange: getCommittedRange(state),
       interval: getProfileInterval(state),
       getCategory: getCategoryColorStrategy(state),
       getLabel: getLabelingStrategy(state),

--- a/src/components/timeline/Selection.js
+++ b/src/components/timeline/Selection.js
@@ -15,7 +15,7 @@ import {
 } from '../../reducers/profile-view';
 import {
   updatePreviewSelection,
-  commitRangeAndUnsetSelection,
+  commitRange,
 } from '../../actions/profile-view';
 import explicitConnect from '../../utils/connect';
 import classNames from 'classnames';
@@ -46,7 +46,7 @@ type StateProps = {|
 |};
 
 type DispatchProps = {|
-  +commitRangeAndUnsetSelection: typeof commitRangeAndUnsetSelection,
+  +commitRange: typeof commitRange,
   +updatePreviewSelection: typeof updatePreviewSelection,
 |};
 
@@ -268,13 +268,9 @@ class TimelineRulerAndSelection extends React.PureComponent<Props, State> {
 
   _zoomButtonOnClick = (e: SyntheticMouseEvent<>) => {
     e.stopPropagation();
-    const {
-      previewSelection,
-      zeroAt,
-      commitRangeAndUnsetSelection,
-    } = this.props;
+    const { previewSelection, zeroAt, commitRange } = this.props;
     if (previewSelection.hasSelection) {
-      commitRangeAndUnsetSelection(
+      commitRange(
         previewSelection.selectionStart - zeroAt,
         previewSelection.selectionEnd - zeroAt
       );
@@ -387,7 +383,7 @@ const options: ExplicitConnectOptions<OwnProps, StateProps, DispatchProps> = {
   }),
   mapDispatchToProps: {
     updatePreviewSelection,
-    commitRangeAndUnsetSelection,
+    commitRange,
   },
   component: TimelineRulerAndSelection,
 };

--- a/src/components/timeline/TracingMarkers.js
+++ b/src/components/timeline/TracingMarkers.js
@@ -14,7 +14,10 @@ import {
   overlayFills,
 } from '../../profile-logic/interval-marker-styles';
 import explicitConnect from '../../utils/connect';
-import { selectorsForThread, getSelection } from '../../reducers/profile-view';
+import {
+  selectorsForThread,
+  getPreviewSelection,
+} from '../../reducers/profile-view';
 import { getSelectedThreadIndex } from '../../reducers/url-state';
 import './TracingMarkers.css';
 
@@ -363,7 +366,7 @@ const jankOptions: ExplicitConnectOptions<OwnProps, StateProps, {||}> = {
       isSelected: threadIndex === selectedThread,
       styles: styles,
       overlayFills: overlayFills,
-      isModifyingSelection: getSelection(state).isModifying,
+      isModifyingSelection: getPreviewSelection(state).isModifying,
     };
   },
   component: TimelineTracingMarkers,
@@ -379,7 +382,7 @@ const tracingOptions: ExplicitConnectOptions<OwnProps, StateProps, {||}> = {
     const { threadIndex } = props;
     const selectors = selectorsForThread(threadIndex);
     const selectedThread = getSelectedThreadIndex(state);
-    const intervalMarkers = selectors.getRangeSelectionFilteredTracingMarkersForHeader(
+    const intervalMarkers = selectors.getCommittedRangeFilteredTracingMarkersForHeader(
       state
     );
     return {
@@ -387,7 +390,7 @@ const tracingOptions: ExplicitConnectOptions<OwnProps, StateProps, {||}> = {
       isSelected: threadIndex === selectedThread,
       styles,
       overlayFills,
-      isModifyingSelection: getSelection(state).isModifying,
+      isModifyingSelection: getPreviewSelection(state).isModifying,
     };
   },
   component: TimelineTracingMarkers,

--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -10,7 +10,7 @@ import StackGraph from './StackGraph';
 import {
   selectorsForThread,
   getProfileInterval,
-  getDisplayRange,
+  getCommittedRange,
 } from '../../reducers/profile-view';
 import { getSelectedThreadIndex } from '../../reducers/url-state';
 import {
@@ -186,7 +186,7 @@ const options: ExplicitConnectOptions<OwnProps, StateProps, DispatchProps> = {
     const { threadIndex } = ownProps;
     const selectors = selectorsForThread(threadIndex);
     const selectedThread = getSelectedThreadIndex(state);
-    const displayRange = getDisplayRange(state);
+    const committedRange = getCommittedRange(state);
     return {
       thread: selectors.getFilteredThread(state),
       callNodeInfo: selectors.getCallNodeInfo(state),
@@ -196,8 +196,8 @@ const options: ExplicitConnectOptions<OwnProps, StateProps, DispatchProps> = {
           : -1,
       unfilteredSamplesRange: selectors.unfilteredSamplesRange(state),
       interval: getProfileInterval(state),
-      rangeStart: displayRange.start,
-      rangeEnd: displayRange.end,
+      rangeStart: committedRange.start,
+      rangeEnd: committedRange.end,
     };
   },
   mapDispatchToProps: {

--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -23,7 +23,7 @@ import {
 } from './TracingMarkers';
 import {
   changeSelectedThread,
-  updateProfileSelection,
+  updatePreviewSelection,
   changeRightClickedTrack,
   changeSelectedCallNode,
   focusCallTree,
@@ -60,7 +60,7 @@ type StateProps = {|
 type DispatchProps = {|
   +changeSelectedThread: typeof changeSelectedThread,
   +changeRightClickedTrack: typeof changeRightClickedTrack,
-  +updateProfileSelection: typeof updateProfileSelection,
+  +updatePreviewSelection: typeof updatePreviewSelection,
   +changeSelectedCallNode: typeof changeSelectedCallNode,
   +focusCallTree: typeof focusCallTree,
 |};
@@ -101,10 +101,10 @@ class TimelineTrackThread extends PureComponent<Props> {
     const {
       rangeStart,
       rangeEnd,
-      updateProfileSelection,
+      updatePreviewSelection,
       changeSelectedThread,
     } = this.props;
-    updateProfileSelection({
+    updatePreviewSelection({
       hasSelection: true,
       isModifying: false,
       selectionStart: Math.max(rangeStart, start),
@@ -202,7 +202,7 @@ const options: ExplicitConnectOptions<OwnProps, StateProps, DispatchProps> = {
   },
   mapDispatchToProps: {
     changeSelectedThread,
-    updateProfileSelection,
+    updatePreviewSelection,
     changeRightClickedTrack,
     changeSelectedCallNode,
     focusCallTree,

--- a/src/components/timeline/index.js
+++ b/src/components/timeline/index.js
@@ -25,7 +25,7 @@ import type { SizeProps } from '../shared/WithSize';
 
 import {
   changeGlobalTrackOrder,
-  updateProfileSelection,
+  updatePreviewSelection,
   commitRangeAndUnsetSelection,
 } from '../../actions/profile-view';
 
@@ -50,7 +50,7 @@ type StateProps = {|
 type DispatchProps = {|
   +changeGlobalTrackOrder: typeof changeGlobalTrackOrder,
   +commitRangeAndUnsetSelection: typeof commitRangeAndUnsetSelection,
-  +updateProfileSelection: typeof updateProfileSelection,
+  +updatePreviewSelection: typeof updatePreviewSelection,
 |};
 
 type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
@@ -110,7 +110,7 @@ const options: ExplicitConnectOptions<OwnProps, StateProps, DispatchProps> = {
   }),
   mapDispatchToProps: {
     changeGlobalTrackOrder,
-    updateProfileSelection,
+    updatePreviewSelection,
     commitRangeAndUnsetSelection,
   },
   component: Timeline,

--- a/src/components/timeline/index.js
+++ b/src/components/timeline/index.js
@@ -26,7 +26,7 @@ import type { SizeProps } from '../shared/WithSize';
 import {
   changeGlobalTrackOrder,
   updatePreviewSelection,
-  commitRangeAndUnsetSelection,
+  commitRange,
 } from '../../actions/profile-view';
 
 import type { TrackIndex, GlobalTrack } from '../../types/profile-derived';
@@ -49,7 +49,7 @@ type StateProps = {|
 
 type DispatchProps = {|
   +changeGlobalTrackOrder: typeof changeGlobalTrackOrder,
-  +commitRangeAndUnsetSelection: typeof commitRangeAndUnsetSelection,
+  +commitRange: typeof commitRange,
   +updatePreviewSelection: typeof updatePreviewSelection,
 |};
 
@@ -111,7 +111,7 @@ const options: ExplicitConnectOptions<OwnProps, StateProps, DispatchProps> = {
   mapDispatchToProps: {
     changeGlobalTrackOrder,
     updatePreviewSelection,
-    commitRangeAndUnsetSelection,
+    commitRange,
   },
   component: Timeline,
 };

--- a/src/components/timeline/index.js
+++ b/src/components/timeline/index.js
@@ -13,7 +13,7 @@ import Reorderable from '../shared/Reorderable';
 import { withSize } from '../shared/WithSize';
 import explicitConnect from '../../utils/connect';
 import {
-  getDisplayRange,
+  getCommittedRange,
   getZeroAt,
   getGlobalTracks,
   getGlobalTrackReferences,
@@ -26,7 +26,7 @@ import type { SizeProps } from '../shared/WithSize';
 import {
   changeGlobalTrackOrder,
   updateProfileSelection,
-  addRangeFilterAndUnsetSelection,
+  commitRangeAndUnsetSelection,
 } from '../../actions/profile-view';
 
 import type { TrackIndex, GlobalTrack } from '../../types/profile-derived';
@@ -40,17 +40,16 @@ import type {
 type OwnProps = SizeProps;
 
 type StateProps = {|
-  +displayRange: StartEndRange,
+  +committedRange: StartEndRange,
   +globalTracks: GlobalTrack[],
   +globalTrackOrder: TrackIndex[],
   +globalTrackReferences: TrackReference[],
-  +timeRange: StartEndRange,
   +zeroAt: Milliseconds,
 |};
 
 type DispatchProps = {|
   +changeGlobalTrackOrder: typeof changeGlobalTrackOrder,
-  +addRangeFilterAndUnsetSelection: typeof addRangeFilterAndUnsetSelection,
+  +commitRangeAndUnsetSelection: typeof commitRangeAndUnsetSelection,
   +updateProfileSelection: typeof updateProfileSelection,
 |};
 
@@ -62,7 +61,7 @@ class Timeline extends PureComponent<Props> {
       globalTracks,
       globalTrackOrder,
       changeGlobalTrackOrder,
-      displayRange,
+      committedRange,
       zeroAt,
       width,
       globalTrackReferences,
@@ -72,8 +71,8 @@ class Timeline extends PureComponent<Props> {
       <TimelineSelection width={width}>
         <TimelineRuler
           zeroAt={zeroAt}
-          rangeStart={displayRange.start}
-          rangeEnd={displayRange.end}
+          rangeStart={committedRange.start}
+          rangeEnd={committedRange.end}
           width={width}
         />
         <OverflowEdgeIndicator className="timelineOverflowEdgeIndicator">
@@ -106,14 +105,13 @@ const options: ExplicitConnectOptions<OwnProps, StateProps, DispatchProps> = {
     globalTracks: getGlobalTracks(state),
     globalTrackOrder: getGlobalTrackOrder(state),
     globalTrackReferences: getGlobalTrackReferences(state),
-    timeRange: getDisplayRange(state),
-    displayRange: getDisplayRange(state),
+    committedRange: getCommittedRange(state),
     zeroAt: getZeroAt(state),
   }),
   mapDispatchToProps: {
     changeGlobalTrackOrder,
     updateProfileSelection,
-    addRangeFilterAndUnsetSelection,
+    commitRangeAndUnsetSelection,
   },
   component: Timeline,
 };

--- a/src/profile-logic/committed-ranges.js
+++ b/src/profile-logic/committed-ranges.js
@@ -57,9 +57,9 @@ export function getFormattedTimeLength(length: number): string {
 }
 
 export function getCommittedRangeLabels(
-  commitedRanges: StartEndRange[]
+  committedRanges: StartEndRange[]
 ): string[] {
-  const labels = commitedRanges.map(range =>
+  const labels = committedRanges.map(range =>
     getFormattedTimeLength(range.end - range.start)
   );
   labels.unshift('Full Range');

--- a/src/profile-logic/committed-ranges.js
+++ b/src/profile-logic/committed-ranges.js
@@ -5,7 +5,19 @@
 
 import type { StartEndRange } from '../types/units';
 
-export function parseRangeFilters(stringValue: string = ''): StartEndRange[] {
+/**
+ * Users can make preview range selections on the profile, and then can commit these
+ * to drill down into a profile. This file contains functions for working with these
+ * committed ranges.
+ */
+
+/**
+ * Parse URL encoded committed ranges with the form: "start-end~start-end", where
+ * `start` and `end` are positive or negative float numbers.
+ */
+export function parseCommittedRanges(
+  stringValue: string = ''
+): StartEndRange[] {
   if (!stringValue) {
     return [];
   }
@@ -18,7 +30,11 @@ export function parseRangeFilters(stringValue: string = ''): StartEndRange[] {
   });
 }
 
-export function stringifyRangeFilters(
+/**
+ * Stringify committed ranges into the following form: "start-end~start-end", where
+ * `start` and `end` are float numbers.
+ */
+export function stringifyCommittedRanges(
   arrayValue: StartEndRange[] = []
 ): string {
   return arrayValue
@@ -40,8 +56,10 @@ export function getFormattedTimeLength(length: number): string {
   return `${length.toFixed(0)} ms`;
 }
 
-export function getRangeFilterLabels(rangeFilters: StartEndRange[]): string[] {
-  const labels = rangeFilters.map(range =>
+export function getCommittedRangeLabels(
+  commitedRanges: StartEndRange[]
+): string[] {
+  const labels = commitedRanges.map(range =>
     getFormattedTimeLength(range.end - range.start)
   );
   labels.unshift('Full Range');

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -46,7 +46,7 @@ import type {
 import type { Milliseconds, StartEndRange } from '../types/units';
 import type {
   Action,
-  ProfileSelection,
+  PreviewSelection,
   RequestedLib,
   TrackReference,
 } from '../types/actions';
@@ -381,14 +381,14 @@ function waitingForLibs(state: Set<RequestedLib> = new Set(), action: Action) {
   }
 }
 
-function selection(
-  state: ProfileSelection = { hasSelection: false, isModifying: false },
+function previewSelection(
+  state: PreviewSelection = { hasSelection: false, isModifying: false },
   action: Action
-): ProfileSelection {
+): PreviewSelection {
   // TODO: Rename to timeRangeSelection
   switch (action.type) {
-    case 'UPDATE_PROFILE_SELECTION':
-      return action.selection;
+    case 'UPDATE_PREVIEW_SELECTION':
+      return action.previewSelection;
     default:
       return state;
   }
@@ -524,7 +524,7 @@ export default wrapReducerInResetter(
       perThread: viewOptionsPerThread,
       symbolicationStatus,
       waitingForLibs,
-      selection,
+      previewSelection,
       scrollToSelectionGeneration,
       focusCallTreeGeneration,
       rootRange,
@@ -610,8 +610,8 @@ export const getThreadNames = (state: State): string[] =>
   getProfile(state).threads.map(t => t.name);
 export const getRightClickedTrack = (state: State) =>
   getProfileViewOptions(state).rightClickedTrack;
-export const getSelection = (state: State) =>
-  getProfileViewOptions(state).selection;
+export const getPreviewSelection = (state: State) =>
+  getProfileViewOptions(state).previewSelection;
 
 /**
  * Tracks
@@ -725,10 +725,10 @@ export type SelectorsForThread = {
   getTracingMarkers: State => TracingMarker[],
   getTracingMarkersForView: State => TracingMarker[],
   getMarkerTiming: State => MarkerTimingRows,
-  getRangeSelectionFilteredTracingMarkers: State => TracingMarker[],
-  getRangeSelectionFilteredTracingMarkersForHeader: State => TracingMarker[],
+  getCommittedRangeFilteredTracingMarkers: State => TracingMarker[],
+  getCommittedRangeFilteredTracingMarkersForHeader: State => TracingMarker[],
   getFilteredThread: State => Thread,
-  getRangeSelectionFilteredThread: State => Thread,
+  getPreviewFilteredThread: State => Thread,
   getCallNodeInfo: State => CallNodeInfo,
   getCallNodeMaxDepth: State => number,
   getSelectedCallNodePath: State => CallNodePath,
@@ -760,7 +760,7 @@ export const selectorsForThread = (
      * 3. Transform - Apply the transform stack that modifies the stacks and samples.
      * 4. Implementation - Modify stacks and samples to only show a single implementation.
      * 5. Search - Exclude samples that don't include some text in the stack.
-     * 6. Range selection - Only include samples that are within a user's sub-selection.
+     * 6. Preview - Only include samples that are within a user's preview range selection.
      */
     const getThread = (state: State): Thread =>
       getProfile(state).threads[threadIndex];
@@ -869,14 +869,14 @@ export const selectorsForThread = (
           : thread;
       }
     );
-    const getRangeSelectionFilteredThread = createSelector(
+    const getPreviewFilteredThread = createSelector(
       getFilteredThread,
-      getSelection,
-      (thread, selection): Thread => {
-        if (!selection.hasSelection) {
+      getPreviewSelection,
+      (thread, previewSelection): Thread => {
+        if (!previewSelection.hasSelection) {
           return thread;
         }
-        const { selectionStart, selectionEnd } = selection;
+        const { selectionStart, selectionEnd } = previewSelection;
         return ProfileData.filterThreadToRange(
           thread,
           selectionStart,
@@ -941,7 +941,7 @@ export const selectorsForThread = (
       getTracingMarkersForView,
       MarkerTiming.getMarkerTiming
     );
-    const getRangeSelectionFilteredTracingMarkers = createSelector(
+    const getCommittedRangeFilteredTracingMarkers = createSelector(
       getTracingMarkers,
       getCommittedRange,
       (markers, range): TracingMarker[] => {
@@ -949,8 +949,8 @@ export const selectorsForThread = (
         return ProfileData.filterTracingMarkersToRange(markers, start, end);
       }
     );
-    const getRangeSelectionFilteredTracingMarkersForHeader = createSelector(
-      getRangeSelectionFilteredTracingMarkers,
+    const getCommittedRangeFilteredTracingMarkersForHeader = createSelector(
+      getCommittedRangeFilteredTracingMarkers,
       (markers): TracingMarker[] =>
         markers.filter(
           tm =>
@@ -1011,7 +1011,7 @@ export const selectorsForThread = (
         )
     );
     const getCallTree = createSelector(
-      getRangeSelectionFilteredThread,
+      getPreviewFilteredThread,
       getProfileInterval,
       getCallNodeInfo,
       getCategories,
@@ -1027,7 +1027,7 @@ export const selectorsForThread = (
       StackTiming.getStackTimingByDepth
     );
     const getCallNodeMaxDepthForFlameGraph = createSelector(
-      getRangeSelectionFilteredThread,
+      getPreviewFilteredThread,
       getCallNodeInfo,
       ProfileData.computeCallNodeMaxDepth
     );
@@ -1036,7 +1036,7 @@ export const selectorsForThread = (
       FlameGraph.getFlameGraphTiming
     );
     const getSearchFilteredMarkers = createSelector(
-      getRangeSelectionFilteredThread,
+      getPreviewFilteredThread,
       UrlState.getMarkersSearchString,
       ProfileData.getSearchFilteredMarkers
     );
@@ -1068,10 +1068,10 @@ export const selectorsForThread = (
       getTracingMarkers,
       getTracingMarkersForView,
       getMarkerTiming,
-      getRangeSelectionFilteredTracingMarkers,
-      getRangeSelectionFilteredTracingMarkersForHeader,
+      getCommittedRangeFilteredTracingMarkers,
+      getCommittedRangeFilteredTracingMarkersForHeader,
       getFilteredThread,
-      getRangeSelectionFilteredThread,
+      getPreviewFilteredThread,
       getCallNodeInfo,
       getCallNodeMaxDepth,
       getSelectedCallNodePath,
@@ -1158,7 +1158,7 @@ export const selectedNodeSelectors: SelectorsForNode = (() => {
     selectedThreadSelectors.getCallNodeInfo,
     getProfileInterval,
     UrlState.getInvertCallstack,
-    selectedThreadSelectors.getRangeSelectionFilteredThread,
+    selectedThreadSelectors.getPreviewFilteredThread,
     (
       selectedPath,
       callNodeInfo,

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -574,13 +574,13 @@ export const getTabOrder = createSelector(
   viewOptions => viewOptions.tabOrder
 );
 
-export const getDisplayRange = createSelector(
+export const getCommittedRange = createSelector(
   (state: State) => getProfileViewOptions(state).rootRange,
   (state: State) => getProfileViewOptions(state).zeroAt,
-  UrlState.getRangeFilters,
-  (rootRange, zeroAt, rangeFilters): StartEndRange => {
-    if (rangeFilters.length > 0) {
-      let { start, end } = rangeFilters[rangeFilters.length - 1];
+  UrlState.getAllCommittedRanges,
+  (rootRange, zeroAt, committedRanges): StartEndRange => {
+    if (committedRanges.length > 0) {
+      let { start, end } = committedRanges[committedRanges.length - 1];
       start += zeroAt;
       end += zeroAt;
       return { start, end };
@@ -756,7 +756,7 @@ export const selectorsForThread = (
      * interactions. The transforms are order dependendent.
      *
      * 1. Unfiltered - The first selector gets the unmodified original thread.
-     * 2. Range - New samples table with only samples in range.
+     * 2. Range - New samples table with only samples in the committed range.
      * 3. Transform - Apply the transform stack that modifies the stacks and samples.
      * 4. Implementation - Modify stacks and samples to only show a single implementation.
      * 5. Search - Exclude samples that don't include some text in the stack.
@@ -766,7 +766,7 @@ export const selectorsForThread = (
       getProfile(state).threads[threadIndex];
     const getRangeFilteredThread = createSelector(
       getThread,
-      getDisplayRange,
+      getCommittedRange,
       (thread, range): Thread => {
         const { start, end } = range;
         return ProfileData.filterThreadToRange(thread, start, end);
@@ -943,7 +943,7 @@ export const selectorsForThread = (
     );
     const getRangeSelectionFilteredTracingMarkers = createSelector(
       getTracingMarkers,
-      getDisplayRange,
+      getCommittedRange,
       (markers, range): TracingMarker[] => {
         const { start, end } = range;
         return ProfileData.filterTracingMarkersToRange(markers, start, end);

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -389,6 +389,9 @@ function previewSelection(
   switch (action.type) {
     case 'UPDATE_PREVIEW_SELECTION':
       return action.previewSelection;
+    case 'COMMIT_RANGE':
+    case 'POP_COMMITTED_RANGES':
+      return { hasSelection: false, isModifying: false };
     default:
       return state;
   }

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -8,7 +8,7 @@ import escapeStringRegexp from 'escape-string-regexp';
 import { createSelector } from 'reselect';
 import { ensureExists } from '../utils/flow';
 import { urlFromState } from '../app-logic/url-handling';
-import * as RangeFilters from '../profile-logic/range-filters';
+import * as CommittedRanges from '../profile-logic/committed-ranges';
 
 import type { ThreadIndex, Pid } from '../types/profile';
 import type { TrackIndex } from '../types/profile-derived';
@@ -64,14 +64,14 @@ function selectedTab(state: TabSlug = 'calltree', action: Action) {
   }
 }
 
-function rangeFilters(state: StartEndRange[] = [], action: Action) {
+function committedRanges(state: StartEndRange[] = [], action: Action) {
   switch (action.type) {
-    case 'ADD_RANGE_FILTER': {
+    case 'COMMIT_RANGE': {
       const { start, end } = action;
       return [...state, { start, end }];
     }
-    case 'POP_RANGE_FILTERS':
-      return state.slice(0, action.firstRemovedFilterIndex);
+    case 'POP_COMMITTED_RANGES':
+      return state.slice(0, action.firstPoppedFilterIndex);
     default:
       return state;
   }
@@ -122,10 +122,10 @@ function transforms(state: TransformStacksPerThread = {}, action: Action) {
       });
     }
     case 'POP_TRANSFORMS_FROM_STACK': {
-      const { threadIndex, firstRemovedFilterIndex } = action;
+      const { threadIndex, firstPoppedFilterIndex } = action;
       const transforms = state[threadIndex] || [];
       return Object.assign({}, state, {
-        [threadIndex]: transforms.slice(0, firstRemovedFilterIndex),
+        [threadIndex]: transforms.slice(0, firstPoppedFilterIndex),
       });
     }
     default:
@@ -267,7 +267,7 @@ const profileSpecific = combineReducers({
   localTrackOrderByPid,
   implementation,
   invertCallstack,
-  rangeFilters,
+  committedRanges,
   callTreeSearchString,
   markersSearchString,
   transforms,
@@ -325,8 +325,8 @@ export const getProfileSpecificState = (state: State) =>
 export const getDataSource = (state: State) => getUrlState(state).dataSource;
 export const getHash = (state: State) => getUrlState(state).hash;
 export const getProfileUrl = (state: State) => getUrlState(state).profileUrl;
-export const getRangeFilters = (state: State) =>
-  getProfileSpecificState(state).rangeFilters;
+export const getAllCommittedRanges = (state: State) =>
+  getProfileSpecificState(state).committedRanges;
 export const getImplementationFilter = (state: State) =>
   getProfileSpecificState(state).implementation;
 export const getInvertCallstack = (state: State) =>
@@ -436,7 +436,7 @@ export const getProfileName: State => null | string = createSelector(
   }
 );
 
-export const getRangeFilterLabels = createSelector(
-  getRangeFilters,
-  RangeFilters.getRangeFilterLabels
+export const getCommittedRangeLabels = createSelector(
+  getAllCommittedRanges,
+  CommittedRanges.getCommittedRangeLabels
 );

--- a/src/test/components/ProfileCallTreeView.test.js
+++ b/src/test/components/ProfileCallTreeView.test.js
@@ -19,7 +19,7 @@ import {
   changeCallTreeSearchString,
   changeImplementationFilter,
   changeInvertCallstack,
-  addRangeFilter,
+  commitRange,
 } from '../../actions/profile-view';
 
 describe('calltree/ProfileCallTreeView', function() {
@@ -135,7 +135,7 @@ describe('calltree/ProfileCallTreeView EmptyReasons', function() {
 
   it('shows reasons for being out of range of a threads samples', function() {
     const store = storeWithProfile(profile);
-    store.dispatch(addRangeFilter(5, 10));
+    store.dispatch(commitRange(5, 10));
     expect(renderWithStore(store)).toMatchSnapshot();
   });
 

--- a/src/test/components/TrackThread.test.js
+++ b/src/test/components/TrackThread.test.js
@@ -14,7 +14,7 @@ import { changeSelectedThread } from '../../actions/profile-view';
 import TrackThread from '../../components/timeline/TrackThread';
 import {
   selectedThreadSelectors,
-  getSelection,
+  getPreviewSelection,
 } from '../../reducers/profile-view';
 import { getSelectedThreadIndex } from '../../reducers/url-state';
 import mockCanvasContext from '../fixtures/mocks/canvas-context';
@@ -164,7 +164,7 @@ describe('timeline/TrackThread', function() {
     function clickAndGetMarkerName(pageX: number) {
       tracingMarkersCanvas.simulate('mousedown', getMouseEvent({ pageX }));
       tracingMarkersCanvas.simulate('mouseup', getMouseEvent({ pageX }));
-      return getSelection(getState());
+      return getPreviewSelection(getState());
     }
 
     expect(clickAndGetMarkerName(STACK_1_X_POSITION)).toMatchObject({

--- a/src/test/store/__snapshots__/profile-view.test.js.snap
+++ b/src/test/store/__snapshots__/profile-view.test.js.snap
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`snapshots of selectors/profile-view matches the last stored run of getProfile 1`] = `
+exports[
+  `snapshots of selectors/profile-view matches the last stored run of getProfile 1`
+] = `
 Object {
   "meta": Object {
     "abi": "",
@@ -450,7 +452,9 @@ Object {
 }
 `;
 
-exports[`snapshots of selectors/profile-view matches the last stored run of getThreads 1`] = `
+exports[
+  `snapshots of selectors/profile-view matches the last stored run of getThreads 1`
+] = `
 Array [
   Object {
     "frameTable": Object {
@@ -860,7 +864,9 @@ Array [
 ]
 `;
 
-exports[`snapshots of selectors/profile-view matches the last stored run of selectedNodeSelectors.getTimingsForSidebar 1`] = `
+exports[
+  `snapshots of selectors/profile-view matches the last stored run of selectedNodeSelectors.getTimingsForSidebar 1`
+] = `
 Object {
   "forFunc": Object {
     "selfTime": Object {
@@ -890,7 +896,9 @@ Object {
 }
 `;
 
-exports[`snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getCallNodeInfo 1`] = `
+exports[
+  `snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getCallNodeInfo 1`
+] = `
 Object {
   "callNodeTable": Object {
     "category": Int32Array [
@@ -948,7 +956,9 @@ Object {
 }
 `;
 
-exports[`snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getCallTree 1`] = `
+exports[
+  `snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getCallTree 1`
+] = `
 CallTree {
   "_callNodeChildCount": Uint32Array [
     1,
@@ -1151,7 +1161,9 @@ CallTree {
 }
 `;
 
-exports[`snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getFilteredThread 1`] = `
+exports[
+  `snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getFilteredThread 1`
+] = `
 Object {
   "frameTable": Object {
     "address": Array [
@@ -1416,7 +1428,9 @@ Object {
 }
 `;
 
-exports[`snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getFlameGraphTiming 1`] = `
+exports[
+  `snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getFlameGraphTiming 1`
+] = `
 Array [
   Object {
     "callNode": Array [
@@ -1481,7 +1495,9 @@ Array [
 ]
 `;
 
-exports[`snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getJankInstances 1`] = `
+exports[
+  `snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getJankInstances 1`
+] = `
 Array [
   Object {
     "data": null,
@@ -1493,7 +1509,9 @@ Array [
 ]
 `;
 
-exports[`snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getMarkerTiming 1`] = `
+exports[
+  `snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getMarkerTiming 1`
+] = `
 Array [
   Object {
     "end": Array [
@@ -1594,7 +1612,9 @@ Array [
 ]
 `;
 
-exports[`snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getProcessedMarkersThread 1`] = `
+exports[
+  `snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getProcessedMarkersThread 1`
+] = `
 Object {
   "frameTable": Object {
     "address": Array [
@@ -1900,7 +1920,9 @@ Object {
 }
 `;
 
-exports[`snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getRangeAndTransformFilteredThread 1`] = `
+exports[
+  `snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getRangeAndTransformFilteredThread 1`
+] = `
 Object {
   "frameTable": Object {
     "address": Array [
@@ -2165,7 +2187,9 @@ Object {
 }
 `;
 
-exports[`snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getRangeFilteredThread 1`] = `
+exports[
+  `snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getRangeFilteredThread 1`
+] = `
 Object {
   "frameTable": Object {
     "address": Array [
@@ -2433,7 +2457,9 @@ Object {
 }
 `;
 
-exports[`snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getRangeSelectionFilteredThread 1`] = `
+exports[
+  `snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getPreviewFilteredThread 1`
+] = `
 Object {
   "frameTable": Object {
     "address": Array [
@@ -2685,7 +2711,9 @@ Object {
 }
 `;
 
-exports[`snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getRangeSelectionFilteredTracingMarkers 1`] = `
+exports[
+  `snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getCommittedRangeFilteredTracingMarkers 1`
+] = `
 Array [
   Object {
     "data": null,
@@ -2711,7 +2739,9 @@ Array [
 ]
 `;
 
-exports[`snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getRangeSelectionFilteredTracingMarkersForHeader 1`] = `
+exports[
+  `snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getCommittedRangeFilteredTracingMarkersForHeader 1`
+] = `
 Array [
   Object {
     "data": null,
@@ -2737,7 +2767,9 @@ Array [
 ]
 `;
 
-exports[`snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getSearchFilteredMarkers 1`] = `
+exports[
+  `snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getSearchFilteredMarkers 1`
+] = `
 Object {
   "data": Array [
     null,
@@ -2755,12 +2787,16 @@ Object {
 }
 `;
 
-exports[`snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getThreadProcessDetails 1`] = `
+exports[
+  `snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getThreadProcessDetails 1`
+] = `
 "thread: \\"Thread with samples\\" (0)
 process: \\"default\\" (0)"
 `;
 
-exports[`snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getTracingMarkers 1`] = `
+exports[
+  `snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getTracingMarkers 1`
+] = `
 Array [
   Object {
     "data": null,
@@ -2807,7 +2843,9 @@ Array [
 ]
 `;
 
-exports[`snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getViewOptions 1`] = `
+exports[
+  `snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getViewOptions 1`
+] = `
 Object {
   "expandedCallNodePaths": PathSet {
     "_table": Map {

--- a/src/test/store/actions.test.js
+++ b/src/test/store/actions.test.js
@@ -10,7 +10,7 @@ import * as UrlStateSelectors from '../../reducers/url-state';
 import {
   changeCallTreeSearchString,
   changeInvertCallstack,
-  updateProfileSelection,
+  updatePreviewSelection,
   changeImplementationFilter,
   changeSelectedCallNode,
 } from '../../actions/profile-view';
@@ -304,20 +304,20 @@ describe('actions/changeImplementationFilter', function() {
   });
 });
 
-describe('actions/updateProfileSelection', function() {
+describe('actions/updatePreviewSelection', function() {
   it('can update the selection with new values', function() {
     const store = storeWithProfile();
 
-    const initialSelection = ProfileViewSelectors.getProfileViewOptions(
+    const initialSelection = ProfileViewSelectors.getPreviewSelection(
       store.getState()
-    ).selection;
+    );
     expect(initialSelection).toEqual({
       hasSelection: false,
       isModifying: false,
     });
 
     store.dispatch(
-      updateProfileSelection({
+      updatePreviewSelection({
         hasSelection: true,
         isModifying: false,
         selectionStart: 100,
@@ -325,9 +325,9 @@ describe('actions/updateProfileSelection', function() {
       })
     );
 
-    const secondSelection = ProfileViewSelectors.getProfileViewOptions(
+    const secondSelection = ProfileViewSelectors.getPreviewSelection(
       store.getState()
-    ).selection;
+    );
     expect(secondSelection).toEqual({
       hasSelection: true,
       isModifying: false,

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -473,7 +473,7 @@ describe('actions/ProfileView', function() {
         selectionStart: 1,
       });
 
-      dispatch(ProfileView.commitRangeAndUnsetSelection(2, 8));
+      dispatch(ProfileView.commitRange(2, 8));
       expect(UrlStateSelectors.getAllCommittedRanges(getState())).toEqual([
         { start: 0, end: 10 },
         { start: 2, end: 8 },
@@ -496,7 +496,7 @@ describe('actions/ProfileView', function() {
       return store;
     }
 
-    it('pops a commited range', function() {
+    it('pops a committed range', function() {
       const { getState, dispatch } = setupStore();
       expect(UrlStateSelectors.getAllCommittedRanges(getState())).toEqual([
         { start: 0, end: 10 },
@@ -534,7 +534,7 @@ describe('actions/ProfileView', function() {
         { start: 3, end: 7 },
       ]);
 
-      dispatch(ProfileView.popCommittedRangesAndUnsetSelection(2));
+      dispatch(ProfileView.popCommittedRanges(2));
       expect(UrlStateSelectors.getAllCommittedRanges(getState())).toEqual([
         { start: 0, end: 10 },
         { start: 1, end: 9 },

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -431,31 +431,31 @@ describe('actions/ProfileView', function() {
     });
   });
 
-  describe('addRangeFilter', function() {
-    it('adds a range filter', function() {
+  describe('commitRange', function() {
+    it('commits a range', function() {
       const { profile } = getProfileFromTextSamples('A');
       const { dispatch, getState } = storeWithProfile(profile);
 
-      expect(UrlStateSelectors.getRangeFilters(getState())).toEqual([]);
-      dispatch(ProfileView.addRangeFilter(0, 10));
-      expect(UrlStateSelectors.getRangeFilters(getState())).toEqual([
+      expect(UrlStateSelectors.getAllCommittedRanges(getState())).toEqual([]);
+      dispatch(ProfileView.commitRange(0, 10));
+      expect(UrlStateSelectors.getAllCommittedRanges(getState())).toEqual([
         { start: 0, end: 10 },
       ]);
 
-      dispatch(ProfileView.addRangeFilter(1, 9));
-      expect(UrlStateSelectors.getRangeFilters(getState())).toEqual([
+      dispatch(ProfileView.commitRange(1, 9));
+      expect(UrlStateSelectors.getAllCommittedRanges(getState())).toEqual([
         { start: 0, end: 10 },
         { start: 1, end: 9 },
       ]);
     });
   });
 
-  describe('addRangeFilterAndUnsetSelection', function() {
-    it('adds a range filter and unsets a selection', function() {
+  describe('commitRangeAndUnsetSelection', function() {
+    it('commits a range and unsets a selection', function() {
       const { profile } = getProfileFromTextSamples('A');
       const { dispatch, getState } = storeWithProfile(profile);
 
-      dispatch(ProfileView.addRangeFilter(0, 10));
+      dispatch(ProfileView.commitRange(0, 10));
       dispatch(
         ProfileView.updateProfileSelection({
           hasSelection: true,
@@ -464,7 +464,7 @@ describe('actions/ProfileView', function() {
           selectionEnd: 9,
         })
       );
-      expect(UrlStateSelectors.getRangeFilters(getState())).toEqual([
+      expect(UrlStateSelectors.getAllCommittedRanges(getState())).toEqual([
         { start: 0, end: 10 },
       ]);
       expect(
@@ -476,8 +476,8 @@ describe('actions/ProfileView', function() {
         selectionStart: 1,
       });
 
-      dispatch(ProfileView.addRangeFilterAndUnsetSelection(2, 8));
-      expect(UrlStateSelectors.getRangeFilters(getState())).toEqual([
+      dispatch(ProfileView.commitRangeAndUnsetSelection(2, 8));
+      expect(UrlStateSelectors.getAllCommittedRanges(getState())).toEqual([
         { start: 0, end: 10 },
         { start: 2, end: 8 },
       ]);
@@ -490,33 +490,33 @@ describe('actions/ProfileView', function() {
     });
   });
 
-  describe('popRangeFilters', function() {
+  describe('popCommittedRanges', function() {
     function setupStore() {
       const { profile } = getProfileFromTextSamples('A');
       const store = storeWithProfile(profile);
-      store.dispatch(ProfileView.addRangeFilter(0, 10));
-      store.dispatch(ProfileView.addRangeFilter(1, 9));
-      store.dispatch(ProfileView.addRangeFilter(2, 8));
-      store.dispatch(ProfileView.addRangeFilter(3, 7));
+      store.dispatch(ProfileView.commitRange(0, 10));
+      store.dispatch(ProfileView.commitRange(1, 9));
+      store.dispatch(ProfileView.commitRange(2, 8));
+      store.dispatch(ProfileView.commitRange(3, 7));
       return store;
     }
 
-    it('pops a range filter', function() {
+    it('pops a commited range', function() {
       const { getState, dispatch } = setupStore();
-      expect(UrlStateSelectors.getRangeFilters(getState())).toEqual([
+      expect(UrlStateSelectors.getAllCommittedRanges(getState())).toEqual([
         { start: 0, end: 10 },
         { start: 1, end: 9 },
         { start: 2, end: 8 },
         { start: 3, end: 7 },
       ]);
-      dispatch(ProfileView.popRangeFilters(2));
-      expect(UrlStateSelectors.getRangeFilters(getState())).toEqual([
+      dispatch(ProfileView.popCommittedRanges(2));
+      expect(UrlStateSelectors.getAllCommittedRanges(getState())).toEqual([
         { start: 0, end: 10 },
         { start: 1, end: 9 },
       ]);
     });
 
-    it('pops a range filter and unsets the selection', function() {
+    it('pops a committed range and unsets the selection', function() {
       const { getState, dispatch } = setupStore();
       dispatch(
         ProfileView.updateProfileSelection({
@@ -534,15 +534,15 @@ describe('actions/ProfileView', function() {
         selectionEnd: 9,
         selectionStart: 1,
       });
-      expect(UrlStateSelectors.getRangeFilters(getState())).toEqual([
+      expect(UrlStateSelectors.getAllCommittedRanges(getState())).toEqual([
         { start: 0, end: 10 },
         { start: 1, end: 9 },
         { start: 2, end: 8 },
         { start: 3, end: 7 },
       ]);
 
-      dispatch(ProfileView.popRangeFiltersAndUnsetSelection(2));
-      expect(UrlStateSelectors.getRangeFilters(getState())).toEqual([
+      dispatch(ProfileView.popCommittedRangesAndUnsetSelection(2));
+      expect(UrlStateSelectors.getAllCommittedRanges(getState())).toEqual([
         { start: 0, end: 10 },
         { start: 1, end: 9 },
       ]);
@@ -677,7 +677,7 @@ describe('snapshots of selectors/profile-view', function() {
     dispatch(ProfileView.changeExpandedCallNodes(0, [[A], [A, B]]));
     dispatch(ProfileView.changeSelectedCallNode(0, [A, B]));
     dispatch(ProfileView.changeSelectedMarker(0, 1));
-    dispatch(ProfileView.addRangeFilter(3, 7)); // Reminder: upper bound "7" is exclusive.
+    dispatch(ProfileView.commitRange(3, 7)); // Reminder: upper bound "7" is exclusive.
     dispatch(
       ProfileView.updateProfileSelection({
         hasSelection: true,

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -404,25 +404,24 @@ describe('actions/ProfileView', function() {
     });
   });
 
-  describe('updateProfileSelection', function() {
+  describe('updatePreviewSelection', function() {
     it('updates the profile selection', function() {
       const { profile } = getProfileFromTextSamples('A');
       const { dispatch, getState } = storeWithProfile(profile);
 
-      expect(
-        ProfileViewSelectors.getProfileViewOptions(getState()).selection
-      ).toEqual({ hasSelection: false, isModifying: false });
+      expect(ProfileViewSelectors.getPreviewSelection(getState())).toEqual({
+        hasSelection: false,
+        isModifying: false,
+      });
       dispatch(
-        ProfileView.updateProfileSelection({
+        ProfileView.updatePreviewSelection({
           hasSelection: true,
           isModifying: false,
           selectionStart: 0,
           selectionEnd: 1,
         })
       );
-      expect(
-        ProfileViewSelectors.getProfileViewOptions(getState()).selection
-      ).toEqual({
+      expect(ProfileViewSelectors.getPreviewSelection(getState())).toEqual({
         hasSelection: true,
         isModifying: false,
         selectionStart: 0,
@@ -457,7 +456,7 @@ describe('actions/ProfileView', function() {
 
       dispatch(ProfileView.commitRange(0, 10));
       dispatch(
-        ProfileView.updateProfileSelection({
+        ProfileView.updatePreviewSelection({
           hasSelection: true,
           isModifying: false,
           selectionStart: 1,
@@ -467,9 +466,7 @@ describe('actions/ProfileView', function() {
       expect(UrlStateSelectors.getAllCommittedRanges(getState())).toEqual([
         { start: 0, end: 10 },
       ]);
-      expect(
-        ProfileViewSelectors.getProfileViewOptions(getState()).selection
-      ).toEqual({
+      expect(ProfileViewSelectors.getPreviewSelection(getState())).toEqual({
         hasSelection: true,
         isModifying: false,
         selectionEnd: 9,
@@ -481,9 +478,7 @@ describe('actions/ProfileView', function() {
         { start: 0, end: 10 },
         { start: 2, end: 8 },
       ]);
-      expect(
-        ProfileViewSelectors.getProfileViewOptions(getState()).selection
-      ).toEqual({
+      expect(ProfileViewSelectors.getPreviewSelection(getState())).toEqual({
         hasSelection: false,
         isModifying: false,
       });
@@ -519,16 +514,14 @@ describe('actions/ProfileView', function() {
     it('pops a committed range and unsets the selection', function() {
       const { getState, dispatch } = setupStore();
       dispatch(
-        ProfileView.updateProfileSelection({
+        ProfileView.updatePreviewSelection({
           hasSelection: true,
           isModifying: false,
           selectionStart: 1,
           selectionEnd: 9,
         })
       );
-      expect(
-        ProfileViewSelectors.getProfileViewOptions(getState()).selection
-      ).toEqual({
+      expect(ProfileViewSelectors.getPreviewSelection(getState())).toEqual({
         hasSelection: true,
         isModifying: false,
         selectionEnd: 9,
@@ -546,9 +539,7 @@ describe('actions/ProfileView', function() {
         { start: 0, end: 10 },
         { start: 1, end: 9 },
       ]);
-      expect(
-        ProfileViewSelectors.getProfileViewOptions(getState()).selection
-      ).toEqual({
+      expect(ProfileViewSelectors.getPreviewSelection(getState())).toEqual({
         hasSelection: false,
         isModifying: false,
       });
@@ -679,7 +670,7 @@ describe('snapshots of selectors/profile-view', function() {
     dispatch(ProfileView.changeSelectedMarker(0, 1));
     dispatch(ProfileView.commitRange(3, 7)); // Reminder: upper bound "7" is exclusive.
     dispatch(
-      ProfileView.updateProfileSelection({
+      ProfileView.updatePreviewSelection({
         hasSelection: true,
         isModifying: false,
         selectionStart: 4,
@@ -775,18 +766,18 @@ describe('snapshots of selectors/profile-view', function() {
       selectedThreadSelectors.getMarkerTiming(getState())
     ).toMatchSnapshot();
   });
-  it('matches the last stored run of selectedThreadSelector.getRangeSelectionFilteredTracingMarkers', function() {
+  it('matches the last stored run of selectedThreadSelector.getCommittedRangeFilteredTracingMarkers', function() {
     const { getState } = setupStore();
     expect(
-      selectedThreadSelectors.getRangeSelectionFilteredTracingMarkers(
+      selectedThreadSelectors.getCommittedRangeFilteredTracingMarkers(
         getState()
       )
     ).toMatchSnapshot();
   });
-  it('matches the last stored run of selectedThreadSelector.getRangeSelectionFilteredTracingMarkersForHeader', function() {
+  it('matches the last stored run of selectedThreadSelector.getCommittedRangeFilteredTracingMarkersForHeader', function() {
     const { getState } = setupStore();
     expect(
-      selectedThreadSelectors.getRangeSelectionFilteredTracingMarkersForHeader(
+      selectedThreadSelectors.getCommittedRangeFilteredTracingMarkersForHeader(
         getState()
       )
     ).toMatchSnapshot();
@@ -797,10 +788,10 @@ describe('snapshots of selectors/profile-view', function() {
       selectedThreadSelectors.getFilteredThread(getState())
     ).toMatchSnapshot();
   });
-  it('matches the last stored run of selectedThreadSelector.getRangeSelectionFilteredThread', function() {
+  it('matches the last stored run of selectedThreadSelector.getPreviewFilteredThread', function() {
     const { getState } = setupStore();
     expect(
-      selectedThreadSelectors.getRangeSelectionFilteredThread(getState())
+      selectedThreadSelectors.getPreviewFilteredThread(getState())
     ).toMatchSnapshot();
   });
   it('matches the last stored run of selectedThreadSelector.getCallNodeInfo', function() {

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -152,7 +152,7 @@ describe('actions/receive-profile', function() {
 
       const state = store.getState();
       expect(getView(state)).toEqual({ phase: 'DATA_LOADED' });
-      expect(ProfileViewSelectors.getDisplayRange(state)).toEqual({
+      expect(ProfileViewSelectors.getCommittedRange(state)).toEqual({
         start: 0,
         end: 1007,
       });
@@ -185,7 +185,7 @@ describe('actions/receive-profile', function() {
 
       const state = store.getState();
       expect(getView(state)).toEqual({ phase: 'DATA_LOADED' });
-      expect(ProfileViewSelectors.getDisplayRange(state)).toEqual({
+      expect(ProfileViewSelectors.getCommittedRange(state)).toEqual({
         start: 0,
         end: 1007,
       });
@@ -230,7 +230,7 @@ describe('actions/receive-profile', function() {
 
       const state = store.getState();
       expect(getView(state)).toEqual({ phase: 'DATA_LOADED' });
-      expect(ProfileViewSelectors.getDisplayRange(state)).toEqual({
+      expect(ProfileViewSelectors.getCommittedRange(state)).toEqual({
         start: 0,
         end: 1007,
       });
@@ -265,7 +265,7 @@ describe('actions/receive-profile', function() {
       ]);
 
       const state = store.getState();
-      expect(ProfileViewSelectors.getDisplayRange(state)).toEqual({
+      expect(ProfileViewSelectors.getCommittedRange(state)).toEqual({
         start: 0,
         end: 1007,
       });
@@ -344,7 +344,7 @@ describe('actions/receive-profile', function() {
 
       const state = store.getState();
       expect(getView(state)).toEqual({ phase: 'DATA_LOADED' });
-      expect(ProfileViewSelectors.getDisplayRange(state)).toEqual({
+      expect(ProfileViewSelectors.getCommittedRange(state)).toEqual({
         start: 0,
         end: 1007,
       });
@@ -378,7 +378,7 @@ describe('actions/receive-profile', function() {
       ]);
 
       const state = store.getState();
-      expect(ProfileViewSelectors.getDisplayRange(state)).toEqual({
+      expect(ProfileViewSelectors.getCommittedRange(state)).toEqual({
         start: 0,
         end: 1007,
       });

--- a/src/test/store/zipped-profiles.test.js
+++ b/src/test/store/zipped-profiles.test.js
@@ -194,18 +194,18 @@ describe('profile state invalidation when switching between profiles', function(
     viewProfile('profile1.json');
 
     // It starts out empty.
-    expect(UrlStateSelectors.getRangeFilters(getState())).toEqual([]);
+    expect(UrlStateSelectors.getAllCommittedRanges(getState())).toEqual([]);
 
     // Add a url-encoded bit of state.
-    dispatch(ProfileViewActions.addRangeFilter(0, 10));
-    expect(UrlStateSelectors.getRangeFilters(getState())).toEqual([
+    dispatch(ProfileViewActions.commitRange(0, 10));
+    expect(UrlStateSelectors.getAllCommittedRanges(getState())).toEqual([
       { start: 0, end: 10 },
     ]);
 
     // It switches to another profile and invalidates.
     dispatch(ZippedProfilesActions.returnToZipFileList());
     viewProfile('profile2.json');
-    expect(UrlStateSelectors.getRangeFilters(getState())).toEqual([]);
+    expect(UrlStateSelectors.getAllCommittedRanges(getState())).toEqual([]);
   });
 
   it('invalidates profile view state', async function() {

--- a/src/test/store/zipped-profiles.test.js
+++ b/src/test/store/zipped-profiles.test.js
@@ -223,20 +223,20 @@ describe('profile state invalidation when switching between profiles', function(
     });
 
     // It starts with no selection.
-    expect(ProfileViewSelectors.getSelection(getState())).toEqual(
+    expect(ProfileViewSelectors.getPreviewSelection(getState())).toEqual(
       getNoSelection()
     );
 
     // Add a selection.
-    dispatch(ProfileViewActions.updateProfileSelection(getSomeSelection()));
-    expect(ProfileViewSelectors.getSelection(getState())).toEqual(
+    dispatch(ProfileViewActions.updatePreviewSelection(getSomeSelection()));
+    expect(ProfileViewSelectors.getPreviewSelection(getState())).toEqual(
       getSomeSelection()
     );
     dispatch(ZippedProfilesActions.returnToZipFileList());
     viewProfile('profile2.json');
 
     // It no longer has a selection when viewing another profile.
-    expect(ProfileViewSelectors.getSelection(getState())).toEqual(
+    expect(ProfileViewSelectors.getPreviewSelection(getState())).toEqual(
       getNoSelection()
     );
   });

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -35,7 +35,7 @@ export type DataSource =
   | 'local'
   | 'public'
   | 'from-url';
-export type ProfileSelection =
+export type PreviewSelection =
   | {| +hasSelection: false, +isModifying: false |}
   | {|
       +hasSelection: true,
@@ -90,8 +90,8 @@ type ProfileAction =
       +selectedMarker: IndexIntoMarkersTable | -1,
     |}
   | {|
-      +type: 'UPDATE_PROFILE_SELECTION',
-      +selection: ProfileSelection,
+      +type: 'UPDATE_PREVIEW_SELECTION',
+      +previewSelection: PreviewSelection,
     |}
   | {|
       +type: 'CHANGE_TAB_ORDER',

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -231,8 +231,8 @@ type UrlStateAction =
   | {| +type: 'WAITING_FOR_PROFILE_FROM_FILE' |}
   | {| +type: 'PROFILE_PUBLISHED', +hash: string |}
   | {| +type: 'CHANGE_SELECTED_TAB', +selectedTab: TabSlug |}
-  | {| +type: 'ADD_RANGE_FILTER', +start: number, +end: number |}
-  | {| +type: 'POP_RANGE_FILTERS', +firstRemovedFilterIndex: number |}
+  | {| +type: 'COMMIT_RANGE', +start: number, +end: number |}
+  | {| +type: 'POP_COMMITTED_RANGES', +firstPoppedFilterIndex: number |}
   | {| +type: 'CHANGE_SELECTED_THREAD', +selectedThreadIndex: ThreadIndex |}
   | {| +type: 'CHANGE_RIGHT_CLICKED_TRACK', +trackReference: TrackReference |}
   | {| +type: 'CHANGE_CALL_TREE_SEARCH_STRING', +searchString: string |}
@@ -245,7 +245,7 @@ type UrlStateAction =
   | {|
       +type: 'POP_TRANSFORMS_FROM_STACK',
       +threadIndex: ThreadIndex,
-      +firstRemovedFilterIndex: number,
+      +firstPoppedFilterIndex: number,
     |}
   | {|
       +type: 'CHANGE_IMPLEMENTATION_FILTER',

--- a/src/types/reducers.js
+++ b/src/types/reducers.js
@@ -144,7 +144,7 @@ export type UrlState = {|
     localTrackOrderByPid: Map<Pid, TrackIndex[]>,
     implementation: ImplementationFilter,
     invertCallstack: boolean,
-    rangeFilters: StartEndRange[],
+    committedRanges: StartEndRange[],
     callTreeSearchString: string,
     markersSearchString: string,
     transforms: TransformStacksPerThread,

--- a/src/types/reducers.js
+++ b/src/types/reducers.js
@@ -7,7 +7,7 @@
 import type {
   Action,
   DataSource,
-  ProfileSelection,
+  PreviewSelection,
   ImplementationFilter,
   RequestedLib,
   TrackReference,
@@ -20,6 +20,7 @@ import type {
   ThreadIndex,
   Pid,
 } from './profile';
+
 import type {
   CallNodePath,
   GlobalTrack,
@@ -53,7 +54,7 @@ export type ProfileViewState = {
     perThread: ThreadViewOptions[],
     symbolicationStatus: SymbolicationStatus,
     waitingForLibs: Set<RequestedLib>,
-    selection: ProfileSelection,
+    previewSelection: PreviewSelection,
     scrollToSelectionGeneration: number,
     focusCallTreeGeneration: number,
     rootRange: StartEndRange,

--- a/src/utils/window-console.js
+++ b/src/utils/window-console.js
@@ -30,9 +30,7 @@ export function addDataToWindowObject(
   defineProperty(target, 'filteredThread', {
     enumerable: true,
     get() {
-      return selectedThreadSelectors.getRangeSelectionFilteredThread(
-        getState()
-      );
+      return selectedThreadSelectors.getPreviewFilteredThread(getState());
     },
   });
 


### PR DESCRIPTION
Our current naming situation is confusing and error prone for how our range selections are named. This PR disambiguates the two different types of ranges. It uses "committed ranges" for anything that the user has pushed onto the range stack. It uses "preview range" to talk about the temporary range selection that a user can make before committing it. It also uses the term "preview selection" to describe the current state of the "preview range", and whether the selection is being modified.

There are three commits to this changes, the first for the "committed" ranges, the second for the "preview" ranges, and a third for cleaning up a multiple store `dispatch()` call that was unneeded that I came across during the refactor.