### PR TITLE
Remove the left margin on all graphs

### DIFF
--- a/src/components/flame-graph/FlameGraph.css
+++ b/src/components/flame-graph/FlameGraph.css
@@ -15,20 +15,3 @@
   flex: 1;
   border-top: 1px solid var(--grey-30);
 }
-
-.flameGraphLabels {
-  width: 121px;
-  padding: 9px 14px;
-  border-right: 1px solid var(--grey-30);
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  user-select: none;
-}
-
-.flameGraphLabels > span {
-  flex: 1;
-  cursor: default;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}

--- a/src/components/flame-graph/FlameGraph.js
+++ b/src/components/flame-graph/FlameGraph.js
@@ -46,8 +46,6 @@ type StateProps = {|
   +timeRange: { start: Milliseconds, end: Milliseconds },
   +previewSelection: PreviewSelection,
   +flameGraphTiming: FlameGraphTiming,
-  +threadName: string,
-  +processDetails: string,
   +callTree: CallTree,
   +callNodeInfo: CallNodeInfo,
   +threadIndex: number,
@@ -82,8 +80,6 @@ class FlameGraph extends React.PureComponent<Props> {
       callNodeInfo,
       timeRange,
       previewSelection,
-      threadName,
-      processDetails,
       selectedCallNodeIndex,
       isCallNodeContextMenuVisible,
       scrollToSelectionGeneration,
@@ -101,9 +97,6 @@ class FlameGraph extends React.PureComponent<Props> {
             key={className}
           />
         ))}
