### PR TITLE
Provide a generation value in state for invalidating panel layout sizing

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -75,6 +75,10 @@ export function changeSidebarOpenState(tab: TabSlug, isOpen: boolean): Action {
   return { type: 'CHANGE_SIDEBAR_OPEN_STATE', tab, isOpen };
 }
 
+export function invalidatePanelLayout(): Action {
+  return { type: 'INCREMENT_PANEL_LAYOUT_GENERATION' };
+}
+
 /**
  * This function is called when a browser navigation event happens. A new UrlState
  * is generated when the window.location is serialized, or the state is pulled out of

--- a/src/components/app/DetailsContainer.js
+++ b/src/components/app/DetailsContainer.js
@@ -9,26 +9,35 @@ import SplitterLayout from 'react-splitter-layout';
 import Details from './Details';
 import selectSidebar from '../sidebar';
 
+import { invalidatePanelLayout } from '../../actions/app';
 import { getSelectedTab } from '../../reducers/url-state';
 import { getIsSidebarOpen } from '../../reducers/app';
 import explicitConnect from '../../utils/connect';
 
 import type { TabSlug } from '../../app-logic/tabs-handling';
-import type { ExplicitConnectOptions } from '../../utils/connect';
+import type {
+  ExplicitConnectOptions,
+  ConnectedProps,
+} from '../../utils/connect';
 
 import './DetailsContainer.css';
-
-function dispatchResizeEvent() {
-  const event = new UIEvent('resize', { view: window });
-  window.dispatchEvent(event);
-}
 
 type StateProps = {|
   +selectedTab: TabSlug,
   +isSidebarOpen: boolean,
 |};
 
-function DetailsContainer({ selectedTab, isSidebarOpen }: StateProps) {
+type DispatchProps = {|
+  +invalidatePanelLayout: typeof invalidatePanelLayout,
+|};
+
+type Props = ConnectedProps<{||}, StateProps, DispatchProps>;
+
+function DetailsContainer({
+  selectedTab,
+  isSidebarOpen,
+  invalidatePanelLayout,
+}: Props) {
   const Sidebar = isSidebarOpen && selectSidebar(selectedTab);
 
   return (
@@ -36,7 +45,7 @@ function DetailsContainer({ selectedTab, isSidebarOpen }: StateProps) {
       customClassName="DetailsContainer"
       percentage
       secondaryInitialSize={20}
-      onDragEnd={dispatchResizeEvent}
+      onDragEnd={invalidatePanelLayout}
     >
       <Details />
       {Sidebar && <Sidebar />}
@@ -44,11 +53,14 @@ function DetailsContainer({ selectedTab, isSidebarOpen }: StateProps) {
   );
 }
 
-const options: ExplicitConnectOptions<{||}, StateProps, {||}> = {
+const options: ExplicitConnectOptions<{||}, StateProps, DispatchProps> = {
   mapStateToProps: state => ({
     selectedTab: getSelectedTab(state),
     isSidebarOpen: getIsSidebarOpen(state),
   }),
+  mapDispatchToProps: {
+    invalidatePanelLayout,
+  },
   component: DetailsContainer,
 };
 

--- a/src/components/shared/chart/Viewport.js
+++ b/src/components/shared/chart/Viewport.js
@@ -6,7 +6,10 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import explicitConnect from '../../../utils/connect';
-import { getHasZoomedViaMousewheel } from '../../../reducers/app';
+import {
+  getHasZoomedViaMousewheel,
+  getPanelLayoutGeneration,
+} from '../../../reducers/app';
 import { setHasZoomedViaMousewheel } from '../../../actions/stack-chart';
 import { updatePreviewSelection } from '../../../actions/profile-view';
 
@@ -69,6 +72,7 @@ export type Viewport = {|
 |};
 
 type ViewportStateProps = {|
+  +panelLayoutGeneration: number,
   +hasZoomedViaMousewheel?: boolean,
 |};
 
@@ -523,6 +527,14 @@ export const withChartViewport: WithChartViewport<*, *> =
         window.removeEventListener('mouseup', this._mouseUpListener, true);
       }
 
+      componentDidUpdate(prevProps: ViewportProps) {
+        if (
+          prevProps.panelLayoutGeneration !== this.props.panelLayoutGeneration
+        ) {
+          this._setSize();
+        }
+      }
+
       render() {
         const { chartProps, hasZoomedViaMousewheel } = this.props;
 
@@ -586,6 +598,7 @@ export const withChartViewport: WithChartViewport<*, *> =
       ViewportDispatchProps
     > = {
       mapStateToProps: state => ({
+        panelLayoutGeneration: getPanelLayoutGeneration(state),
         hasZoomedViaMousewheel: getHasZoomedViaMousewheel(state),
       }),
       mapDispatchToProps: { setHasZoomedViaMousewheel, updatePreviewSelection },

--- a/src/components/timeline/OverflowEdgeIndicator.js
+++ b/src/components/timeline/OverflowEdgeIndicator.js
@@ -12,6 +12,7 @@ import './OverflowEdgeIndicator.css';
 type Props = {
   className: string,
   children: React.Node,
+  panelLayoutGeneration: number,
 };
 
 type State = {

--- a/src/components/timeline/index.js
+++ b/src/components/timeline/index.js
@@ -12,6 +12,7 @@ import OverflowEdgeIndicator from './OverflowEdgeIndicator';
 import Reorderable from '../shared/Reorderable';
 import { withSize } from '../shared/WithSize';
 import explicitConnect from '../../utils/connect';
+import { getPanelLayoutGeneration } from '../../reducers/app';
 import {
   getCommittedRange,
   getZeroAt,
@@ -44,6 +45,7 @@ type StateProps = {|
   +globalTracks: GlobalTrack[],
   +globalTrackOrder: TrackIndex[],
   +globalTrackReferences: TrackReference[],
+  +panelLayoutGeneration: number,
   +zeroAt: Milliseconds,
 |};
 
@@ -65,6 +67,7 @@ class Timeline extends PureComponent<Props> {
       zeroAt,
       width,
       globalTrackReferences,
+      panelLayoutGeneration,
     } = this.props;
 
     return (
@@ -75,7 +78,10 @@ class Timeline extends PureComponent<Props> {
           rangeEnd={committedRange.end}
           width={width}
         />
-        <OverflowEdgeIndicator className="timelineOverflowEdgeIndicator">
+        <OverflowEdgeIndicator
+          className="timelineOverflowEdgeIndicator"
+          panelLayoutGeneration={panelLayoutGeneration}
+        >
           {
             <Reorderable
               tagName="ol"
@@ -107,6 +113,7 @@ const options: ExplicitConnectOptions<OwnProps, StateProps, DispatchProps> = {
     globalTrackReferences: getGlobalTrackReferences(state),
     committedRange: getCommittedRange(state),
     zeroAt: getZeroAt(state),
+    panelLayoutGeneration: getPanelLayoutGeneration(state),
   }),
   mapDispatchToProps: {
     changeGlobalTrackOrder,

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -98,11 +98,42 @@ function isSidebarOpenPerPanel(
   }
 }
 
+/**
+ * The panels that make up the timeline, details view, and sidebar can all change
+ * their sizes depending on the state that is fed to them. In order to control
+ * the invalidations of this sizing information, provide a "generation" value that
+ * increases monotonically for any change that potentially changes the sizing of
+ * any of the panels. This provides a mechanism for subscribing components to
+ * deterministically update their sizing correctly.
+ */
+function panelLayoutGeneration(state: number = 0, action: Action): number {
+  switch (action.type) {
+    case 'INCREMENT_PANEL_LAYOUT_GENERATION':
+    // Sidebar: (fallthrough)
+    case 'CHANGE_SIDEBAR_OPEN_STATE':
+    // Timeline: (fallthrough)
+    case 'HIDE_GLOBAL_TRACK':
+    case 'SHOW_GLOBAL_TRACK':
+    case 'ISOLATE_PROCESS':
+    case 'ISOLATE_PROCESS_MAIN_THREAD':
+    case 'HIDE_LOCAL_TRACK':
+    case 'SHOW_LOCAL_TRACK':
+    case 'ISOLATE_LOCAL_TRACK':
+    // Committed range changes: (fallthrough)
+    case 'COMMIT_RANGE':
+    case 'POP_COMMITTED_RANGES':
+      return state + 1;
+    default:
+      return state;
+  }
+}
+
 const appStateReducer: Reducer<AppState> = combineReducers({
   view,
   isUrlSetupDone,
   hasZoomedViaMousewheel,
   isSidebarOpenPerPanel,
+  panelLayoutGeneration,
 });
 
 export default appStateReducer;
