### PR TITLE
Component constructor removal

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,6 +37,9 @@ module.exports = {
     'react/no-redundant-should-component-update': 'error',
     'react/no-this-in-sfc': 'error',
     'react/no-typos': 'error',
+    // Flow provides enough coverage over the prop types, and there can be errors
+    // with some of the more complicated Flow types.
+    'react/prop-types': 'off',
     "react/jsx-curly-brace-presence": ['error', { "props": 'never', "children": 'never' }],
     // `no-unused-prop-types` is buggy when we use destructuring parameters in
     // functions as it misunderstands them as functional components.

--- a/src/components/app/FooterLinks.js
+++ b/src/components/app/FooterLinks.js
@@ -13,12 +13,9 @@ class FooterLinks extends PureComponent<{||}, State> {
     this.setState({ hide: true });
   };
 
-  constructor() {
-    super();
-    this.state = {
-      hide: false,
-    };
-  }
+  state = {
+    hide: false,
+  };
 
   render() {
     if (this.state.hide) {

--- a/src/components/app/Home.js
+++ b/src/components/app/Home.js
@@ -55,12 +55,16 @@ type UploadButtonProps = {
 
 class UploadButton extends React.PureComponent<UploadButtonProps> {
   _input: HTMLInputElement | null;
-  _takeInputRef = input => (this._input = input);
 
-  constructor(props: UploadButtonProps) {
-    super(props);
-    (this: any)._upload = this._upload.bind(this);
-  }
+  _takeInputRef = input => {
+    this._input = input;
+  };
+
+  _upload = () => {
+    if (this._input) {
+      this.props.retrieveProfileFromFile(this._input.files[0]);
+    }
+  };
 
   render() {
     return (
@@ -68,12 +72,6 @@ class UploadButton extends React.PureComponent<UploadButtonProps> {
         <input type="file" ref={this._takeInputRef} onChange={this._upload} />
       </div>
     );
-  }
-
-  _upload() {
-    if (this._input) {
-      this.props.retrieveProfileFromFile(this._input.files[0]);
-    }
   }
 }
 
@@ -124,22 +122,12 @@ type HomeState = {
 };
 
 class Home extends React.PureComponent<HomeProps, HomeState> {
-  _supportsWebExtensionAPI: boolean;
-  _isFirefox: boolean;
-
-  constructor(props: HomeProps) {
-    super(props);
-    (this: any)._startDragging = this._startDragging.bind(this);
-    (this: any)._stopDragging = this._stopDragging.bind(this);
-    (this: any)._handleProfileDrop = this._handleProfileDrop.bind(this);
-    this.state = {
-      isDragging: false,
-      isAddonInstalled: Boolean(window.isGeckoProfilerAddonInstalled),
-    };
-
-    this._supportsWebExtensionAPI = _supportsWebExtensionAPI();
-    this._isFirefox = _isFirefox();
-  }
+  _supportsWebExtensionAPI: boolean = _supportsWebExtensionAPI();
+  _isFirefox: boolean = _isFirefox();
+  state = {
+    isDragging: false,
+    isAddonInstalled: Boolean(window.isGeckoProfilerAddonInstalled),
+  };
 
   addonInstalled() {
     this.setState({ isAddonInstalled: true });
@@ -161,17 +149,17 @@ class Home extends React.PureComponent<HomeProps, HomeState> {
     document.removeEventListener(('drop': string), _preventDefault, false);
   }
 
-  _startDragging(event: Event) {
+  _startDragging = (event: Event) => {
     event.preventDefault();
     this.setState({ isDragging: true });
-  }
+  };
 
-  _stopDragging(event: Event) {
+  _stopDragging = (event: Event) => {
     event.preventDefault();
     this.setState({ isDragging: false });
-  }
+  };
 
-  _handleProfileDrop(event: DragEvent) {
+  _handleProfileDrop = (event: DragEvent) => {
     event.preventDefault();
     if (!event.dataTransfer) {
       return;
@@ -181,7 +169,7 @@ class Home extends React.PureComponent<HomeProps, HomeState> {
     if (files.length > 0) {
       this.props.retrieveProfileFromFile(files[0]);
     }
-  }
+  };
 
   _renderInstructions() {
     const { isAddonInstalled } = this.state;

--- a/src/components/app/MenuButtons.js
+++ b/src/components/app/MenuButtons.js
@@ -154,10 +154,16 @@ class ProfileSharingCompositeButton extends PureComponent<
   _permalinkButton: ButtonWithPanel | null;
   _uploadErrorButton: ButtonWithPanel | null;
   _permalinkTextField: HTMLInputElement | null;
-  _permalinkButtonCreated: (ButtonWithPanel | null) => void;
-  _uploadErrorButtonCreated: (ButtonWithPanel | null) => void;
-  _permalinkTextFieldCreated: (HTMLInputElement | null) => void;
-  _attemptToSecondaryShare: () => void;
+  _takePermalinkButtonRef = elem => {
+    this._permalinkButton = elem;
+  };
+  _takeUploadErrorButtonRef = elem => {
+    this._uploadErrorButton = elem;
+  };
+  _takePermalinkTextFieldRef = elem => {
+    this._permalinkTextField = elem;
+  };
+  _attemptToSecondaryShare = () => this._attemptToShare(true);
 
   constructor(props: ProfileSharingCompositeButtonProps) {
     super(props);
@@ -169,29 +175,6 @@ class ProfileSharingCompositeButton extends PureComponent<
       fullUrl: window.location.href,
       shortUrl: window.location.href,
       shareNetworkUrls: false,
-    };
-
-    (this: any)._attemptToShare = this._attemptToShare.bind(this);
-    (this: any)._attemptToSecondaryShare = this._attemptToShare.bind(
-      this,
-      true
-    );
-    (this: any)._onChangeShareNetworkUrls = this._onChangeShareNetworkUrls.bind(
-      this
-    );
-    (this: any)._onPermalinkPanelOpen = this._onPermalinkPanelOpen.bind(this);
-    (this: any)._onPermalinkPanelClose = this._onPermalinkPanelClose.bind(this);
-    (this: any)._onSecondarySharePanelOpen = this._onSecondarySharePanelOpen.bind(
-      this
-    );
-    this._permalinkButtonCreated = (elem: ButtonWithPanel | null) => {
-      this._permalinkButton = elem;
-    };
-    this._uploadErrorButtonCreated = (elem: ButtonWithPanel | null) => {
-      this._uploadErrorButton = elem;
-    };
-    this._permalinkTextFieldCreated = (elem: HTMLInputElement | null) => {
-      this._permalinkTextField = elem;
     };
   }
 
@@ -209,9 +192,9 @@ class ProfileSharingCompositeButton extends PureComponent<
     }
   }
 
-  _onPermalinkPanelOpen() {
+  _onPermalinkPanelOpen = () => {
     this._shortenUrlAndFocusTextFieldOnCompletion();
-  }
+  };
 
   _shortenUrlAndFocusTextFieldOnCompletion(): Promise<void> {
     return shortenUrl(this.state.fullUrl)
@@ -226,11 +209,11 @@ class ProfileSharingCompositeButton extends PureComponent<
       .catch(() => {});
   }
 
-  _onPermalinkPanelClose() {
+  _onPermalinkPanelClose = () => {
     if (this._permalinkTextField) {
       this._permalinkTextField.blur();
     }
-  }
+  };
 
   _notifyAnalytics() {
     sendAnalytics({
@@ -251,7 +234,7 @@ class ProfileSharingCompositeButton extends PureComponent<
    * them. We check the current state before attempting to share depending
    * on that flag.
    */
-  _attemptToShare(isSecondaryShare: boolean = false) {
+  _attemptToShare = (isSecondaryShare: boolean = false) => {
     if (
       ((!isSecondaryShare && this.state.state !== 'local') ||
         (isSecondaryShare && this.state.state !== 'public')) &&
@@ -346,15 +329,15 @@ class ProfileSharingCompositeButton extends PureComponent<
           eventAction: 'failed',
         });
       });
-  }
+  };
 
-  _onChangeShareNetworkUrls(event: SyntheticEvent<HTMLInputElement>) {
+  _onChangeShareNetworkUrls = (event: SyntheticEvent<HTMLInputElement>) => {
     this.setState({
       shareNetworkUrls: event.currentTarget.checked,
     });
-  }
+  };
 
-  _onSecondarySharePanelOpen() {
+  _onSecondarySharePanelOpen = () => {
     const { profileSharingStatus } = this.props;
     // In the secondary sharing panel, we disable the URL sharing checkbox and
     // force it to the value we haven't used yet.
@@ -363,7 +346,7 @@ class ProfileSharingCompositeButton extends PureComponent<
     this.setState({
       shareNetworkUrls: !profileSharingStatus.sharedWithUrls,
     });
-  }
+  };
 
   render() {
     const { state, uploadProgress, error, shortUrl } = this.state;
@@ -415,7 +398,7 @@ class ProfileSharingCompositeButton extends PureComponent<
         <UploadingStatus progress={uploadProgress} />
         <ButtonWithPanel
           className="menuButtonsPermalinkButton"
-          ref={this._permalinkButtonCreated}
+          ref={this._takePermalinkButtonRef}
           label="Permalink"
           panel={
             <ArrowPanel
@@ -428,14 +411,14 @@ class ProfileSharingCompositeButton extends PureComponent<
                 className="menuButtonsPermalinkTextField"
                 value={shortUrl}
                 readOnly="readOnly"
-                ref={this._permalinkTextFieldCreated}
+                ref={this._takePermalinkTextFieldRef}
               />
             </ArrowPanel>
           }
         />
         <ButtonWithPanel
           className="menuButtonsUploadErrorButton"
-          ref={this._uploadErrorButtonCreated}
+          ref={this._takeUploadErrorButtonRef}
           label="Upload Error"
           panel={
             <ArrowPanel
@@ -488,19 +471,15 @@ class ProfileDownloadButton extends PureComponent<
   ProfileDownloadButtonProps,
   ProfileDownloadButtonState
 > {
-  constructor(props: ProfileDownloadButtonProps) {
-    super(props);
-    this.state = {
-      uncompressedBlobUrl: '',
-      compressedBlobUrl: '',
-      uncompressedSize: 0,
-      compressedSize: 0,
-      filename: '',
-    };
-    (this: any)._onPanelOpen = this._onPanelOpen.bind(this);
-  }
+  state = {
+    uncompressedBlobUrl: '',
+    compressedBlobUrl: '',
+    uncompressedSize: 0,
+    compressedSize: 0,
+    filename: '',
+  };
 
-  _onPanelOpen() {
+  _onPanelOpen = () => {
     const { profile, rootRange } = this.props;
     const profileDate = new Date(profile.meta.startTime + rootRange.start);
     const serializedProfile = serializeProfile(profile);
@@ -528,7 +507,7 @@ class ProfileDownloadButton extends PureComponent<
       eventCategory: 'profile save locally',
       eventAction: 'save',
     });
-  }
+  };
 
   render() {
     const {

--- a/src/components/app/TabBar.js
+++ b/src/components/app/TabBar.js
@@ -22,17 +22,12 @@ type Props = {|
 |};
 
 class TabBar extends React.PureComponent<Props> {
-  constructor(props: Props) {
-    super(props);
-    (this: any)._mouseDownListener = this._mouseDownListener.bind(this);
-  }
-
-  _mouseDownListener(e: SyntheticMouseEvent<HTMLElement>) {
+  _mouseDownListener = (e: SyntheticMouseEvent<HTMLElement>) => {
     this.props.onSelectTab(e.currentTarget.dataset.name);
     // Prevent focusing the tab so that actual content like the
     // calltree can perform its own focusing.
     e.preventDefault();
-  }
+  };
 
   render() {
     const {

--- a/src/components/app/ZipFileViewer.js
+++ b/src/components/app/ZipFileViewer.js
@@ -123,7 +123,7 @@ const ZipFileRow = explicitConnect(zipFileRowConnectOptions);
 class ZipFileViewer extends React.PureComponent<Props> {
   _fixedColumns = [];
   _mainColumn = { propName: 'name', title: '', component: ZipFileRow };
-  _treeView: ?TreeView<IndexIntoZipFileTable, ZipDisplayData>;
+  _treeView: ?TreeView<ZipDisplayData>;
   _takeTreeViewRef = treeView => (this._treeView = treeView);
 
   componentWillMount() {

--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -76,10 +76,7 @@ class CallTreeComponent extends PureComponent<Props> {
   ];
   _mainColumn: Column = { propName: 'name', title: '' };
   _appendageColumn: Column = { propName: 'lib', title: '' };
-  _treeView: TreeView<
-    IndexIntoCallNodeTable,
-    CallNodeDisplayData
-  > | null = null;
+  _treeView: TreeView<CallNodeDisplayData> | null = null;
   _takeTreeViewRef = treeView => (this._treeView = treeView);
 
   componentDidMount() {

--- a/src/components/calltree/CallTree.js
+++ b/src/components/calltree/CallTree.js
@@ -68,30 +68,19 @@ type DispatchProps = {|
 type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
 
 class CallTreeComponent extends PureComponent<Props> {
-  _fixedColumns: Column[];
-  _mainColumn: Column;
-  _appendageColumn: Column;
-  _treeView: TreeView<IndexIntoCallNodeTable, CallNodeDisplayData> | null;
+  _fixedColumns: Column[] = [
+    { propName: 'totalTimePercent', title: '' },
+    { propName: 'totalTime', title: 'Running Time (ms)' },
+    { propName: 'selfTime', title: 'Self (ms)' },
+    { propName: 'icon', title: '', component: NodeIcon },
+  ];
+  _mainColumn: Column = { propName: 'name', title: '' };
+  _appendageColumn: Column = { propName: 'lib', title: '' };
+  _treeView: TreeView<
+    IndexIntoCallNodeTable,
+    CallNodeDisplayData
+  > | null = null;
   _takeTreeViewRef = treeView => (this._treeView = treeView);
-
-  constructor(props: Props) {
-    super(props);
-    this._fixedColumns = [
-      { propName: 'totalTimePercent', title: '' },
-      { propName: 'totalTime', title: 'Running Time (ms)' },
-      { propName: 'selfTime', title: 'Self (ms)' },
-      { propName: 'icon', title: '', component: NodeIcon },
-    ];
-    this._mainColumn = { propName: 'name', title: '' };
-    this._appendageColumn = { propName: 'lib', title: '' };
-    this._treeView = null;
-    (this: any)._onSelectedCallNodeChange = this._onSelectedCallNodeChange.bind(
-      this
-    );
-    (this: any)._onExpandedCallNodesChange = this._onExpandedCallNodesChange.bind(
-      this
-    );
-  }
 
   componentDidMount() {
     this.focus();
@@ -125,17 +114,17 @@ class CallTreeComponent extends PureComponent<Props> {
     }
   }
 
-  _onSelectedCallNodeChange(newSelectedCallNode: IndexIntoCallNodeTable) {
+  _onSelectedCallNodeChange = (newSelectedCallNode: IndexIntoCallNodeTable) => {
     const { callNodeInfo, threadIndex, changeSelectedCallNode } = this.props;
     changeSelectedCallNode(
       threadIndex,
       getCallNodePathFromIndex(newSelectedCallNode, callNodeInfo.callNodeTable)
     );
-  }
+  };
 
-  _onExpandedCallNodesChange(
+  _onExpandedCallNodesChange = (
     newExpandedCallNodeIndexes: Array<IndexIntoCallNodeTable | null>
-  ) {
+  ) => {
     const { callNodeInfo, threadIndex, changeExpandedCallNodes } = this.props;
     changeExpandedCallNodes(
       threadIndex,
@@ -143,7 +132,7 @@ class CallTreeComponent extends PureComponent<Props> {
         getCallNodePathFromIndex(callNodeIndex, callNodeInfo.callNodeTable)
       )
     );
-  }
+  };
 
   procureInterestingInitialSelection() {
     // Expand the heaviest callstack up to a certain depth and select the frame

--- a/src/components/flame-graph/Canvas.js
+++ b/src/components/flame-graph/Canvas.js
@@ -214,13 +214,6 @@ export function getHoverBackgroundColor(stackType: StackType): string {
 class FlameGraphCanvas extends React.PureComponent<Props> {
   _textMeasurement: null | TextMeasurement;
 
-  constructor(props: Props) {
-    super(props);
-    (this: any)._getHoveredStackInfo = this._getHoveredStackInfo.bind(this);
-    (this: any)._drawCanvas = this._drawCanvas.bind(this);
-    (this: any)._hitTest = this._hitTest.bind(this);
-  }
-
   componentDidUpdate(prevProps) {
     // If the stack depth changes (say, when changing the time range
     // selection or applying a transform), move the viewport
@@ -274,10 +267,10 @@ class FlameGraphCanvas extends React.PureComponent<Props> {
     }
   };
 
-  _drawCanvas(
+  _drawCanvas = (
     ctx: CanvasRenderingContext2D,
     hoveredItem: HoveredStackTiming | null
-  ) {
+  ) => {
     const {
       thread,
       flameGraphTiming,
@@ -380,12 +373,12 @@ class FlameGraphCanvas extends React.PureComponent<Props> {
         }
       }
     }
-  }
+  };
 
-  _getHoveredStackInfo({
+  _getHoveredStackInfo = ({
     depth,
     flameGraphTimingIndex,
-  }: HoveredStackTiming): React.Node {
+  }: HoveredStackTiming): React.Node => {
     const {
       thread,
       flameGraphTiming,
@@ -459,7 +452,7 @@ class FlameGraphCanvas extends React.PureComponent<Props> {
         </div>
       </div>
     );
-  }
+  };
 
   _onMouseDown = (hoveredItem: HoveredStackTiming | null) => {
     // Change our selection to the hovered item, or deselect (with
@@ -474,7 +467,7 @@ class FlameGraphCanvas extends React.PureComponent<Props> {
     this.props.onSelectionChange(callNodeIndex);
   };
 
-  _hitTest(x: CssPixels, y: CssPixels): HoveredStackTiming | null {
+  _hitTest = (x: CssPixels, y: CssPixels): HoveredStackTiming | null => {
     const {
       flameGraphTiming,
       maxStackDepth,
@@ -497,7 +490,7 @@ class FlameGraphCanvas extends React.PureComponent<Props> {
     }
 
     return null;
-  }
+  };
 
   _noOp = () => {};
 

--- a/src/components/marker-chart/Canvas.js
+++ b/src/components/marker-chart/Canvas.js
@@ -64,18 +64,10 @@ const MARKER_LABEL_MAX_LENGTH = 150;
 class MarkerChartCanvas extends React.PureComponent<Props, State> {
   _textMeasurement: null | TextMeasurement;
 
-  constructor(props: Props) {
-    super(props);
-    (this: any).onDoubleClickMarker = this.onDoubleClickMarker.bind(this);
-    (this: any).getHoveredMarkerInfo = this.getHoveredMarkerInfo.bind(this);
-    (this: any).drawCanvas = this.drawCanvas.bind(this);
-    (this: any).hitTest = this.hitTest.bind(this);
-  }
-
-  drawCanvas(
+  drawCanvas = (
     ctx: CanvasRenderingContext2D,
     hoveredItem: IndexIntoMarkerTiming | null
-  ) {
+  ) => {
     const {
       rowHeight,
       markerTimingRows,
@@ -98,7 +90,7 @@ class MarkerChartCanvas extends React.PureComponent<Props, State> {
 
     this.drawMarkers(ctx, hoveredItem, startRow, endRow);
     this.drawSeparatorsAndLabels(ctx, startRow, endRow);
-  }
+  };
 
   // Note: we used a long argument list instead of an object parameter on
   // purpose, to reduce GC pressure while drawing.
@@ -282,7 +274,7 @@ class MarkerChartCanvas extends React.PureComponent<Props, State> {
     }
   }
 
-  hitTest(x: CssPixels, y: CssPixels): IndexIntoMarkerTiming | null {
+  hitTest = (x: CssPixels, y: CssPixels): IndexIntoMarkerTiming | null => {
     const {
       rangeStart,
       rangeEnd,
@@ -317,9 +309,9 @@ class MarkerChartCanvas extends React.PureComponent<Props, State> {
       }
     }
     return null;
-  }
+  };
 
-  onDoubleClickMarker(markerIndex: IndexIntoMarkerTiming | null) {
+  onDoubleClickMarker = (markerIndex: IndexIntoMarkerTiming | null) => {
     if (markerIndex === null) {
       return;
     }
@@ -331,7 +323,7 @@ class MarkerChartCanvas extends React.PureComponent<Props, State> {
       selectionStart: marker.start,
       selectionEnd: marker.start + marker.dur,
     });
-  }
+  };
 
   drawRoundedRect(
     ctx: CanvasRenderingContext2D,
@@ -349,7 +341,7 @@ class MarkerChartCanvas extends React.PureComponent<Props, State> {
     ctx.fillRect(x + c, bottom - c, width - 2 * c, c);
   }
 
-  getHoveredMarkerInfo(hoveredItem: IndexIntoMarkerTiming): React.Node {
+  getHoveredMarkerInfo = (hoveredItem: IndexIntoMarkerTiming): React.Node => {
     const marker = this.props.markers[hoveredItem];
     return (
       <MarkerTooltipContents
@@ -357,7 +349,7 @@ class MarkerChartCanvas extends React.PureComponent<Props, State> {
         threadIndex={this.props.threadIndex}
       />
     );
-  }
+  };
 
   render() {
     const { containerWidth, containerHeight, isDragging } = this.props.viewport;

--- a/src/components/marker-table/ContextMenu.js
+++ b/src/components/marker-table/ContextMenu.js
@@ -41,11 +41,6 @@ type DispatchProps = {|
 type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
 
 class MarkersContextMenu extends PureComponent<Props> {
-  constructor(props: Props) {
-    super(props);
-    (this: any).handleClick = this.handleClick.bind(this);
-  }
-
   setStartRange() {
     const {
       selectedMarker,
@@ -102,10 +97,10 @@ class MarkersContextMenu extends PureComponent<Props> {
     );
   }
 
-  handleClick(
+  handleClick = (
     event: SyntheticEvent<>,
     data: { type: 'setStartRange' | 'setEndRange' | 'copyMarkerJSON' }
-  ): void {
+  ): void => {
     switch (data.type) {
       case 'setStartRange':
         this.setStartRange();
@@ -119,7 +114,7 @@ class MarkersContextMenu extends PureComponent<Props> {
       default:
         throw new Error(`Unknown type ${data.type}`);
     }
-  }
+  };
 
   render() {
     return (

--- a/src/components/marker-table/Settings.js
+++ b/src/components/marker-table/Settings.js
@@ -28,15 +28,9 @@ type DispatchProps = {|
 type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
 
 class Settings extends PureComponent<Props> {
-  constructor(props: Props) {
-    super(props);
-    (this: any)._onSearchFieldIdleAfterChange = this._onSearchFieldIdleAfterChange.bind(
-      this
-    );
-  }
-  _onSearchFieldIdleAfterChange(value: string) {
+  _onSearchFieldIdleAfterChange = (value: string) => {
     this.props.changeMarkersSearchString(value);
-  }
+  };
 
   render() {
     const { searchString } = this.props;

--- a/src/components/marker-table/index.js
+++ b/src/components/marker-table/index.js
@@ -150,7 +150,7 @@ class MarkerTable extends PureComponent<Props> {
   _mainColumn = { propName: 'name', title: '' };
   _expandedNodeIds: Array<IndexIntoMarkersTable | null> = [];
   _onExpandedNodeIdsChange = () => {};
-  _treeView: ?TreeView<IndexIntoMarkersTable, MarkerDisplayData>;
+  _treeView: ?TreeView<MarkerDisplayData>;
   _takeTreeViewRef = treeView => (this._treeView = treeView);
 
   componentDidMount() {

--- a/src/components/shared/ArrowPanel.js
+++ b/src/components/shared/ArrowPanel.js
@@ -26,21 +26,12 @@ type State = {
 };
 
 class ArrowPanel extends React.PureComponent<Props, State> {
-  _panelElementCreated: (HTMLElement | null) => void;
-  _panelElement: HTMLElement | null;
+  _panelElement: HTMLElement | null = null;
+  state = { open: false };
 
-  constructor(props: Props) {
-    super(props);
-    this.state = { open: false };
-    (this: any)._windowMouseDownListener = this._windowMouseDownListener.bind(
-      this
-    );
-    this._panelElementCreated = (elem: HTMLElement | null) => {
-      this._panelElement = elem;
-    };
-    (this: any)._onOkButtonClick = this._onOkButtonClick.bind(this);
-    (this: any)._onCancelButtonClick = this._onCancelButtonClick.bind(this);
-  }
+  _takePanelElementRef = (elem: HTMLElement | null) => {
+    this._panelElement = elem;
+  };
 
   open() {
     if (this.state.open) {
@@ -78,7 +69,7 @@ class ArrowPanel extends React.PureComponent<Props, State> {
     );
   }
 
-  _windowMouseDownListener(e: MouseEvent) {
+  _windowMouseDownListener = (e: MouseEvent) => {
     const target: Node = (e.target: any); // make flow happy
     if (
       this.state.open &&
@@ -87,21 +78,21 @@ class ArrowPanel extends React.PureComponent<Props, State> {
     ) {
       this.close();
     }
-  }
+  };
 
-  _onOkButtonClick() {
+  _onOkButtonClick = () => {
     this.close();
     if (this.props.onOkButtonClick) {
       this.props.onOkButtonClick();
     }
-  }
+  };
 
-  _onCancelButtonClick() {
+  _onCancelButtonClick = () => {
     this.close();
     if (this.props.onCancelButtonClick) {
       this.props.onCancelButtonClick();
     }
-  }
+  };
 
   render() {
     const {
@@ -122,7 +113,7 @@ class ArrowPanel extends React.PureComponent<Props, State> {
             { open, hasTitle, hasButtons },
             className
           )}
-          ref={this._panelElementCreated}
+          ref={this._takePanelElementRef}
         >
           <div className="arrowPanelArrow" />
           {hasTitle ? <h1 className="arrowPanelTitle">{title}</h1> : null}

--- a/src/components/shared/ButtonWithPanel.js
+++ b/src/components/shared/ButtonWithPanel.js
@@ -37,31 +37,11 @@ type State = {|
 |};
 
 class ButtonWithPanel extends React.PureComponent<Props, State> {
-  _panel: Panel | null;
-
-  _onPanelOpen: () => void;
-  _onPanelClose: () => void;
-  _panelCreated: (Panel | null) => void;
+  _panel: Panel | null = null;
 
   constructor(props: Props) {
     super(props);
     this.state = { open: !!props.open };
-    this._onPanelOpen = () => {
-      this.setState({ open: true });
-      if (this.props.panel.props.onOpen) {
-        this.props.panel.props.onOpen();
-      }
-    };
-    this._onPanelClose = () => {
-      this.setState({ open: false });
-      if (this.props.panel.props.onClose) {
-        this.props.panel.props.onClose();
-      }
-    };
-    (this: any)._onButtonClick = this._onButtonClick.bind(this);
-    this._panelCreated = (panel: Panel | null) => {
-      this._panel = panel;
-    };
   }
 
   componentWillReceiveProps(props: Props) {
@@ -70,15 +50,33 @@ class ButtonWithPanel extends React.PureComponent<Props, State> {
     }
   }
 
+  _onPanelOpen = () => {
+    this.setState({ open: true });
+    if (this.props.panel.props.onOpen) {
+      this.props.panel.props.onOpen();
+    }
+  };
+
+  _onPanelClose = () => {
+    this.setState({ open: false });
+    if (this.props.panel.props.onClose) {
+      this.props.panel.props.onClose();
+    }
+  };
+
+  _takePanelRef = (panel: Panel | null) => {
+    this._panel = panel;
+  };
+
   openPanel() {
     if (this._panel) {
       this._panel.open();
     }
   }
 
-  _onButtonClick() {
+  _onButtonClick = () => {
     this.openPanel();
-  }
+  };
 
   render() {
     const { className, label, panel, disabled } = this.props;
@@ -98,7 +96,7 @@ class ButtonWithPanel extends React.PureComponent<Props, State> {
           />
         </div>
         {React.cloneElement(panel, {
-          ref: this._panelCreated,
+          ref: this._takePanelRef,
           onOpen: this._onPanelOpen,
           onClose: this._onPanelClose,
         })}

--- a/src/components/shared/DivWithTooltip.js
+++ b/src/components/shared/DivWithTooltip.js
@@ -23,15 +23,11 @@ type State = {|
  * a div.
  */
 export default class DivWithTooltip extends React.PureComponent<Props, State> {
-  constructor(props: Props) {
-    super(props);
-
-    this.state = {
-      isMouseOver: false,
-      mouseX: 0,
-      mouseY: 0,
-    };
-  }
+  state = {
+    isMouseOver: false,
+    mouseX: 0,
+    mouseY: 0,
+  };
 
   componentWillUnmount() {
     document.removeEventListener('mousemove', this._onMouseMove, false);

--- a/src/components/shared/Draggable.js
+++ b/src/components/shared/Draggable.js
@@ -34,25 +34,20 @@ type State = {
  * During the drag, the additional className 'dragging' is set on the element.
  */
 export default class Draggable extends React.PureComponent<Props, State> {
-  _container: HTMLDivElement | null;
-  _containerCreated: (HTMLDivElement | null) => *;
+  _container: HTMLDivElement | null = null;
   _handlers: {
     mouseMoveHandler: MouseEvent => *,
     mouseUpHandler: MouseEvent => *,
-  } | null;
+  } | null = null;
+  state = {
+    dragging: false,
+  };
 
-  constructor(props: Props) {
-    super(props);
-    this.state = { dragging: false };
-    (this: any)._onMouseDown = this._onMouseDown.bind(this);
-    this._handlers = null;
-    this._container = null;
-    this._containerCreated = c => {
-      this._container = c;
-    };
-  }
+  _takeContainerRef = (c: HTMLDivElement | null) => {
+    this._container = c;
+  };
 
-  _onMouseDown(e: SyntheticMouseEvent<>) {
+  _onMouseDown = (e: SyntheticMouseEvent<>) => {
     if (!this._container || e.button !== 0) {
       return;
     }
@@ -90,7 +85,7 @@ export default class Draggable extends React.PureComponent<Props, State> {
     };
 
     this._installMoveAndUpHandlers(mouseMoveHandler, mouseUpHandler);
-  }
+  };
 
   _installMoveAndUpHandlers(
     mouseMoveHandler: MouseEvent => *,
@@ -125,7 +120,7 @@ export default class Draggable extends React.PureComponent<Props, State> {
       <div
         {...props}
         onMouseDown={this._onMouseDown}
-        ref={this._containerCreated}
+        ref={this._takeContainerRef}
       >
         {this.props.children}
       </div>

--- a/src/components/shared/FilterNavigatorBar.js
+++ b/src/components/shared/FilterNavigatorBar.js
@@ -12,22 +12,17 @@ import './FilterNavigatorBar.css';
 type Props = {|
   +className: string,
   +items: string[],
-  +onPop: number => *,
+  +onPop: number => mixed,
   +selectedItem: number,
   +uncommittedItem?: string,
 |};
 
 class FilterNavigatorBar extends PureComponent<Props> {
-  constructor(props: Props) {
-    super(props);
-    (this: any)._onLiClick = this._onLiClick.bind(this);
-  }
-
-  _onLiClick(e: SyntheticMouseEvent<HTMLLIElement>) {
+  _onLiClick = (e: SyntheticMouseEvent<HTMLLIElement>) => {
     const element = e.currentTarget;
     const index = parseInt(element.dataset.index, 10) || 0;
     this.props.onPop(index);
-  }
+  };
 
   render() {
     const { className, items, selectedItem, uncommittedItem } = this.props;

--- a/src/components/shared/Reorderable.js
+++ b/src/components/shared/Reorderable.js
@@ -47,40 +47,34 @@ type XY = {|
 type EventWithPageProperties = { pageX: number, pageY: number };
 
 class Reorderable extends React.PureComponent<Props, State> {
-  _xy: {| horizontal: XY, vertical: XY |};
+  _xy: {| horizontal: XY, vertical: XY |} = {
+    horizontal: {
+      pageXY: 'pageX',
+      translateXY: 'translateX',
+      lefttop: 'left',
+      rightbottom: 'right',
+    },
+    vertical: {
+      pageXY: 'pageY',
+      translateXY: 'translateY',
+      lefttop: 'top',
+      rightbottom: 'bottom',
+    },
+  };
 
-  constructor(props: Props) {
-    super(props);
-    (this: any)._onMouseDown = this._onMouseDown.bind(this);
-    this.state = {
-      phase: 'RESTING',
-      manipulatingIndex: -1,
-      destinationIndex: -1,
-      manipulationDelta: 0,
-      adjustPrecedingBy: 0,
-      adjustSucceedingBy: 0,
-      finalOffset: 0,
-    };
+  state = {
+    phase: 'RESTING',
+    manipulatingIndex: -1,
+    destinationIndex: -1,
+    manipulationDelta: 0,
+    adjustPrecedingBy: 0,
+    adjustSucceedingBy: 0,
+    finalOffset: 0,
+  };
 
-    this._xy = {
-      horizontal: {
-        pageXY: 'pageX',
-        translateXY: 'translateX',
-        lefttop: 'left',
-        rightbottom: 'right',
-      },
-      vertical: {
-        pageXY: 'pageY',
-        translateXY: 'translateY',
-        lefttop: 'top',
-        rightbottom: 'bottom',
-      },
-    };
-  }
-
-  _onMouseDown(
+  _onMouseDown = (
     event: { target: EventTarget } & SyntheticMouseEvent<HTMLElement>
-  ) {
+  ) => {
     const container = event.currentTarget;
 
     if (
@@ -111,7 +105,7 @@ class Reorderable extends React.PureComponent<Props, State> {
     }
 
     this._startDraggingElement(container, element, event);
-  }
+  };
 
   _getXY(): XY {
     return this._xy[this.props.orient];

--- a/src/components/shared/StackSearchField.js
+++ b/src/components/shared/StackSearchField.js
@@ -38,28 +38,18 @@ type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
 type State = {| searchFieldFocused: boolean |};
 
 class StackSearchField extends React.PureComponent<Props, State> {
-  constructor(props: Props) {
-    super(props);
-    (this: any)._onSearchFieldIdleAfterChange = this._onSearchFieldIdleAfterChange.bind(
-      this
-    );
-    (this: any)._onSearchFieldFocus = this._onSearchFieldFocus.bind(this);
-    (this: any)._onSearchFieldBlur = this._onSearchFieldBlur.bind(this);
-
-    this.state = { searchFieldFocused: false };
-  }
-
-  _onSearchFieldIdleAfterChange(value: string) {
+  state = { searchFieldFocused: false };
+  _onSearchFieldIdleAfterChange = (value: string) => {
     this.props.changeCallTreeSearchString(value);
-  }
+  };
 
-  _onSearchFieldFocus() {
+  _onSearchFieldFocus = () => {
     this.setState({ searchFieldFocused: true });
-  }
+  };
 
-  _onSearchFieldBlur() {
+  _onSearchFieldBlur = () => {
     this.setState(() => ({ searchFieldFocused: false }));
-  }
+  };
 
   render() {
     const { currentSearchString, searchStrings, className } = this.props;

--- a/src/components/shared/StackSettings.js
+++ b/src/components/shared/StackSettings.js
@@ -30,27 +30,17 @@ type Props = {|
 |};
 
 class StackSettings extends PureComponent<Props> {
-  constructor(props: Props) {
-    super(props);
-    (this: any)._onImplementationFilterChange = this._onImplementationFilterChange.bind(
-      this
-    );
-    (this: any)._onInvertCallstackClick = this._onInvertCallstackClick.bind(
-      this
-    );
-  }
-
-  _onImplementationFilterChange(e: SyntheticEvent<HTMLSelectElement>) {
+  _onImplementationFilterChange = (e: SyntheticEvent<HTMLSelectElement>) => {
     this.props.changeImplementationFilter(
       // This function is here to satisfy Flow that we are getting a valid
       // implementation filter.
       toValidImplementationFilter(e.currentTarget.value)
     );
-  }
+  };
 
-  _onInvertCallstackClick(e: SyntheticEvent<HTMLInputElement>) {
+  _onInvertCallstackClick = (e: SyntheticEvent<HTMLInputElement>) => {
     this.props.changeInvertCallstack(e.currentTarget.checked);
-  }
+  };
 
   render() {
     const {

--- a/src/components/shared/Tooltip.js
+++ b/src/components/shared/Tooltip.js
@@ -25,26 +25,22 @@ type State = {
 };
 
 export default class Tooltip extends React.PureComponent<Props, State> {
-  _isMounted: boolean;
+  _isMounted: boolean = false;
   _mountElement: ?HTMLElement;
+
+  state = {
+    interiorElement: null,
+    isNewContentLaidOut: false,
+  };
 
   // This allows to get the store so that we can pass it along to the tooltip
   // children with a react-redux Provider. We can safely remove it once we use
   // React 16's portals.
   static contextTypes = { store: PropTypes.object.isRequired };
 
-  constructor(props: Props) {
-    super(props);
-    (this: any)._setMountElement = this._setMountElement.bind(this);
-    this.state = {
-      interiorElement: null,
-      isNewContentLaidOut: false,
-    };
-  }
-
-  _setMountElement(el: HTMLElement | null) {
+  _takeInteriorElementRef = (el: HTMLElement | null) => {
     this.setState({ interiorElement: el });
-  }
+  };
 
   componentDidMount() {
     this._isMounted = true;
@@ -138,7 +134,11 @@ export default class Tooltip extends React.PureComponent<Props, State> {
 
     ReactDOM.render(
       <Provider store={this.context.store}>
-        <div className="tooltip" style={style} ref={this._setMountElement}>
+        <div
+          className="tooltip"
+          style={style}
+          ref={this._takeInteriorElementRef}
+        >
           {children}
         </div>
       </Provider>,

--- a/src/components/shared/TreeView.js
+++ b/src/components/shared/TreeView.js
@@ -26,6 +26,7 @@ const PAGE_KEYS_DELTA = 15;
 // This is used for the result of RegExp.prototype.exec because Flow doesn't do it.
 // See https://github.com/facebook/flow/issues/4099
 type RegExpResult = null | ({ index: number, input: string } & string[]);
+type NodeIndex = number;
 
 export type Column = {
   propName: string,
@@ -96,7 +97,7 @@ function reactStringWithHighlightedSubstrings(
   return highlighted;
 }
 
-type TreeViewRowFixedColumnsProps<NodeIndex: number, DisplayData: Object> = {|
+type TreeViewRowFixedColumnsProps<DisplayData: Object> = {|
   +displayData: DisplayData,
   +nodeId: NodeIndex,
   +columns: Column[],
@@ -107,11 +108,8 @@ type TreeViewRowFixedColumnsProps<NodeIndex: number, DisplayData: Object> = {|
   +rowHeightStyle: { height: CssPixels, lineHeight: string },
 |};
 
-class TreeViewRowFixedColumns<
-  NodeIndex: number,
-  DisplayData: Object
-> extends React.PureComponent<
-  TreeViewRowFixedColumnsProps<NodeIndex, DisplayData>
+class TreeViewRowFixedColumns<DisplayData: Object> extends React.PureComponent<
+  TreeViewRowFixedColumnsProps<DisplayData>
 > {
   _onClick = (event: SyntheticMouseEvent<>) => {
     const { nodeId, onClick } = this.props;
@@ -165,10 +163,7 @@ class TreeViewRowFixedColumns<
   }
 }
 
-type TreeViewRowScrolledColumnsProps<
-  NodeIndex: number,
-  DisplayData: Object
-> = {|
+type TreeViewRowScrolledColumnsProps<DisplayData: Object> = {|
   +displayData: DisplayData,
   +nodeId: NodeIndex,
   +depth: number,
@@ -188,11 +183,8 @@ type TreeViewRowScrolledColumnsProps<
 |};
 
 class TreeViewRowScrolledColumns<
-  NodeIndex: number,
   DisplayData: Object
-> extends React.PureComponent<
-  TreeViewRowScrolledColumnsProps<NodeIndex, DisplayData>
-> {
+> extends React.PureComponent<TreeViewRowScrolledColumnsProps<DisplayData>> {
   /**
    * In this mousedown handler, we use event delegation so we have to use
    * `target` instead of `currentTarget`.
@@ -281,7 +273,7 @@ class TreeViewRowScrolledColumns<
   }
 }
 
-interface Tree<NodeIndex: number, DisplayData: Object> {
+interface Tree<DisplayData: Object> {
   getDepth(NodeIndex): number;
   getRoots(): NodeIndex[];
   getDisplayData(NodeIndex): DisplayData;
@@ -291,10 +283,10 @@ interface Tree<NodeIndex: number, DisplayData: Object> {
   getAllDescendants(NodeIndex): Set<NodeIndex>;
 }
 
-type TreeViewProps<NodeIndex, DisplayData> = {|
+type TreeViewProps<DisplayData> = {|
   +fixedColumns: Column[],
   +mainColumn: Column,
-  +tree: Tree<NodeIndex, DisplayData>,
+  +tree: Tree<DisplayData>,
   +expandedNodeIds: Array<NodeIndex | null>,
   +selectedNodeId: NodeIndex | null,
   +onExpandedNodesChange: (Array<NodeIndex | null>) => mixed,
@@ -311,17 +303,16 @@ type TreeViewProps<NodeIndex, DisplayData> = {|
   +indentWidth: CssPixels,
 |};
 
-class TreeView<
-  NodeIndex: number,
-  DisplayData: Object
-> extends React.PureComponent<TreeViewProps<NodeIndex, DisplayData>> {
+class TreeView<DisplayData: Object> extends React.PureComponent<
+  TreeViewProps<DisplayData>
+> {
   _specialItems: (NodeIndex | null)[];
   _visibleRows: NodeIndex[];
   _expandedNodes: Set<NodeIndex | null>;
   _list: VirtualList | null = null;
   _takeListRef = (list: VirtualList | null) => (this._list = list);
 
-  constructor(props: TreeViewProps<NodeIndex, DisplayData>) {
+  constructor(props: TreeViewProps<DisplayData>) {
     super(props);
     this._specialItems = [props.selectedNodeId];
     this._expandedNodes = new Set(props.expandedNodeIds);
@@ -338,7 +329,7 @@ class TreeView<
     }
   }
 
-  componentWillReceiveProps(nextProps: TreeViewProps<NodeIndex, DisplayData>) {
+  componentWillReceiveProps(nextProps: TreeViewProps<DisplayData>) {
     if (nextProps.selectedNodeId !== this.props.selectedNodeId) {
       this._specialItems = [nextProps.selectedNodeId];
     }
@@ -404,7 +395,7 @@ class TreeView<
   };
 
   _addVisibleRowsFromNode(
-    props: TreeViewProps<NodeIndex, DisplayData>,
+    props: TreeViewProps<DisplayData>,
     arr: NodeIndex[],
     nodeId: NodeIndex,
     depth: number
@@ -419,9 +410,7 @@ class TreeView<
     }
   }
 
-  _getAllVisibleRows(
-    props: TreeViewProps<NodeIndex, DisplayData>
-  ): NodeIndex[] {
+  _getAllVisibleRows(props: TreeViewProps<DisplayData>): NodeIndex[] {
     const roots = props.tree.getRoots();
     const allRows = [];
     for (let i = 0; i < roots.length; i++) {
@@ -482,10 +471,8 @@ class TreeView<
     const { tree, selectedNodeId, mainColumn } = this.props;
     if (selectedNodeId) {
       const displayData = tree.getDisplayData(selectedNodeId);
-      event.clipboardData.setData(
-        'text/plain',
-        displayData[mainColumn.propName]
-      );
+      const clipboardData: DataTransfer = (event: Object).clipboardData;
+      clipboardData.setData('text/plain', displayData[mainColumn.propName]);
     }
   };
 

--- a/src/components/shared/TreeView.js
+++ b/src/components/shared/TreeView.js
@@ -113,15 +113,10 @@ class TreeViewRowFixedColumns<
 > extends React.PureComponent<
   TreeViewRowFixedColumnsProps<NodeIndex, DisplayData>
 > {
-  constructor(props: TreeViewRowFixedColumnsProps<NodeIndex, DisplayData>) {
-    super(props);
-    (this: any)._onClick = this._onClick.bind(this);
-  }
-
-  _onClick(event: SyntheticMouseEvent<>) {
+  _onClick = (event: SyntheticMouseEvent<>) => {
     const { nodeId, onClick } = this.props;
     onClick(nodeId, event);
-  }
+  };
 
   render() {
     const {
@@ -198,23 +193,18 @@ class TreeViewRowScrolledColumns<
 > extends React.PureComponent<
   TreeViewRowScrolledColumnsProps<NodeIndex, DisplayData>
 > {
-  constructor(props: TreeViewRowScrolledColumnsProps<NodeIndex, DisplayData>) {
-    super(props);
-    (this: any)._onClick = this._onClick.bind(this);
-  }
-
   /**
    * In this mousedown handler, we use event delegation so we have to use
    * `target` instead of `currentTarget`.
    */
-  _onClick(event: { target: Element } & SyntheticMouseEvent<Element>) {
+  _onClick = (event: { target: Element } & SyntheticMouseEvent<Element>) => {
     const { nodeId, isExpanded, onToggle, onClick } = this.props;
     if (event.target.classList.contains('treeRowToggleButton')) {
       onToggle(nodeId, !isExpanded, event.altKey === true);
     } else {
       onClick(nodeId, event);
     }
-  }
+  };
 
   render() {
     const {
@@ -328,20 +318,14 @@ class TreeView<
   _specialItems: (NodeIndex | null)[];
   _visibleRows: NodeIndex[];
   _expandedNodes: Set<NodeIndex | null>;
-  _list: VirtualList | null;
+  _list: VirtualList | null = null;
   _takeListRef = (list: VirtualList | null) => (this._list = list);
 
   constructor(props: TreeViewProps<NodeIndex, DisplayData>) {
     super(props);
-    (this: any)._renderRow = this._renderRow.bind(this);
-    (this: any)._toggle = this._toggle.bind(this);
-    (this: any)._onKeyDown = this._onKeyDown.bind(this);
-    (this: any)._onCopy = this._onCopy.bind(this);
-    (this: any)._onRowClicked = this._onRowClicked.bind(this);
     this._specialItems = [props.selectedNodeId];
     this._expandedNodes = new Set(props.expandedNodeIds);
     this._visibleRows = this._getAllVisibleRows(props);
-    this._list = null;
   }
 
   scrollSelectionIntoView() {
@@ -367,7 +351,7 @@ class TreeView<
     }
   }
 
-  _renderRow(nodeId: NodeIndex, index: number, columnIndex: number) {
+  _renderRow = (nodeId: NodeIndex, index: number, columnIndex: number) => {
     const {
       tree,
       fixedColumns,
@@ -417,7 +401,7 @@ class TreeView<
         indentWidth={indentWidth}
       />
     );
-  }
+  };
 
   _addVisibleRowsFromNode(
     props: TreeViewProps<NodeIndex, DisplayData>,
@@ -450,11 +434,11 @@ class TreeView<
     return !this._expandedNodes.has(nodeId);
   }
 
-  _toggle(
+  _toggle = (
     nodeId: NodeIndex,
     newExpanded: boolean = this._isCollapsed(nodeId),
     toggleAll: * = false
-  ) {
+  ) => {
     const newSet = new Set(this._expandedNodes);
     if (newExpanded) {
       newSet.add(nodeId);
@@ -467,7 +451,7 @@ class TreeView<
       newSet.delete(nodeId);
     }
     this.props.onExpandedNodesChange(Array.from(newSet.values()));
-  }
+  };
 
   _toggleAll(
     nodeId: NodeIndex,
@@ -480,20 +464,20 @@ class TreeView<
     this.props.onSelectionChange(nodeId);
   }
 
-  _onRowClicked(nodeId: NodeIndex, event: SyntheticMouseEvent<>) {
+  _onRowClicked = (nodeId: NodeIndex, event: SyntheticMouseEvent<>) => {
     this._select(nodeId);
     if (event.detail === 2 && event.button === 0) {
       // double click
       this._toggle(nodeId);
     }
-  }
+  };
 
   /**
    * Flow doesn't yet know about Clipboard events, so infer what's going on with the
    * event.
    * See: https://github.com/facebook/flow/issues/1856
    */
-  _onCopy(event: *) {
+  _onCopy = (event: *) => {
     event.preventDefault();
     const { tree, selectedNodeId, mainColumn } = this.props;
     if (selectedNodeId) {
@@ -503,9 +487,9 @@ class TreeView<
         displayData[mainColumn.propName]
       );
     }
-  }
+  };
 
-  _onKeyDown(event: KeyboardEvent) {
+  _onKeyDown = (event: KeyboardEvent) => {
     const hasModifier = event.ctrlKey || event.altKey;
     const isNavigationKey =
       event.key.startsWith('Arrow') ||
@@ -624,7 +608,7 @@ class TreeView<
         onEnterKey(selectedNodeId);
       }
     }
-  }
+  };
 
   focus() {
     if (this._list) {

--- a/src/components/shared/chart/Canvas.js
+++ b/src/components/shared/chart/Canvas.js
@@ -38,32 +38,18 @@ export default class ChartCanvas<HoveredItem> extends React.Component<
   Props<HoveredItem>,
   State<HoveredItem>
 > {
-  _devicePixelRatio: number;
-  _offsetX: CssPixels;
-  _offsetY: CssPixels;
+  _devicePixelRatio: number = 1;
+  _offsetX: CssPixels = 0;
+  _offsetY: CssPixels = 0;
   _ctx: CanvasRenderingContext2D;
-  _canvas: HTMLCanvasElement | null;
-  _isDrawScheduled: boolean;
+  _canvas: HTMLCanvasElement | null = null;
+  _isDrawScheduled: boolean = false;
 
-  constructor(props: Props<HoveredItem>) {
-    super(props);
-    this._devicePixelRatio = 1;
-    this._offsetX = 0;
-    this._offsetY = 0;
-    this._isDrawScheduled = false;
-    this.state = {
-      hoveredItem: null,
-      pageX: 0,
-      pageY: 0,
-    };
-
-    (this: any)._setCanvasRef = this._setCanvasRef.bind(this);
-    (this: any)._onMouseDown = this._onMouseDown.bind(this);
-    (this: any)._onMouseMove = this._onMouseMove.bind(this);
-    (this: any)._onMouseOut = this._onMouseOut.bind(this);
-    (this: any)._onDoubleClick = this._onDoubleClick.bind(this);
-    (this: any)._getHoveredItemInfo = this._getHoveredItemInfo.bind(this);
-  }
+  state: State<HoveredItem> = {
+    hoveredItem: null,
+    pageX: 0,
+    pageY: 0,
+  };
 
   _scheduleDraw() {
     const { className, drawCanvas } = this.props;
@@ -112,13 +98,15 @@ export default class ChartCanvas<HoveredItem> extends React.Component<
     }
   }
 
-  _onMouseDown() {
+  _onMouseDown = () => {
     if (this.props.onMouseDown) {
       this.props.onMouseDown(this.state.hoveredItem);
     }
-  }
+  };
 
-  _onMouseMove(event: { nativeEvent: MouseEvent } & SyntheticMouseEvent<>) {
+  _onMouseMove = (
+    event: { nativeEvent: MouseEvent } & SyntheticMouseEvent<>
+  ) => {
     if (!this._canvas) {
       return;
     }
@@ -138,29 +126,29 @@ export default class ChartCanvas<HoveredItem> extends React.Component<
         hoveredItem: null,
       });
     }
-  }
+  };
 
-  _onMouseOut() {
+  _onMouseOut = () => {
     if (this.state.hoveredItem !== null) {
       this.setState({ hoveredItem: null });
     }
-  }
+  };
 
-  _onDoubleClick() {
+  _onDoubleClick = () => {
     this.props.onDoubleClickItem(this.state.hoveredItem);
-  }
+  };
 
-  _getHoveredItemInfo(): React.Node {
+  _getHoveredItemInfo = (): React.Node => {
     const { hoveredItem } = this.state;
     if (hoveredItem === null) {
       return null;
     }
     return this.props.getHoveredItemInfo(hoveredItem);
-  }
+  };
 
-  _setCanvasRef(canvas: HTMLCanvasElement | null) {
+  _takeCanvasRef = (canvas: HTMLCanvasElement | null) => {
     this._canvas = canvas;
-  }
+  };
 
   componentWillReceiveProps() {
     // It is possible that the data backing the chart has been
@@ -206,7 +194,7 @@ export default class ChartCanvas<HoveredItem> extends React.Component<
       <div>
         <canvas
           className={className}
-          ref={this._setCanvasRef}
+          ref={this._takeCanvasRef}
           onMouseDown={this._onMouseDown}
           onMouseMove={this._onMouseMove}
           onMouseOut={this._onMouseOut}

--- a/src/components/shared/chart/Viewport.js
+++ b/src/components/shared/chart/Viewport.js
@@ -156,28 +156,17 @@ export const withChartViewport: WithChartViewport<*, *> =
     >;
 
     class ChartViewport extends React.PureComponent<ViewportProps, State> {
-      shiftScrollId: number;
-      zoomRangeSelectionScheduled: boolean;
-      zoomRangeSelectionScrollDelta: number;
-      _container: HTMLElement | null;
-      _takeContainerRef = container => (this._container = container);
+      shiftScrollId: number = 0;
+      zoomRangeSelectionScheduled: boolean = false;
+      zoomRangeSelectionScrollDelta: number = 0;
+      _container: HTMLElement | null = null;
+
+      _takeContainerRef = container => {
+        this._container = container;
+      };
 
       constructor(props: ViewportProps) {
         super(props);
-        (this: any).moveViewport = this.moveViewport.bind(this);
-        (this: any)._mouseWheelListener = this._mouseWheelListener.bind(this);
-        (this: any)._mouseDownListener = this._mouseDownListener.bind(this);
-        (this: any)._mouseMoveListener = this._mouseMoveListener.bind(this);
-        (this: any)._mouseUpListener = this._mouseUpListener.bind(this);
-
-        (this: any)._setSize = this._setSize.bind(this);
-        (this: any)._setSizeNextFrame = this._setSizeNextFrame.bind(this);
-
-        this.shiftScrollId = 0;
-        this.zoomRangeSelectionScheduled = false;
-        this.zoomRangeSelectionScrollDelta = 0;
-        this._container = null;
-
         this.state = this.getDefaultState(props);
       }
 
@@ -257,7 +246,7 @@ export const withChartViewport: WithChartViewport<*, *> =
         }
       }
 
-      _setSize() {
+      _setSize = () => {
         if (this._container) {
           const rect = this._container.getBoundingClientRect();
           const { startsAtBottom } = this.props.viewportProps;
@@ -279,13 +268,13 @@ export const withChartViewport: WithChartViewport<*, *> =
             }));
           }
         }
-      }
+      };
 
-      _setSizeNextFrame() {
+      _setSizeNextFrame = () => {
         requestAnimationFrame(this._setSize);
-      }
+      };
 
-      _mouseWheelListener(event: SyntheticWheelEvent<>) {
+      _mouseWheelListener = (event: SyntheticWheelEvent<>) => {
         // We handle the wheel event, so disable the browser's handling, such
         // as back/forward swiping or scrolling.
         event.preventDefault();
@@ -309,7 +298,7 @@ export const withChartViewport: WithChartViewport<*, *> =
           -getNormalizedScrollDelta(event, containerHeight, 'deltaX'),
           -getNormalizedScrollDelta(event, containerHeight, 'deltaY')
         );
-      }
+      };
 
       zoomRangeSelection(event: SyntheticWheelEvent<>) {
         const {
@@ -400,15 +389,15 @@ export const withChartViewport: WithChartViewport<*, *> =
         }
       }
 
-      _mouseDownListener(event: SyntheticMouseEvent<>) {
+      _mouseDownListener = (event: SyntheticMouseEvent<>) => {
         event.stopPropagation();
         event.preventDefault();
 
         window.addEventListener('mousemove', this._mouseMoveListener, true);
         window.addEventListener('mouseup', this._mouseUpListener, true);
-      }
+      };
 
-      _mouseMoveListener(event: MouseEvent) {
+      _mouseMoveListener = (event: MouseEvent) => {
         event.stopPropagation();
         event.preventDefault();
 
@@ -428,9 +417,9 @@ export const withChartViewport: WithChartViewport<*, *> =
         });
 
         this.moveViewport(offsetX, offsetY);
-      }
+      };
 
-      moveViewport(offsetX: CssPixels, offsetY: CssPixels): boolean {
+      moveViewport = (offsetX: CssPixels, offsetY: CssPixels): boolean => {
         const {
           updatePreviewSelection,
           viewportProps: {
@@ -507,9 +496,9 @@ export const withChartViewport: WithChartViewport<*, *> =
         }
 
         return viewportVerticalChanged || viewportHorizontalChanged;
-      }
+      };
 
-      _mouseUpListener(event: MouseEvent) {
+      _mouseUpListener = (event: MouseEvent) => {
         event.stopPropagation();
         event.preventDefault();
         window.removeEventListener('mousemove', this._mouseMoveListener, true);
@@ -517,7 +506,7 @@ export const withChartViewport: WithChartViewport<*, *> =
         this.setState({
           isDragging: false,
         });
-      }
+      };
 
       componentDidMount() {
         window.addEventListener('resize', this._setSizeNextFrame, false);

--- a/src/components/stack-chart/Canvas.js
+++ b/src/components/stack-chart/Canvas.js
@@ -57,15 +57,7 @@ const TEXT_OFFSET_START = 3;
 const TEXT_OFFSET_TOP = 11;
 
 class StackChartCanvas extends React.PureComponent<Props> {
-  _textMeasurement: null | TextMeasurement;
-
-  constructor(props: Props) {
-    super(props);
-    (this: any)._onDoubleClickStack = this._onDoubleClickStack.bind(this);
-    (this: any)._getHoveredStackInfo = this._getHoveredStackInfo.bind(this);
-    (this: any)._drawCanvas = this._drawCanvas.bind(this);
-    (this: any)._hitTest = this._hitTest.bind(this);
-  }
+  _textMeasurement: null | TextMeasurement = null;
 
   /**
    * Draw the canvas.
@@ -76,10 +68,10 @@ class StackChartCanvas extends React.PureComponent<Props> {
    * src/components/shared/chart/Viewport.js for a diagram detailing the various
    * components of this set-up.
    */
-  _drawCanvas(
+  _drawCanvas = (
     ctx: CanvasRenderingContext2D,
     hoveredItem: HoveredStackTiming | null
-  ) {
+  ) => {
     const {
       thread,
       rangeStart,
@@ -192,12 +184,12 @@ class StackChartCanvas extends React.PureComponent<Props> {
         }
       }
     }
-  }
+  };
 
-  _getHoveredStackInfo({
+  _getHoveredStackInfo = ({
     depth,
     stackTableIndex,
-  }: HoveredStackTiming): React.Node {
+  }: HoveredStackTiming): React.Node => {
     const { thread, getLabel, getCategory, stackTimingByDepth } = this.props;
     const stackTiming = stackTimingByDepth[depth];
 
@@ -260,9 +252,9 @@ class StackChartCanvas extends React.PureComponent<Props> {
         </div>
       </div>
     );
-  }
+  };
 
-  _onDoubleClickStack(hoveredItem: HoveredStackTiming | null) {
+  _onDoubleClickStack = (hoveredItem: HoveredStackTiming | null) => {
     if (hoveredItem === null) {
       return;
     }
@@ -274,9 +266,9 @@ class StackChartCanvas extends React.PureComponent<Props> {
       selectionStart: stackTimingByDepth[depth].start[stackTableIndex],
       selectionEnd: stackTimingByDepth[depth].end[stackTableIndex],
     });
-  }
+  };
 
-  _hitTest(x: CssPixels, y: CssPixels): HoveredStackTiming | null {
+  _hitTest = (x: CssPixels, y: CssPixels): HoveredStackTiming | null => {
     const {
       rangeStart,
       rangeEnd,
@@ -306,7 +298,7 @@ class StackChartCanvas extends React.PureComponent<Props> {
     }
 
     return null;
-  }
+  };
 
   render() {
     const { containerWidth, containerHeight, isDragging } = this.props.viewport;


### PR DESCRIPTION
Remove constructors from the components, and rely upon class initializers

We added the transform-class-properties transform in cf4d92e09, and agreed to
start using the following pattern for bound functions:

```js
class MyClass {
  myValue: boolean = false;
  myBoundHandler = () => {
    // handle something
  }
}
```

rather than

```js
class MyClass {
  constructor() {
    super();
    this.myValue = false
    (this: any).myBoundHandler = this.myBoundHandler.bind(this);
  }
}
```

However, no effort was made to convert everything en masse, but we have
been doing it with new and modified components. This PR converts every
existing component to use the new pattern.

There are two additional commits with changes to an eslint rule and some types. They should contain justifications for the changes in the commit messages.