### PR TITLE
Always reserve space for a vertical scrollbar.

### DIFF
--- a/src/components/timeline/Ruler.css
+++ b/src/components/timeline/Ruler.css
@@ -12,7 +12,7 @@
   position: absolute;
   top: 20px;
   left: -150px;
-  right: 0;
+  right: calc(0px - var(--vertical-scrollbar-reserved-width));
   height: 1px;
   background: var(--grey-30);
   z-index: 3;

--- a/src/components/timeline/Selection.css
+++ b/src/components/timeline/Selection.css
@@ -3,8 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 .timelineSelection {
+  --thread-label-column-width: 150px;
+  --vertical-scrollbar-reserved-width: 15px;
+  --content-width: calc(100vw - var(--thread-label-column-width) - var(--vertical-scrollbar-reserved-width));
   position: relative;
-  margin-left: 149px;
+  width: var(--content-width);
+  margin-left: calc(var(--thread-label-column-width) - 1px);
   border-left: 1px solid var(--grey-30);
   -moz-user-focus: ignore;
 }

--- a/src/components/timeline/index.css
+++ b/src/components/timeline/index.css
@@ -4,15 +4,19 @@
 
 
 .timelineOverflowEdgeIndicatorScrollbox {
-  margin: 0 0 0 -150px;
-  padding-left: 150px;
+  margin-right: calc(0px - var(--vertical-scrollbar-reserved-width));
+  margin-left: calc(0px - var(--thread-label-column-width));
+  padding-left: var(--thread-label-column-width);
   max-height: 250px;
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden; /* if the platform scrollbar ends up being larger than --vertical-scrollbar-reserved-width (which is unexpected), make sure there is no horizontal scrollbar */
+  background: linear-gradient(to left, white, #EEE calc(var(--vertical-scrollbar-reserved-width) - 1px), var(--grey-30) 0, var(--grey-30) var(--vertical-scrollbar-reserved-width), transparent 0);
 }
 
 .timelineThreadList {
   list-style: none;
-  margin: 0 0 0 -150px;
+  margin: 0 0 0 calc(0px - var(--thread-label-column-width));
+  width: calc(100vw - var(--vertical-scrollbar-reserved-width));
   padding: 0;
   box-shadow: inset 0 1px var(--grey-30);
   background-color: var(--grey-20);


### PR DESCRIPTION
Fixes #619, fixes #1123.

Depending on the number of threads / tracks visible in the list at the
top, and the height of the header area, the list of tracks can be
vertically scrollable. The scrollbar for vertical scrolling causes a
bunch of problems, depending on the platform:
 - Dragging the scrollbar thumb is currently impossible because we
   override the mouse events to control the range selection.
 - On platforms with overlay scrollbars, the scrollbar overlaps the
   graphs and makes it hard to interact with the parts of the graphs
   close to the right edge.
 - On platforms with classic (non-overlay) scrollbars, the scrollbar
   subtracts available area from the contents and causes the time scale
   of the graphs to be misaligned with respect to the ruler above the
   scroll box. Furthermore, changing a track's visibility can flip cause
   the track list to flip between having a scrollbar and not having a
   scrollbar, which makes the graphs shift.

This commit addresses all these problems by reserving a fixed amount of
space for the scrollbar at all times. It sets an absolute width on both
the timeline ruler at the top *and* on the scrollable contents.
When there is a scrollbar, the scrollbar is displayed in the reserved
space, otherwise the space is empty.
The reserved space is always 15px wide, regardless of the actual width
of the scrollbar on the current platform. If the actual scrollbar is
narrower than the reserved space, there will be a small gap. If it is
wider than the reserved space, it will cover some of the contents but
but will not affect the contents' size.

We use calc() and viewport units (100vw) in order to compute an absolute
CSS length value that we can use for the graph width. This is needed so
that we can give the "insides" of the scrollable element a width that is
the same regardless of the actual width of the scrollbar on the current
platform. There does not seem to exist a way to use relative sizes
inside a scrollable element that "ignore" the scrollbar width; e.g.
"width: 100%" refers to the "inside width" of the parent element with
the scrollbar width already subtracted, and there's no pure-CSS way to
say "set this element's width to the *outer width* of its parent element".

Screenshots:

1. Non-scrollable box, both overlay and classic scrollbar mode:

<img width="789" alt="screen shot 2018-08-06 at 7 39 25 pm" src="https://user-images.githubusercontent.com/961291/43746330-b308d5a2-99b1-11e8-85f4-650be2efa61e.png">

2. Scrollable box with overlay scrollbar:

<img width="789" alt="screen shot 2018-08-06 at 7 39 44 pm" src="https://user-images.githubusercontent.com/961291/43746338-bd7c149a-99b1-11e8-9967-2a86e8c0f7d0.png">

3. Scrollable box with classic scrollbar:

<img width="789" alt="screen shot 2018-08-06 at 7 40 11 pm" src="https://user-images.githubusercontent.com/961291/43746345-c4c449d4-99b1-11e8-98a8-4a261ac38786.png">

4. Scrollable box with classic scrollbar and correctly-aligned selected hang marker:

<img width="789" alt="screen shot 2018-08-06 at 7 43 33 pm" src="https://user-images.githubusercontent.com/961291/43746357-d0f7a980-99b1-11e8-8152-49c8a0ea40a9.png">