@@ -116,3 +147,5 @@ export const getHasZoomedViaMousewheel = (state: State): boolean => {
 };
 export const getIsSidebarOpen = (state: State): boolean =>
   getApp(state).isSidebarOpenPerPanel[getSelectedTab(state)];
+export const getPanelLayoutGeneration = (state: State) =>
+  getApp(state).panelLayoutGeneration;

--- a/src/test/store/app.test.js
+++ b/src/test/store/app.test.js
@@ -3,12 +3,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
-import { storeWithSimpleProfile } from '../fixtures/stores';
+import { storeWithSimpleProfile, storeWithProfile } from '../fixtures/stores';
 import * as ProfileViewSelectors from '../../reducers/profile-view';
 import * as UrlStateSelectors from '../../reducers/url-state';
 import * as AppSelectors from '../../reducers/app';
 import createStore from '../../app-logic/create-store';
 import { withAnalyticsMock } from '../fixtures/mocks/analytics';
+import { isolateProcess } from '../../actions/profile-view';
+import { getProfileWithNiceTracks } from '../fixtures/profiles/tracks';
 
 import * as AppActions from '../../actions/app';
 
@@ -162,6 +164,33 @@ describe('app actions', function() {
       dispatch(AppActions.updateUrlState(originalUrlState));
       expect(UrlStateSelectors.getUrlState(getState())).toBe(originalUrlState);
       expect(UrlStateSelectors.getSelectedTab(getState())).toEqual('calltree');
+    });
+  });
+
+  describe('panelLayoutGeneration', function() {
+    it('can be manually updated using an action', function() {
+      const { dispatch, getState } = storeWithSimpleProfile();
+      expect(AppSelectors.getPanelLayoutGeneration(getState())).toBe(0);
+      dispatch(AppActions.invalidatePanelLayout());
+      expect(AppSelectors.getPanelLayoutGeneration(getState())).toBe(1);
+      dispatch(AppActions.invalidatePanelLayout());
+      expect(AppSelectors.getPanelLayoutGeneration(getState())).toBe(2);
+    });
+
+    it('will be updated when working with the sidebar', function() {
+      const { dispatch, getState } = storeWithSimpleProfile();
+      expect(AppSelectors.getPanelLayoutGeneration(getState())).toBe(0);
+      dispatch(AppActions.changeSidebarOpenState('flame-graph', false));
+      expect(AppSelectors.getPanelLayoutGeneration(getState())).toBe(1);
+    });
+
+    it('will be updated when working with the timeline', function() {
+      const { dispatch, getState } = storeWithProfile(
+        getProfileWithNiceTracks()
+      );
+      expect(AppSelectors.getPanelLayoutGeneration(getState())).toBe(0);
+      dispatch(isolateProcess(0));
+      expect(AppSelectors.getPanelLayoutGeneration(getState())).toBe(1);
     });
   });
 });

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -164,6 +164,9 @@ type ProfileAction =
   | {|
       +type: 'SET_PROFILE_SHARING_STATUS',
       +profileSharingStatus: ProfileSharingStatus,
+    |}
+  | {|
+      +type: 'INCREMENT_PANEL_LAYOUT_GENERATION',
     |};
 
 type ReceiveProfileAction =

--- a/src/types/reducers.js
+++ b/src/types/reducers.js
@@ -121,6 +121,7 @@ export type AppState = {|
   +isUrlSetupDone: boolean,
   +hasZoomedViaMousewheel: boolean,
   +isSidebarOpenPerPanel: IsSidebarOpenPerPanelState,
+  +panelLayoutGeneration: number,
 |};
 
 export type ZippedProfilesState = {


### PR DESCRIPTION
This PR adds a panelLayoutGeneration value in the store that
increases monotonically on any change to the state that could
potentially invalidate the sizing of components in regards to
the panel layout.

These components include anything to do with the timeline height, and
with the sidebar openeing or being moved.

Resolves #1205
Resolves #736