### PR TITLE
Network track for the timeline

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -3,12 +3,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
+import { getLastVisibleThreadTabSlug } from '../reducers/app';
 import {
   selectorsForThread,
   selectedThreadSelectors,
   getGlobalTracks,
   getGlobalTrackAndIndexByPid,
   getLocalTracks,
+  getLocalTrackFromReference,
+  getGlobalTrackFromReference,
 } from '../reducers/profile-view';
 import {
   getImplementationFilter,
@@ -17,9 +20,10 @@ import {
   getGlobalTrackOrder,
   getLocalTrackOrder,
   getHiddenLocalTracks,
+  getSelectedTab,
 } from '../reducers/url-state';
 import { getCallNodePathFromIndex } from '../profile-logic/profile-data';
-import { ensureExists } from '../utils/flow';
+import { ensureExists, assertExhaustiveCheck } from '../utils/flow';
 import { sendAnalytics } from '../utils/analytics';
 
 import type {
@@ -58,6 +62,81 @@ export function changeSelectedThread(selectedThreadIndex: ThreadIndex): Action {
   return {
     type: 'CHANGE_SELECTED_THREAD',
     selectedThreadIndex,
+  };
+}
+
+export function selectTrack(trackReference: TrackReference): ThunkAction<void> {
+  return (dispatch, getState) => {
+    const currentlySelectedTab = getSelectedTab(getState());
+    const currentlySelectedThreadIndex = getSelectedThreadIndex(getState());
+    // These get assigned based on the track type.
+    let selectedThreadIndex = null;
+    let selectedTab = currentlySelectedTab;
+
+    if (trackReference.type === 'global') {
+      // Handle the case of global tracks.
+      const globalTrack = getGlobalTrackFromReference(
+        getState(),
+        trackReference
+      );
+
+      // Go through each type, and determine the selected slug and thread index.
+      switch (globalTrack.type) {
+        case 'process': {
+          if (globalTrack.mainThreadIndex === null) {
+            // Do not allow selecting process tracks without a thread index.
+            return;
+          }
+          selectedThreadIndex = globalTrack.mainThreadIndex;
+          // Ensure a relevant thread-based tab is used.
+          selectedTab = getLastVisibleThreadTabSlug(getState());
+          break;
+        }
+        case 'screenshots':
+          // Do not allow selecting screenshots.
+          return;
+        default:
+          throw assertExhaustiveCheck(
+            globalTrack,
+            `Unhandled GlobalTrack type.`
+          );
+      }
+    } else {
+      // Handle the case of local tracks.
+      const localTrack = getLocalTrackFromReference(getState(), trackReference);
+
+      // Go through each type, and determine the tab slug and thread index.
+      switch (localTrack.type) {
+        case 'thread': {
+          // Ensure a relevant thread-based tab is used.
+          selectedThreadIndex = localTrack.threadIndex;
+          selectedTab = getLastVisibleThreadTabSlug(getState());
+          break;
+        }
+        case 'network':
+          selectedThreadIndex = localTrack.threadIndex;
+          selectedTab = 'network-chart';
+          break;
+        case 'memory':
+          // TODO - Currently disable selecting memory.
+          return;
+        default:
+          throw assertExhaustiveCheck(localTrack, `Unhandled LocalTrack type.`);
+      }
+    }
+
+    if (
+      currentlySelectedTab === selectedThreadIndex &&
+      currentlySelectedThreadIndex === selectedTab
+    ) {
+      return;
+    }
+
+    dispatch({
+      type: 'SELECT_TRACK',
+      selectedThreadIndex,
+      selectedTab,
+    });
   };
 }
 

--- a/src/components/timeline/LocalTrack.js
+++ b/src/components/timeline/LocalTrack.js
@@ -22,6 +22,7 @@ import {
   getLocalTrackName,
 } from '../../reducers/profile-view';
 import TrackThread from './TrackThread';
+import TrackNetwork from './TrackNetwork';
 import type { ThreadIndex, Pid } from '../../types/profile';
 import type { TrackIndex, LocalTrack } from '../../types/profile-derived';
 import type {
@@ -87,6 +88,7 @@ class LocalTrackComponent extends PureComponent<Props> {
       case 'thread':
         return <TrackThread threadIndex={localTrack.threadIndex} />;
       case 'network':
+        return <TrackNetwork threadIndex={localTrack.threadIndex} />;
       case 'memory':
         // TODO: Add support for these track types.
         return null;

--- a/src/components/timeline/Ruler.css
+++ b/src/components/timeline/Ruler.css
@@ -5,6 +5,8 @@
 .timelineRuler {
   height: 20px;
   overflow: hidden;
+  /* Don't allow this component to steal pointer events, as it can overlay the timeline */
+  pointer-events: none;
 }
 
 .timelineRuler::after {

--- a/src/components/timeline/TrackNetwork.css
+++ b/src/components/timeline/TrackNetwork.css
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+.timelineTrackNetwork {
+  position: relative;
+  width: 100%;
+}
+
+.timelineTrackNetworkCanvas {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+}

--- a/src/components/timeline/TrackNetwork.js
+++ b/src/components/timeline/TrackNetwork.js
@@ -1,0 +1,156 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import React, { PureComponent } from 'react';
+import clamp from 'clamp';
+import { withSize } from '../shared/WithSize';
+import explicitConnect from '../../utils/connect';
+import {
+  selectorsForThread,
+  getCommittedRange,
+} from '../../reducers/profile-view';
+
+import type { ThreadIndex } from '../../types/profile';
+import type {} from '../../types/markers';
+import type { Milliseconds } from '../../types/units';
+import type { SizeProps } from '../shared/WithSize';
+import type {
+  ExplicitConnectOptions,
+  ConnectedProps,
+} from '../../utils/connect';
+
+import './TrackNetwork.css';
+
+type OwnProps = {|
+  +threadIndex: ThreadIndex,
+  ...SizeProps,
+|};
+
+type StateProps = {|
+  +rangeStart: Milliseconds,
+  +rangeEnd: Milliseconds,
+  +networkMarkers: *,
+  +networkTiming: *,
+  +containerHeight: number,
+|};
+type DispatchProps = {||};
+type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
+type State = void;
+
+export const ROW_HEIGHT = 5;
+export const ROW_REPEAT = 7;
+export const MIN_ROW_REPEAT = 4;
+
+class Network extends PureComponent<Props, State> {
+  _canvas: null | HTMLCanvasElement = null;
+  _requestedAnimationFrame: boolean = false;
+
+  _resizeListener = () => {
+    this.forceUpdate();
+  };
+
+  _takeCanvasRef = (canvas: HTMLCanvasElement | null) => {
+    this._canvas = canvas;
+  };
+
+  _scheduleDraw() {
+    if (!this._requestedAnimationFrame) {
+      this._requestedAnimationFrame = true;
+      window.requestAnimationFrame(() => {
+        this._requestedAnimationFrame = false;
+        const canvas = this._canvas;
+        if (canvas) {
+          this.drawCanvas(canvas);
+        }
+      });
+    }
+  }
+
+  componentDidMount() {
+    window.addEventListener('resize', this._resizeListener);
+    this.forceUpdate(); // for initial size
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this._resizeListener);
+  }
+
+  drawCanvas(canvas: HTMLCanvasElement) {
+    const {
+      rangeStart,
+      rangeEnd,
+      networkTiming,
+      width: containerWidth,
+      containerHeight,
+    } = this.props;
+
+    const rangeLength = rangeEnd - rangeStart;
+
+    const devicePixelRatio = window.devicePixelRatio;
+    const rowHeight = ROW_HEIGHT * devicePixelRatio;
+    canvas.width = Math.round(containerWidth * devicePixelRatio);
+    canvas.height = Math.round(containerHeight * devicePixelRatio);
+    const ctx = canvas.getContext('2d');
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.strokeStyle = 'rgba(0, 127, 255, 0.3)';
+
+    ctx.lineCap = 'round';
+    ctx.lineWidth = rowHeight * 0.75;
+    for (let rowIndex = 0; rowIndex < networkTiming.length; rowIndex++) {
+      const timing = networkTiming[rowIndex];
+      for (let timingIndex = 0; timingIndex < timing.length; timingIndex++) {
+        const start =
+          canvas.width / rangeLength * (timing.start[timingIndex] - rangeStart);
+        const end =
+          canvas.width / rangeLength * (timing.end[timingIndex] - rangeStart);
+        const y = (rowIndex % ROW_REPEAT) * rowHeight + rowHeight * 0.5;
+        ctx.beginPath();
+        ctx.moveTo(start, y);
+        ctx.lineTo(end, y);
+        ctx.stroke();
+      }
+    }
+  }
+
+  render() {
+    const { containerHeight } = this.props;
+    this._scheduleDraw();
+
+    return (
+      <div
+        className="timelineTrackNetwork"
+        style={{
+          height: containerHeight,
+        }}
+      >
+        <canvas
+          className="timelineTrackNetworkCanvas"
+          ref={this._takeCanvasRef}
+        />
+      </div>
+    );
+  }
+}
+
+const options: ExplicitConnectOptions<OwnProps, StateProps, DispatchProps> = {
+  mapStateToProps: (state, ownProps) => {
+    const { threadIndex } = ownProps;
+    const selectors = selectorsForThread(threadIndex);
+    const { start, end } = getCommittedRange(state);
+    const networkTiming = selectors.getNetworkTiming(state);
+    return {
+      networkMarkers: selectors.getNetworkTracingMarkers(state),
+      networkTiming: networkTiming,
+      rangeStart: start,
+      rangeEnd: end,
+      containerHeight:
+        ROW_HEIGHT * clamp(networkTiming.length, MIN_ROW_REPEAT, ROW_REPEAT),
+    };
+  },
+  component: Network,
+};
+
+export default withSize(explicitConnect(options));

--- a/src/components/timeline/TrackNetwork.js
+++ b/src/components/timeline/TrackNetwork.js
@@ -42,7 +42,7 @@ type State = void;
 
 export const ROW_HEIGHT = 5;
 export const ROW_REPEAT = 7;
-export const MIN_ROW_REPEAT = 4;
+export const MIN_ROW_REPEAT = 5;
 
 class Network extends PureComponent<Props, State> {
   _canvas: null | HTMLCanvasElement = null;

--- a/src/profile-logic/tracks.js
+++ b/src/profile-logic/tracks.js
@@ -138,12 +138,15 @@ export function computeLocalTracksByPid(
       localTracksByPid.set(pid, tracks);
     }
 
-    if (_isMainThread(thread)) {
-      // This thread was already added as a GlobalTrack.
-      continue;
+    if (!_isMainThread(thread)) {
+      // This thread has not been added as a GlobalTrack, so add it as a local track.
+      tracks.push({ type: 'thread', threadIndex });
     }
 
-    tracks.push({ type: 'thread', threadIndex });
+    if (thread.markers.data.some(datum => datum && datum.type === 'Network')) {
+      // This thread has network markers.
+      tracks.push({ type: 'network', threadIndex });
+    }
   }
 
   return localTracksByPid;

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -8,6 +8,7 @@ import { combineReducers } from 'redux';
 import { getSelectedTab } from './url-state';
 import { tabSlugs } from '../app-logic/tabs-handling';
 
+import type { TabSlug } from '../app-logic/tabs-handling';
 import type { Action } from '../types/store';
 import type {
   State,
@@ -128,12 +129,36 @@ function panelLayoutGeneration(state: number = 0, action: Action): number {
   }
 }
 
+/**
+ * Clicking on tracks can switch between different tabs. This piece of state holds
+ * on to the last relevant thread-based tab that was viewed. This makes the UX nicer
+ * for when a user clicks on a Network track, and gets taken to the Network
+ * panel, then clicks on a thread or process track. With this state we can smoothly
+ * transition them back to the panel they were using.
+ */
+function lastVisibleThreadTabSlug(
+  state: TabSlug = 'calltree',
+  action: Action
+): TabSlug {
+  switch (action.type) {
+    case 'SELECT_TRACK':
+    case 'CHANGE_SELECTED_TAB':
+      if (action.selectedTab !== 'network-chart') {
+        return action.selectedTab;
+      }
+      return state;
+    default:
+      return state;
+  }
+}
+
 const appStateReducer: Reducer<AppState> = combineReducers({
   view,
   isUrlSetupDone,
   hasZoomedViaMousewheel,
   isSidebarOpenPerPanel,
   panelLayoutGeneration,
+  lastVisibleThreadTabSlug,
 });
 
 export default appStateReducer;
@@ -149,3 +174,5 @@ export const getIsSidebarOpen = (state: State): boolean =>
   getApp(state).isSidebarOpenPerPanel[getSelectedTab(state)];
 export const getPanelLayoutGeneration = (state: State) =>
   getApp(state).panelLayoutGeneration;
+export const getLastVisibleThreadTabSlug = (state: State) =>
+  getApp(state).lastVisibleThreadTabSlug;

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -729,6 +729,8 @@ export type SelectorsForThread = {
   getMarkerTiming: State => MarkerTimingRows,
   getCommittedRangeFilteredTracingMarkers: State => TracingMarker[],
   getCommittedRangeFilteredTracingMarkersForHeader: State => TracingMarker[],
+  getNetworkTracingMarkers: State => TracingMarker[],
+  getNetworkTiming: State => MarkerTimingRows,
   getFilteredThread: State => Thread,
   getPreviewFilteredThread: State => Thread,
   getCallNodeInfo: State => CallNodeInfo,
@@ -961,6 +963,17 @@ export const selectorsForThread = (
             !ProfileData.isNetworkMarker(tm)
         )
     );
+    const getNetworkTracingMarkers = createSelector(
+      getCommittedRangeFilteredTracingMarkers,
+      tracingMarkers =>
+        tracingMarkers.filter(
+          marker => marker.data && marker.data.type === 'Network'
+        )
+    );
+    const getNetworkTiming = createSelector(
+      getNetworkTracingMarkers,
+      MarkerTiming.getMarkerTiming
+    );
     const getCallNodeInfo = createSelector(
       getFilteredThread,
       getDefaultCategory,
@@ -1075,6 +1088,8 @@ export const selectorsForThread = (
       getMarkerTiming,
       getCommittedRangeFilteredTracingMarkers,
       getCommittedRangeFilteredTracingMarkersForHeader,
+      getNetworkTracingMarkers,
+      getNetworkTiming,
       getFilteredThread,
       getPreviewFilteredThread,
       getCallNodeInfo,

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -402,6 +402,7 @@ function scrollToSelectionGeneration(state: number = 0, action: Action) {
     case 'CHANGE_INVERT_CALLSTACK':
     case 'CHANGE_SELECTED_CALL_NODE':
     case 'CHANGE_SELECTED_THREAD':
+    case 'SELECT_TRACK':
     case 'HIDE_GLOBAL_TRACK':
     case 'HIDE_LOCAL_TRACK':
       return state + 1;
@@ -629,6 +630,16 @@ export const getGlobalTrackReferences = createSelector(
       trackIndex,
     }))
 );
+export const getGlobalTrackFromReference = (
+  state: State,
+  trackReference: TrackReference
+) => {
+  if (trackReference.type !== 'global') {
+    throw new Error('Expected a global track reference.');
+  }
+  const globalTracks = getGlobalTracks(state);
+  return globalTracks[trackReference.trackIndex];
+};
 
 // Warning: this selector returns a new object on every call, and will not properly
 // work with a PureComponent.
@@ -653,6 +664,16 @@ export const getLocalTracks = (state: State, pid: Pid) =>
     getProfileView(state).localTracksByPid.get(pid),
     'Unable to get the tracks for the given pid.'
   );
+export const getLocalTrackFromReference = (
+  state: State,
+  trackReference: TrackReference
+): LocalTrack => {
+  if (trackReference.type !== 'local') {
+    throw new Error('Expected a local track reference.');
+  }
+  const { pid, trackIndex } = trackReference;
+  return getLocalTracks(state, pid)[trackIndex];
+};
 export const getRightClickedThreadIndex = createSelector(
   getRightClickedTrack,
   getGlobalTracks,

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -55,9 +55,10 @@ function profileUrl(state: string = '', action: Action) {
   }
 }
 
-function selectedTab(state: TabSlug = 'calltree', action: Action) {
+function selectedTab(state: TabSlug = 'calltree', action: Action): TabSlug {
   switch (action.type) {
     case 'CHANGE_SELECTED_TAB':
+    case 'SELECT_TRACK':
       return action.selectedTab;
     default:
       return state;
@@ -83,6 +84,7 @@ function selectedThread(
 ): ThreadIndex | null {
   switch (action.type) {
     case 'CHANGE_SELECTED_THREAD':
+    case 'SELECT_TRACK':
     case 'VIEW_PROFILE':
     case 'ISOLATE_PROCESS':
     case 'ISOLATE_PROCESS_MAIN_THREAD':

--- a/src/test/components/LocalTrack.test.js
+++ b/src/test/components/LocalTrack.test.js
@@ -4,6 +4,10 @@
 
 // @flow
 
+import type { TrackReference } from '../../types/actions';
+import type { Store } from '../../types/store';
+import type { LocalTrack } from '../../types/profile-derived';
+
 import * as React from 'react';
 import { Provider } from 'react-redux';
 import { mount } from 'enzyme';
@@ -12,126 +16,181 @@ import {
   changeSelectedThread,
   hideLocalTrack,
 } from '../../actions/profile-view';
-import LocalTrack from '../../components/timeline/LocalTrack';
+import TimelineLocalTrack from '../../components/timeline/LocalTrack';
 import {
-  getLocalTracks,
   getRightClickedTrack,
+  getLocalTrackFromReference,
+  getProfile,
 } from '../../reducers/profile-view';
 import { getSelectedThreadIndex } from '../../reducers/url-state';
+import { getNetworkTrackProfile } from '../fixtures/profiles/make-profile';
 import { getProfileWithNiceTracks } from '../fixtures/profiles/tracks';
 import { storeWithProfile } from '../fixtures/stores';
 
+// In getProfileWithNiceTracks, the two pids are 111 and 222 for the
+// "GeckoMain process" and "GeckoMain tab" respectively. Use 222 since it has
+// local tracks.
+const PID = 222;
 const LEFT_CLICK = 0;
 const RIGHT_CLICK = 2;
 
 describe('timeline/LocalTrack', function() {
-  /**
-   *  getProfileWithNiceTracks() looks like: [
-   *    'show [thread GeckoMain process]',
-   *    'show [thread GeckoMain tab]',
-   *    '  - show [thread DOM Worker]',         <- use this local track.
-   *    '  - show [thread Style]',
-   *  ]
-   */
-  function setup() {
-    // In getProfileWithNiceTracks, the two pids are 111 and 222 for the
-    // "GeckoMain process" and "GeckoMain tab" respectively. Use 222 since it has
-    // local tracks.
-    const pid = 222;
-    const trackIndex = 0;
-    const profile = getProfileWithNiceTracks();
-    const store = storeWithProfile(profile);
-    const { getState, dispatch } = store;
-    const trackReference = { type: 'local', pid, trackIndex };
-    const localTrack = getLocalTracks(getState(), pid)[trackIndex];
-    if (localTrack.type !== 'thread') {
-      throw new Error('Expected a thread track.');
-    }
-    const { threadIndex } = localTrack;
+  describe('with a thread track', function() {
+    it('matches the snapshot of a local track', () => {
+      const { view } = setupThreadTrack();
+      expect(view).toMatchSnapshot();
+    });
 
-    // The assertions are simpler if this thread is not already selected.
-    dispatch(changeSelectedThread(threadIndex + 1));
+    it('has the correct selectors into useful parts of the component', function() {
+      const { getLocalTrackLabel, getLocalTrackRow } = setupThreadTrack();
+      expect(getLocalTrackLabel().text()).toBe('DOM Worker');
+      expect(getLocalTrackRow().exists()).toBe(true);
+    });
 
-    const view = mount(
-      <Provider store={store}>
-        <LocalTrack pid={pid} localTrack={localTrack} trackIndex={trackIndex} />
-      </Provider>
-    );
+    it('starts out not being selected', function() {
+      const {
+        getState,
+        threadIndex,
+        trackReference,
+        getLocalTrackRow,
+      } = setupThreadTrack();
+      expect(getRightClickedTrack(getState())).not.toEqual(trackReference);
+      expect(getSelectedThreadIndex(getState())).not.toBe(threadIndex);
+      expect(getLocalTrackRow().hasClass('selected')).toBe(false);
+    });
 
-    const getLocalTrackLabel = () => view.find('.timelineTrackLabel').first();
-    const getLocalTrackRow = () => view.find('.timelineTrackLocalRow').first();
+    it('can select a thread by clicking the label', () => {
+      const {
+        getState,
+        getLocalTrackLabel,
+        threadIndex,
+        getLocalTrackRow,
+      } = setupThreadTrack();
+      expect(getSelectedThreadIndex(getState())).not.toBe(threadIndex);
+      getLocalTrackLabel().simulate('mousedown', { button: LEFT_CLICK });
+      expect(getSelectedThreadIndex(getState())).toBe(threadIndex);
+      expect(getLocalTrackRow().hasClass('selected')).toBe(true);
+    });
 
-    return {
-      dispatch,
-      getState,
-      profile,
-      store,
-      view,
-      trackReference,
-      trackIndex,
-      threadIndex,
-      pid,
-      getLocalTrackLabel,
-      getLocalTrackRow,
-    };
-  }
+    it('can right click a thread', () => {
+      const {
+        getState,
+        getLocalTrackLabel,
+        threadIndex,
+        trackReference,
+      } = setupThreadTrack();
 
-  it('matches the snapshot of a local track', () => {
-    const { view } = setup();
-    expect(view).toMatchSnapshot();
+      getLocalTrackLabel().simulate('mousedown', { button: RIGHT_CLICK });
+      expect(getRightClickedTrack(getState())).toEqual(trackReference);
+      expect(getSelectedThreadIndex(getState())).not.toBe(threadIndex);
+    });
+
+    it('can select a thread by clicking the row', () => {
+      const { getState, getLocalTrackRow, threadIndex } = setupThreadTrack();
+      expect(getSelectedThreadIndex(getState())).not.toBe(threadIndex);
+      getLocalTrackRow().simulate('click');
+      expect(getSelectedThreadIndex(getState())).toBe(threadIndex);
+    });
+
+    it('will render a stub div if the track is hidden', () => {
+      const { view, pid, trackReference, dispatch } = setupThreadTrack();
+      dispatch(hideLocalTrack(pid, trackReference.trackIndex));
+      view.update();
+      expect(view.find('.timelineTrackHidden').exists()).toBe(true);
+      expect(view.find('.timelineTrack').exists()).toBe(false);
+    });
   });
 
-  it('has the correct selectors into useful parts of the component', function() {
-    const { getLocalTrackLabel, getLocalTrackRow } = setup();
-    expect(getLocalTrackLabel().text()).toBe('DOM Worker');
-    expect(getLocalTrackRow().exists()).toBe(true);
-  });
+  describe('with a network track', function() {
+    it('has correctly renders the network label', function() {
+      const { getLocalTrackLabel } = setupWithNetworkProfile();
+      expect(getLocalTrackLabel().text()).toBe('Network');
+    });
 
-  it('starts out not being selected', function() {
-    const { getState, threadIndex, trackReference, getLocalTrackRow } = setup();
-    expect(getRightClickedTrack(getState())).not.toEqual(trackReference);
-    expect(getSelectedThreadIndex(getState())).not.toBe(threadIndex);
-    expect(getLocalTrackRow().hasClass('selected')).toBe(false);
-  });
-
-  it('can select a thread by clicking the label', () => {
-    const {
-      getState,
-      getLocalTrackLabel,
-      threadIndex,
-      getLocalTrackRow,
-    } = setup();
-    expect(getSelectedThreadIndex(getState())).not.toBe(threadIndex);
-    getLocalTrackLabel().simulate('mousedown', { button: LEFT_CLICK });
-    expect(getSelectedThreadIndex(getState())).toBe(threadIndex);
-    expect(getLocalTrackRow().hasClass('selected')).toBe(true);
-  });
-
-  it('can right click a thread', () => {
-    const {
-      getState,
-      getLocalTrackLabel,
-      threadIndex,
-      trackReference,
-    } = setup();
-
-    getLocalTrackLabel().simulate('mousedown', { button: RIGHT_CLICK });
-    expect(getRightClickedTrack(getState())).toEqual(trackReference);
-    expect(getSelectedThreadIndex(getState())).not.toBe(threadIndex);
-  });
-
-  it('can select a thread by clicking the row', () => {
-    const { getState, getLocalTrackRow, threadIndex } = setup();
-    expect(getSelectedThreadIndex(getState())).not.toBe(threadIndex);
-    getLocalTrackRow().simulate('click');
-    expect(getSelectedThreadIndex(getState())).toBe(threadIndex);
-  });
-
-  it('will render a stub div if the track is hidden', () => {
-    const { view, trackIndex, pid, dispatch } = setup();
-    dispatch(hideLocalTrack(pid, trackIndex));
-    view.update();
-    expect(view.find('.timelineTrackHidden').exists()).toBe(true);
-    expect(view.find('.timelineTrack').exists()).toBe(false);
+    it('matches the snapshot of the network track', () => {
+      const { view } = setupWithNetworkProfile();
+      expect(view).toMatchSnapshot();
+    });
   });
 });
+
+function setup(
+  store: Store,
+  trackReference: TrackReference,
+  localTrack: LocalTrack
+) {
+  const { getState, dispatch } = store;
+  const { threadIndex } = localTrack;
+  // The assertions are simpler if this thread is not already selected.
+  dispatch(changeSelectedThread(threadIndex + 1));
+
+  const view = mount(
+    <Provider store={store}>
+      <TimelineLocalTrack
+        pid={PID}
+        localTrack={localTrack}
+        trackIndex={trackReference.trackIndex}
+      />
+    </Provider>
+  );
+
+  const getLocalTrackLabel = () => view.find('.timelineTrackLabel').first();
+  const getLocalTrackRow = () => view.find('.timelineTrackLocalRow').first();
+
+  return {
+    dispatch,
+    getState,
+    profile: getProfile(getState()),
+    store,
+    view,
+    trackReference,
+    threadIndex,
+    pid: PID,
+    getLocalTrackLabel,
+    getLocalTrackRow,
+  };
+}
+
+/**
+ *  getProfileWithNiceTracks() looks like: [
+ *    'show [thread GeckoMain process]',
+ *    'show [thread GeckoMain tab]',
+ *    '  - show [thread DOM Worker]',         <- use this local track.
+ *    '  - show [thread Style]',
+ *  ]
+ */
+function setupThreadTrack() {
+  // Select the first local track index, which should be the one noted in the
+  // the comment above.
+  const trackIndex = 0;
+  const profile = getProfileWithNiceTracks();
+  const store = storeWithProfile(profile);
+  const trackReference = { type: 'local', pid: PID, trackIndex };
+  const localTrack = getLocalTrackFromReference(
+    store.getState(),
+    trackReference
+  );
+  if (localTrack.type !== 'thread') {
+    throw new Error('Expected a thread track.');
+  }
+  return setup(store, trackReference, localTrack);
+}
+
+function setupWithNetworkProfile() {
+  // Select the 2nd track, which will be the network track, while the first is the
+  // main thread.
+  const trackIndex = 1;
+  const profile = getNetworkTrackProfile();
+  profile.threads[0].pid = PID;
+
+  const store = storeWithProfile(profile);
+  const trackReference = { type: 'local', pid: PID, trackIndex };
+  const localTrack = getLocalTrackFromReference(
+    store.getState(),
+    trackReference
+  );
+  if (localTrack.type !== 'network') {
+    throw new Error('Expected a network track.');
+  }
+  return setup(store, trackReference, localTrack);
+}

--- a/src/test/components/TrackNetwork.test.js
+++ b/src/test/components/TrackNetwork.test.js
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+import * as React from 'react';
+import { Provider } from 'react-redux';
+import { mount } from 'enzyme';
+
+import TrackNetwork, {
+  ROW_HEIGHT,
+  ROW_REPEAT,
+} from '../../components/timeline/TrackNetwork';
+import mockCanvasContext from '../fixtures/mocks/canvas-context';
+import mockRaf from '../fixtures/mocks/request-animation-frame';
+import { storeWithProfile } from '../fixtures/stores';
+import { getBoundingBox } from '../fixtures/utils';
+
+import { getNetworkTrackProfile } from '../fixtures/profiles/make-profile';
+
+// The graph is 400 pixels wide based on the getBoundingBox mock, and the graph height
+// mimicks what is computed by the actual component.
+const GRAPH_WIDTH = 400;
+const GRAPH_HEIGHT = ROW_HEIGHT * ROW_REPEAT;
+
+describe('timeline/TrackNetwork', function() {
+  it('matches the component snapshot', () => {
+    const { view } = setup();
+    expect(view).toMatchSnapshot();
+    // Trigger any unmounting behavior handlers, just make sure it doesn't
+    // throw any errors.
+    view.unmount();
+  });
+
+  it('matches the 2d context snapshot', () => {
+    const { getContextDrawCalls } = setup();
+    expect(getContextDrawCalls()).toMatchSnapshot();
+  });
+
+  it('redraws on a resize', () => {
+    const { getContextDrawCalls } = setup();
+    // Flush out any existing draw calls.
+    getContextDrawCalls();
+    // Ensure we start out with 0.
+    expect(getContextDrawCalls().length).toEqual(0);
+
+    // Send out the resize, and ensure we are drawing.
+    window.dispatchEvent(new Event('resize'));
+    expect(getContextDrawCalls().length > 0).toBe(true);
+  });
+});
+
+function setup() {
+  const profile = getNetworkTrackProfile();
+  const store = storeWithProfile();
+  const { getState, dispatch } = store;
+  const flushRafCalls = mockRaf();
+  const ctx = mockCanvasContext();
+  jest
+    .spyOn(HTMLCanvasElement.prototype, 'getContext')
+    .mockImplementation(() => ctx);
+
+  jest
+    .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+    .mockImplementation(() => getBoundingBox(GRAPH_WIDTH, GRAPH_HEIGHT));
+
+  const view = mount(
+    <Provider store={store}>
+      <TrackNetwork threadIndex={0} />
+    </Provider>
+  );
+
+  // WithSize uses requestAnimationFrame
+  flushRafCalls();
+  view.update();
+
+  /**
+   * Coordinate the flushing of the requestAnimationFrame and the draw calls.
+   */
+  function getContextDrawCalls() {
+    flushRafCalls();
+    return ctx.__flushDrawLog();
+  }
+
+  return {
+    dispatch,
+    getState,
+    thread: profile.threads[0],
+    store,
+    view,
+    getContextDrawCalls,
+  };
+}

--- a/src/test/components/__snapshots__/LocalTrack.test.js.snap
+++ b/src/test/components/__snapshots__/LocalTrack.test.js.snap
@@ -1,6 +1,50 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`timeline/LocalTrack matches the snapshot of a local track 1`] = `
+exports[`timeline/LocalTrack with a network track matches the snapshot of the network track 1`] = `
+<li
+  className="timelineTrack timelineTrackLocal"
+>
+  <div
+    className="timelineTrackRow timelineTrackLocalRow"
+    onClick={[Function]}
+  >
+    <div
+      className="react-contextmenu-wrapper timelineTrackLabel timelineTrackLocalLabel timelineTrackLocalGrippy"
+      onContextMenu={[Function]}
+      onMouseDown={[Function]}
+      onMouseOut={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchStart={[Function]}
+      title={null}
+    >
+      <h1
+        className="timelineTrackName"
+      >
+        Network
+      </h1>
+    </div>
+    <div
+      className="timelineTrackTrack"
+    >
+      <div
+        className="timelineTrackNetwork"
+        style={
+          Object {
+            "height": 35,
+          }
+        }
+      >
+        <canvas
+          className="timelineTrackNetworkCanvas"
+        />
+      </div>
+    </div>
+  </div>
+</li>
+`;
+
+exports[`timeline/LocalTrack with a thread track matches the snapshot of a local track 1`] = `
 <li
   className="timelineTrack timelineTrackLocal"
 >

--- a/src/test/components/__snapshots__/TrackNetwork.test.js.snap
+++ b/src/test/components/__snapshots__/TrackNetwork.test.js.snap
@@ -1,0 +1,59 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`timeline/TrackNetwork matches the 2d context snapshot 1`] = `
+Array [
+  Array [
+    "clearRect",
+    0,
+    0,
+    0,
+    20,
+  ],
+  Array [
+    "set strokeStyle",
+    "rgba(0, 127, 255, 0.3)",
+  ],
+  Array [
+    "set lineCap",
+    "round",
+  ],
+  Array [
+    "set lineWidth",
+    3.75,
+  ],
+  Array [
+    "clearRect",
+    0,
+    0,
+    400,
+    20,
+  ],
+  Array [
+    "set strokeStyle",
+    "rgba(0, 127, 255, 0.3)",
+  ],
+  Array [
+    "set lineCap",
+    "round",
+  ],
+  Array [
+    "set lineWidth",
+    3.75,
+  ],
+]
+`;
+
+exports[`timeline/TrackNetwork matches the component snapshot 1`] = `
+<div
+  className="timelineTrackNetwork"
+  style={
+    Object {
+      "height": 20,
+    }
+  }
+>
+  <canvas
+    className="timelineTrackNetworkCanvas"
+  />
+</div>
+`;

--- a/src/test/components/__snapshots__/TrackNetwork.test.js.snap
+++ b/src/test/components/__snapshots__/TrackNetwork.test.js.snap
@@ -7,7 +7,7 @@ Array [
     0,
     0,
     0,
-    20,
+    25,
   ],
   Array [
     "set strokeStyle",
@@ -26,7 +26,7 @@ Array [
     0,
     0,
     400,
-    20,
+    25,
   ],
   Array [
     "set strokeStyle",
@@ -48,7 +48,7 @@ exports[`timeline/TrackNetwork matches the component snapshot 1`] = `
   className="timelineTrackNetwork"
   style={
     Object {
-      "height": 20,
+      "height": 25,
     }
   }
 >

--- a/src/test/fixtures/mocks/canvas-context.js
+++ b/src/test/fixtures/mocks/canvas-context.js
@@ -33,6 +33,9 @@ export default function mockCanvasContext() {
       clearRect: spyLog('clearRect'),
       beginPath: spyLog('beginPath'),
       closePath: spyLog('closePath'),
+      moveTo: spyLog('moveTo'),
+      lineTo: spyLog('lineTo'),
+      stroke: spyLog('stroke'),
       arc: spyLog('arc'),
       measureText: spyLog('measureText', text => ({ width: text.length * 5 })),
       createLinearGradient: spyLog('createLinearGradient', () => ({

--- a/src/test/fixtures/profiles/make-profile.js
+++ b/src/test/fixtures/profiles/make-profile.js
@@ -11,7 +11,7 @@ import type {
   IndexIntoCategoryList,
   CategoryList,
 } from '../../../types/profile';
-import type { MarkerPayload } from '../../../types/markers';
+import type { MarkerPayload, NetworkPayload } from '../../../types/markers';
 import type { Milliseconds } from '../../../types/units';
 
 // Array<[MarkerName, Milliseconds, Data]>
@@ -492,4 +492,30 @@ function _buildThreadFromTextOnlyStacks(
     samples.time.push(columnIndex);
   });
   return thread;
+}
+
+function getNetworkMarker(startTime: number, id) {
+  const payload: NetworkPayload = {
+    type: 'Network',
+    id,
+    pri: 0,
+    status: 'DONE',
+    startTime,
+    endTime: startTime + 1,
+  };
+  return ['Network', startTime, payload];
+}
+
+/**
+ * This function computes a profile with network markers, which will in turn generate
+ * a profile that contains a main thread track, and a network track.
+ *
+ * This generates 10 network markers ranged 3-4 ms on their start times.
+ */
+export function getNetworkTrackProfile() {
+  return getProfileWithMarkers(
+    Array(10)
+      .fill()
+      .map((_, i) => getNetworkMarker(3 + 0.1 * i, i))
+  );
 }

--- a/src/test/fixtures/profiles/make-profile.js
+++ b/src/test/fixtures/profiles/make-profile.js
@@ -499,7 +499,7 @@ function getNetworkMarker(startTime: number, id) {
     type: 'Network',
     id,
     pri: 0,
-    status: 'DONE',
+    status: 'STOP',
     startTime,
     endTime: startTime + 1,
   };

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -247,6 +247,11 @@ type UrlStateAction =
   | {| +type: 'COMMIT_RANGE', +start: number, +end: number |}
   | {| +type: 'POP_COMMITTED_RANGES', +firstPoppedFilterIndex: number |}
   | {| +type: 'CHANGE_SELECTED_THREAD', +selectedThreadIndex: ThreadIndex |}
+  | {|
+      +type: 'SELECT_TRACK',
+      +selectedThreadIndex: ThreadIndex,
+      +selectedTab: TabSlug,
+    |}
   | {| +type: 'CHANGE_RIGHT_CLICKED_TRACK', +trackReference: TrackReference |}
   | {| +type: 'CHANGE_CALL_TREE_SEARCH_STRING', +searchString: string |}
   | {|

--- a/src/types/reducers.js
+++ b/src/types/reducers.js
@@ -122,6 +122,7 @@ export type AppState = {|
   +hasZoomedViaMousewheel: boolean,
   +isSidebarOpenPerPanel: IsSidebarOpenPerPanelState,
   +panelLayoutGeneration: number,
+  +lastVisibleThreadTabSlug: TabSlug,
 |};
 
 export type ZippedProfilesState = {


### PR DESCRIPTION
[Deploy preview](https://deploy-preview-1189--perf-html.netlify.com/public/70d85c3ff35a08d5f66217eec9b3dba659508647/network-chart/?globalTrackOrder=1-2-0-3-4&hiddenGlobalTracks=5-6-1-2&localTrackOrderByPid=27270-0-1-2-3-4~27273-0~51000-0~&thread=0&v=3)

<del>I'm pushing this up at the end of the day, feel free to look at the deploy preview, but I plan on reading through it all again with some fresh eyes tomorrow before asking for review.</del>

Edit: This is now ready for review, @ola, would you feel comfortable reviewing this? I have split the work into multiple logical commits, so it will be easiest to look at each in turn, rather than the whole at once. I still haven't reproduced the first-paint effect Markus describes below.

Also resolves #1196