-        <div title={processDetails} className="flameGraphLabels grippy">
-          <span>{threadName}</span>
-        </div>
         <ContextMenuTrigger
           id="CallNodeContextMenu"
           attributes={{
@@ -161,8 +154,6 @@ const options: ExplicitConnectOptions<{||}, StateProps, DispatchProps> = {
       callTree: selectedThreadSelectors.getCallTree(state),
       timeRange: getCommittedRange(state),
       previewSelection: getPreviewSelection(state),
-      threadName: selectedThreadSelectors.getFriendlyThreadName(state),
-      processDetails: selectedThreadSelectors.getThreadProcessDetails(state),
       callNodeInfo: selectedThreadSelectors.getCallNodeInfo(state),
       threadIndex: getSelectedThreadIndex(state),
       selectedCallNodeIndex: selectedThreadSelectors.getSelectedCallNodeIndex(

--- a/src/components/marker-chart/index.css
+++ b/src/components/marker-chart/index.css
@@ -4,24 +4,5 @@
 
 .markerChart {
   display: flex;
-  flex-direction: row;
   flex: 1;
-}
-
-.markerChartLabels {
-  width: 135px;
-  display: flex;
-  padding: 9px 0 9px 14px;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
-.markerChartLabelsName {
-  flex: 1;
-  cursor: default;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }

--- a/src/components/marker-chart/index.js
+++ b/src/components/marker-chart/index.js
@@ -47,8 +47,6 @@ type StateProps = {|
   +interval: Milliseconds,
   +threadIndex: number,
   +previewSelection: PreviewSelection,
-  +threadName: string,
-  +processDetails: string,
 |};
 
 type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
@@ -70,8 +68,6 @@ class MarkerChart extends React.PureComponent<Props> {
       markerTimingRows,
       markers,
       previewSelection,
-      threadName,
-      processDetails,
       updatePreviewSelection,
     } = this.props;
 
@@ -85,9 +81,6 @@ class MarkerChart extends React.PureComponent<Props> {
 
     return (
       <div className="markerChart">
-        <div className="markerChartLabels grippy" title={processDetails}>
-          <span className="markerChartLabelsName">{threadName}</span>
-        </div>
         <MarkerChartCanvas
           key={threadIndex}
           viewportProps={{
@@ -124,7 +117,6 @@ const options: ExplicitConnectOptions<{||}, StateProps, DispatchProps> = {
   mapStateToProps: state => {
     const markers = selectedThreadSelectors.getTracingMarkersForView(state);
     const markerTimingRows = selectedThreadSelectors.getMarkerTiming(state);
-    const threadName = selectedThreadSelectors.getFriendlyThreadName(state);
 
     return {
       markers,
@@ -134,8 +126,6 @@ const options: ExplicitConnectOptions<{||}, StateProps, DispatchProps> = {
       interval: getProfileInterval(state),
       threadIndex: getSelectedThreadIndex(state),
       previewSelection: getPreviewSelection(state),
-      threadName,
-      processDetails: selectedThreadSelectors.getThreadProcessDetails(state),
     };
   },
   mapDispatchToProps: { updatePreviewSelection },

--- a/src/components/stack-chart/index.css
+++ b/src/components/stack-chart/index.css
@@ -9,26 +9,8 @@
   overflow: hidden;
 }
 
-.stackChartGraph {
+.stackChartContent {
   display: flex;
-  flex-direction: row;
   flex: 1;
   border-top: 1px solid var(--grey-30);
-}
-
-.stackChartLabels {
-  width: 121px;
-  padding: 9px 14px;
-  border-right: 1px solid var(--grey-30);
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  user-select: none;
-}
-
-.stackChartLabels > span {
-  flex: 1;
-  cursor: default;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }

--- a/src/components/stack-chart/index.js
+++ b/src/components/stack-chart/index.js
@@ -46,8 +46,6 @@ type StateProps = {|
   +getCategory: GetCategory,
   +getLabel: GetLabel,
   +previewSelection: PreviewSelection,
-  +threadName: string,
-  +processDetails: string,
 |};
 
 type DispatchProps = {|
@@ -75,8 +73,6 @@ class StackChartGraph extends React.PureComponent<Props> {
       getCategory,
       getLabel,
       previewSelection,
-      threadName,
-      processDetails,
       updatePreviewSelection,
     } = this.props;
 
@@ -85,10 +81,7 @@ class StackChartGraph extends React.PureComponent<Props> {
     return (
       <div className="stackChart">
         <StackSettings />
-        <div className="stackChartGraph">
-          <div title={processDetails} className="stackChartLabels grippy">
-            <span>{threadName}</span>
-          </div>
+        <div className="stackChartContent">
           <StackChartCanvas
             viewportProps={{
               previewSelection,
@@ -130,8 +123,6 @@ const options: ExplicitConnectOptions<{||}, StateProps, DispatchProps> = {
       getCategory: getCategoryColorStrategy(state),
       getLabel: getLabelingStrategy(state),
       previewSelection: getPreviewSelection(state),
-      threadName: selectedThreadSelectors.getFriendlyThreadName(state),
-      processDetails: selectedThreadSelectors.getThreadProcessDetails(state),
     };
   },
   mapDispatchToProps: { updatePreviewSelection },

--- a/src/test/components/__snapshots__/FlameGraph.test.js.snap
+++ b/src/test/components/__snapshots__/FlameGraph.test.js.snap
@@ -98,15 +98,6 @@ exports[`renders FlameGraph correctly 1`] = `
     className="flameGraphContent"
   >
     <div
-      className="flameGraphLabels grippy"
-      title="thread: \\"Empty\\" (0)
-process: \\"default\\" (0)"
-    >
-      <span>
-        Empty
-      </span>
-    </div>
-    <div
       className="react-contextmenu-wrapper treeViewContextMenu"
       onContextMenu={[Function]}
       onMouseDown={[Function]}

--- a/src/test/components/__snapshots__/MarkerChart.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerChart.test.js.snap
@@ -39,17 +39,6 @@ exports[`renders MarkerChart correctly 1`] = `
   className="markerChart"
 >
   <div
-    className="markerChartLabels grippy"
-    title="thread: \\"Empty\\" (0)
-process: \\"default\\" (0)"
-  >
-    <span
-      className="markerChartLabelsName"
-    >
-      Empty
-    </span>
-  </div>
-  <div
     className="chartViewport"
     onMouseDown={[Function]}
     onWheel={[Function]}
@@ -466,17 +455,6 @@ exports[`renders MarkerChart correctly 3`] = `
 <div
   className="markerChart"
 >
-  <div
-    className="markerChartLabels grippy"
-    title="thread: \\"Empty\\" (0)
-process: \\"default\\" (0)"
-  >
-    <span
-      className="markerChartLabelsName"
-    >
-      Empty
-    </span>
-  </div>
   <div
     className="chartViewport"
     onMouseDown={[Function]}

--- a/src/test/components/__snapshots__/StackChart.test.js.snap
+++ b/src/test/components/__snapshots__/StackChart.test.js.snap
@@ -94,17 +94,8 @@ exports[`renders StackChartGraph correctly 1`] = `
     </div>
   </div>
   <div
-    className="stackChartGraph"
+    className="stackChartContent"
   >
-    <div
-      className="stackChartLabels grippy"
-      title="thread: \\"Empty\\" (0)
-process: \\"default\\" (0)"
-    >
-      <span>
-        Empty
-      </span>
-    </div>
     <div
       className="chartViewport"
       onMouseDown={[Function]}


### PR DESCRIPTION
This PR removes the left margin on the stack and marker charts. The original idea was to have the charts aligned with the graph above, but that is no longer a concern. I was doing some performance audits on that area, and found the thread name to be paint flashing, so it seemed like a good idea to go ahead and remove it since that is what we've already been discussing.

Before changes:
<img width="477" alt="image" src="https://user-images.githubusercontent.com/1588648/43793253-9b9e5fa6-9a40-11e8-992f-ab0d72a26df9.png">

After changes:
<img width="388" alt="image" src="https://user-images.githubusercontent.com/1588648/43793230-8e4ba7fa-9a40-11e8-89c9-e4949410af04.png">
