### PR TITLE
Marker chart search

### DIFF
--- a/src/components/marker-chart/MarkerChartEmptyReasons.js
+++ b/src/components/marker-chart/MarkerChartEmptyReasons.js
@@ -16,30 +16,41 @@ import explicitConnect, {
 
 import type { State } from '../../types/store';
 import type { TabSlug } from '../../app-logic/tabs-handling';
-import type { Thread } from '../../types/profile';
 
 type StateProps = {|
-  +thread: Thread,
   +threadName: string,
   +selectedTab: TabSlug,
+  +isMarkerChartEmptyInFullRange: boolean,
+  +isNetworkChartEmptyInFullRange: boolean,
 |};
 
 type Props = ConnectedProps<{||}, StateProps, {||}>;
 class MarkerChartEmptyReasons extends PureComponent<Props> {
   render() {
-    const { selectedTab, thread, threadName } = this.props;
+    const {
+      selectedTab,
+      isNetworkChartEmptyInFullRange,
+      isMarkerChartEmptyInFullRange,
+      threadName,
+    } = this.props;
 
-    let reason;
-    let viewName = 'marker chart';
-    if (thread.markers.length === 0) {
-      reason = 'This thread contains no markers.';
-    } else if (selectedTab === 'network-chart') {
+    let reason, viewName;
+    if (selectedTab === 'network-chart') {
       viewName = 'network chart';
-      reason = 'This thread has no network markers.';
+      if (isNetworkChartEmptyInFullRange) {
+        reason = 'This thread has no network information.';
+      } else {
+        reason =
+          'All network requests were filtered out by the current selection or search term.';
+      }
     } else {
-      // I can't think of a possible reason coming here at the moment as we
-      // don't have any search yet.
-      reason = 'No markers have been found in this thread.';
+      viewName = 'marker chart';
+      if (isMarkerChartEmptyInFullRange) {
+        reason = 'This thread contains no markers for this chart.';
+      } else {
+        reason =
+          'All markers were filtered out by the current selection or search term.';
+      }
     }
 
     return (
@@ -54,8 +65,13 @@ class MarkerChartEmptyReasons extends PureComponent<Props> {
 
 const options: ExplicitConnectOptions<{||}, StateProps, {||}> = {
   mapStateToProps: (state: State) => ({
-    thread: selectedThreadSelectors.getThread(state),
     threadName: selectedThreadSelectors.getFriendlyThreadName(state),
+    isMarkerChartEmptyInFullRange: selectedThreadSelectors.getIsMarkerChartEmptyInFullRange(
+      state
+    ),
+    isNetworkChartEmptyInFullRange: selectedThreadSelectors.getIsNetworkChartEmptyInFullRange(
+      state
+    ),
     selectedTab: getSelectedTab(state),
   }),
   component: MarkerChartEmptyReasons,

--- a/src/components/marker-chart/index.css
+++ b/src/components/marker-chart/index.css
@@ -5,4 +5,9 @@
 .markerChart {
   display: flex;
   flex: 1;
+  flex-flow: column nowrap;
+}
+
+.markerChartCanvas {
+  border-top: 1px solid var(--grey-30);
 }

--- a/src/components/marker-chart/index.js
+++ b/src/components/marker-chart/index.js
@@ -7,6 +7,7 @@ import * as React from 'react';
 import explicitConnect from '../../utils/connect';
 import MarkerChartCanvas from './Canvas';
 import MarkerChartEmptyReasons from './MarkerChartEmptyReasons';
+import MarkerSettings from '../shared/MarkerSettings';
 
 import {
   selectedThreadSelectors,
@@ -14,7 +15,10 @@ import {
   getProfileInterval,
   getPreviewSelection,
 } from '../../reducers/profile-view';
-import { getSelectedThreadIndex } from '../../reducers/url-state';
+import {
+  getSelectedThreadIndex,
+  getSelectedTab,
+} from '../../reducers/url-state';
 import { updatePreviewSelection } from '../../actions/profile-view';
 
 import type {
@@ -71,35 +75,36 @@ class MarkerChart extends React.PureComponent<Props> {
       updatePreviewSelection,
     } = this.props;
 
-    if (!markers.length) {
-      return <MarkerChartEmptyReasons />;
-    }
-
     // The viewport needs to know about the height of what it's drawing, calculate
     // that here at the top level component.
     const maxViewportHeight = maxMarkerRows * ROW_HEIGHT;
 
     return (
       <div className="markerChart">
-        <MarkerChartCanvas
-          key={threadIndex}
-          viewportProps={{
-            timeRange,
-            previewSelection,
-            maxViewportHeight,
-            viewportNeedsUpdate,
-            maximumZoom: this.getMaximumZoom(),
-          }}
-          chartProps={{
-            markerTimingRows,
-            markers,
-            updatePreviewSelection,
-            rangeStart: timeRange.start,
-            rangeEnd: timeRange.end,
-            rowHeight: ROW_HEIGHT,
-            threadIndex,
-          }}
-        />
+        <MarkerSettings />
+        {markers.length === 0 ? (
+          <MarkerChartEmptyReasons />
+        ) : (
+          <MarkerChartCanvas
+            key={threadIndex}
+            viewportProps={{
+              timeRange,
+              previewSelection,
+              maxViewportHeight,
+              viewportNeedsUpdate,
+              maximumZoom: this.getMaximumZoom(),
+            }}
+            chartProps={{
+              markerTimingRows,
+              markers,
+              updatePreviewSelection,
+              rangeStart: timeRange.start,
+              rangeEnd: timeRange.end,
+              rowHeight: ROW_HEIGHT,
+              threadIndex,
+            }}
+          />
+        )}
       </div>
     );
   }
@@ -115,8 +120,13 @@ function viewportNeedsUpdate(
 
 const options: ExplicitConnectOptions<{||}, StateProps, DispatchProps> = {
   mapStateToProps: state => {
-    const markers = selectedThreadSelectors.getTracingMarkersForView(state);
-    const markerTimingRows = selectedThreadSelectors.getMarkerTiming(state);
+    const isNetworkChart = getSelectedTab(state) === 'network-chart';
+    const markers = isNetworkChart
+      ? selectedThreadSelectors.getNetworkChartTracingMarkers(state)
+      : selectedThreadSelectors.getMarkerChartTracingMarkers(state);
+    const markerTimingRows = isNetworkChart
+      ? selectedThreadSelectors.getNetworkChartTiming(state)
+      : selectedThreadSelectors.getMarkerChartTiming(state);
 
     return {
       markers,

--- a/src/components/marker-table/index.js
+++ b/src/components/marker-table/index.js
@@ -14,7 +14,7 @@ import {
 } from '../../reducers/profile-view';
 import { getSelectedThreadIndex } from '../../reducers/url-state';
 import { changeSelectedMarker } from '../../actions/profile-view';
-import Settings from './Settings';
+import MarkerSettings from '../shared/MarkerSettings';
 
 import './index.css';
 
@@ -213,7 +213,7 @@ class MarkerTable extends PureComponent<Props> {
     const tree = new MarkerTree(markers, zeroAt);
     return (
       <div className="markerTable">
-        <Settings />
+        <MarkerSettings />
         <TreeView
           maxNodeDepth={0}
           tree={tree}

--- a/src/components/shared/MarkerSettings.css
+++ b/src/components/shared/MarkerSettings.css
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-.markerTableSettings {
+.markerSettings {
   height: 25px;
   padding: 0;
   line-height: 25px;
@@ -10,11 +10,11 @@
   flex-flow: row nowrap;
 }
 
-.markerTableSettingsSpacer {
+.markerSettingsSpacer {
   flex: 1;
 }
 
-.markerTableSettingsLabel {
+.markerSettingsLabel {
   -webkit-user-select: none;
   -moz-user-select: none;
   user-select: none;
@@ -24,10 +24,10 @@
   height: 25px;
 }
 
-.markerTableSettingsSearchbar {
+.markerSettingsSearchbar {
   padding: 0 5px;
 }
 
-.markerTableSettingsSearchField {
+.markerSettingsSearchField {
   width: 250px;
 }

--- a/src/components/shared/MarkerSettings.js
+++ b/src/components/shared/MarkerSettings.js
@@ -15,7 +15,7 @@ import type {
   ConnectedProps,
 } from '../../utils/connect';
 
-import './Settings.css';
+import './MarkerSettings.css';
 
 type StateProps = {|
   +searchString: string,
@@ -35,13 +35,13 @@ class Settings extends PureComponent<Props> {
   render() {
     const { searchString } = this.props;
     return (
-      <div className="markerTableSettings">
-        <div className="markerTableSettingsSpacer" />
-        <div className="markerTableSettingsSearchbar">
-          <label className="markerTableSettingsSearchbarLabel">
+      <div className="markerSettings">
+        <div className="markerSettingsSpacer" />
+        <div className="markerSettingsSearchbar">
+          <label className="markerSettingsSearchbarLabel">
             {'Filter Markers: '}
             <IdleSearchField
-              className="markerTableSettingsSearchField"
+              className="markerSettingsSearchField"
               title="Only display markers that match a certain name"
               idlePeriod={200}
               defaultValue={searchString}

--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -366,3 +366,7 @@ export function extractScreenshotsById(
 
   return idToScreenshotMarkers;
 }
+
+export function filterForMarkerChart(markers: TracingMarker[]) {
+  return markers.filter(marker => !isNetworkMarker(marker));
+}

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -748,8 +748,12 @@ export type SelectorsForThread = {
   getJankInstances: State => TracingMarker[],
   getProcessedMarkersTable: State => MarkersTable,
   getTracingMarkers: State => TracingMarker[],
-  getTracingMarkersForView: State => TracingMarker[],
-  getMarkerTiming: State => MarkerTimingRows,
+  getIsNetworkChartEmptyInFullRange: State => boolean,
+  getNetworkChartTracingMarkers: State => TracingMarker[],
+  getMarkerChartTracingMarkers: State => TracingMarker[],
+  getIsMarkerChartEmptyInFullRange: State => boolean,
+  getMarkerChartTiming: State => MarkerTimingRows,
+  getNetworkChartTiming: State => MarkerTimingRows,
   getCommittedRangeFilteredTracingMarkers: State => TracingMarker[],
   getCommittedRangeFilteredTracingMarkersForHeader: State => TracingMarker[],
   getNetworkTracingMarkers: State => TracingMarker[],
@@ -1009,27 +1013,28 @@ export const selectorsForThread = (
         );
       }
     );
-    const getTracingMarkersForNetworkChart = createSelector(
+    const getIsNetworkChartEmptyInFullRange = createSelector(
       getTracingMarkers,
+      markers => markers.filter(MarkerData.isNetworkMarker).length === 0
+    );
+    const getNetworkChartTracingMarkers = createSelector(
+      getSearchFilteredTracingMarkers,
       markers => markers.filter(MarkerData.isNetworkMarker)
     );
-    const getTracingMarkersForMarkerChart = createSelector(
+    const getIsMarkerChartEmptyInFullRange = createSelector(
       getTracingMarkers,
+      markers => MarkerData.filterForMarkerChart(markers).length === 0
+    );
+    const getMarkerChartTracingMarkers = createSelector(
+      getSearchFilteredTracingMarkers,
       markers => markers.filter(marker => !MarkerData.isNetworkMarker(marker))
     );
-    const getTracingMarkersForView = state => {
-      const selectedTab = UrlState.getSelectedTab(state);
-      switch (selectedTab) {
-        case 'marker-chart':
-          return getTracingMarkersForMarkerChart(state);
-        case 'network-chart':
-          return getTracingMarkersForNetworkChart(state);
-        default:
-          return getTracingMarkers(state);
-      }
-    };
-    const getMarkerTiming = createSelector(
-      getTracingMarkersForView,
+    const getMarkerChartTiming = createSelector(
+      getMarkerChartTracingMarkers,
+      MarkerTiming.getMarkerTiming
+    );
+    const getNetworkChartTiming = createSelector(
+      getNetworkChartTracingMarkers,
       MarkerTiming.getMarkerTiming
     );
     const getNetworkTracingMarkers = createSelector(
@@ -1169,8 +1174,12 @@ export const selectorsForThread = (
       getJankInstances,
       getProcessedMarkersTable,
       getTracingMarkers,
-      getTracingMarkersForView,
-      getMarkerTiming,
+      getIsNetworkChartEmptyInFullRange,
+      getNetworkChartTracingMarkers,
+      getIsMarkerChartEmptyInFullRange,
+      getMarkerChartTracingMarkers,
+      getMarkerChartTiming,
+      getNetworkChartTiming,
       getCommittedRangeFilteredTracingMarkers,
       getCommittedRangeFilteredTracingMarkersForHeader,
       getNetworkTracingMarkers,

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -1027,7 +1027,7 @@ export const selectorsForThread = (
     );
     const getMarkerChartTracingMarkers = createSelector(
       getSearchFilteredTracingMarkers,
-      markers => markers.filter(marker => !MarkerData.isNetworkMarker(marker))
+      MarkerData.filterForMarkerChart
     );
     const getMarkerChartTiming = createSelector(
       getMarkerChartTracingMarkers,

--- a/src/test/components/MarkerChart.test.js
+++ b/src/test/components/MarkerChart.test.js
@@ -14,7 +14,10 @@ import { changeSelectedTab } from '../../actions/app';
 import EmptyReasons from '../../components/shared/EmptyReasons';
 import mockCanvasContext from '../fixtures/mocks/canvas-context';
 import { storeWithProfile } from '../fixtures/stores';
-import { getProfileWithMarkers } from '../fixtures/profiles/make-profile';
+import {
+  getProfileWithMarkers,
+  getNetworkMarker,
+} from '../fixtures/profiles/make-profile';
 import { getBoundingBox } from '../fixtures/utils';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
 
@@ -53,21 +56,9 @@ const MARKERS = [
   ],
 ];
 
-const NETWORK_MARKERS = [
-  [
-    'Load event',
-    11,
-    {
-      type: 'Network',
-      startTime: 11,
-      endTime: 12,
-      id: 31666793873480,
-      status: 'STATUS_START',
-      pri: 0,
-      URI: 'https://tiles.services.mozilla.com/v3/links/ping-centre',
-    },
-  ],
-];
+const NETWORK_MARKERS = Array(10)
+  .fill()
+  .map((_, i) => getNetworkMarker(3 + 0.1 * i, i));
 
 function setupWithProfile(profile) {
   const flushRafCalls = mockRaf();
@@ -99,108 +90,166 @@ function setupWithProfile(profile) {
   };
 }
 
-it('renders MarkerChart correctly', () => {
-  window.devicePixelRatio = 1;
+describe('MarkerChart', function() {
+  it('renders the normal marker chart and matches the snapshot', () => {
+    window.devicePixelRatio = 1;
 
-  const profile = getProfileWithMarkers([...MARKERS, ...NETWORK_MARKERS]);
-  const {
-    flushRafCalls,
-    dispatch,
-    markerChart,
-    flushDrawLog,
-  } = setupWithProfile(profile);
-
-  dispatch(changeSelectedTab('marker-chart'));
-  markerChart.update();
-  flushRafCalls();
-
-  let drawCalls = flushDrawLog();
-  expect(markerChart).toMatchSnapshot();
-  expect(drawCalls).toMatchSnapshot();
-
-  dispatch(changeSelectedTab('network-chart'));
-  markerChart.update();
-  flushRafCalls();
-
-  drawCalls = flushDrawLog();
-  expect(markerChart).toMatchSnapshot();
-  expect(drawCalls).toMatchSnapshot();
-
-  delete window.devicePixelRatio;
-});
-
-it('renders the hoveredItem markers properly', () => {
-  window.devicePixelRatio = 1;
-
-  const profile = getProfileWithMarkers(MARKERS);
-  const {
-    flushRafCalls,
-    dispatch,
-    markerChart,
-    flushDrawLog,
-  } = setupWithProfile(profile);
-
-  dispatch(changeSelectedTab('marker-chart'));
-  markerChart.update();
-  flushRafCalls();
-  flushDrawLog();
-
-  // No tooltip displayed yet
-  expect(markerChart.find('Tooltip').exists()).toEqual(false);
-
-  // Move the mouse on top of an item.
-  markerChart.find('canvas').simulate('mousemove', {
-    nativeEvent: { offsetX: 50, offsetY: 5 },
-    pageX: 50,
-    pageY: 5,
-  });
-  markerChart.update();
-  flushRafCalls();
-
-  const drawCalls = flushDrawLog();
-  expect(drawCalls).toMatchSnapshot();
-
-  // The tooltip should be displayed
-  expect(markerChart.find('Tooltip').exists()).toEqual(true);
-});
-
-describe('EmptyReasons', () => {
-  it('shows a reason when a profile has no markers', () => {
-    const profile = getProfileWithMarkers([]);
-    const { dispatch, markerChart } = setupWithProfile(profile);
+    const profile = getProfileWithMarkers([...MARKERS, ...NETWORK_MARKERS]);
+    const {
+      flushRafCalls,
+      dispatch,
+      markerChart,
+      flushDrawLog,
+    } = setupWithProfile(profile);
 
     dispatch(changeSelectedTab('marker-chart'));
     markerChart.update();
-    expect(markerChart.find(EmptyReasons)).toMatchSnapshot();
+    flushRafCalls();
+
+    const drawCalls = flushDrawLog();
+    expect(markerChart).toMatchSnapshot();
+    expect(drawCalls).toMatchSnapshot();
+
+    delete window.devicePixelRatio;
   });
 
-  fit("shows a reason when a profile's markers have been filtered out", () => {
+  it('renders the network marker chart and matches the snapshot', () => {
+    window.devicePixelRatio = 1;
+
+    const profile = getProfileWithMarkers([...MARKERS, ...NETWORK_MARKERS]);
+    const {
+      flushRafCalls,
+      dispatch,
+      markerChart,
+      flushDrawLog,
+    } = setupWithProfile(profile);
+
+    dispatch(changeSelectedTab('network-chart'));
+    markerChart.update();
+    flushRafCalls();
+
+    expect(markerChart).toMatchSnapshot();
+    expect(flushDrawLog()).toMatchSnapshot();
+
+    delete window.devicePixelRatio;
+  });
+
+  it('renders the hoveredItem markers properly', () => {
+    window.devicePixelRatio = 1;
+
     const profile = getProfileWithMarkers(MARKERS);
-    const { dispatch, markerChart } = setupWithProfile(profile);
+    const {
+      flushRafCalls,
+      dispatch,
+      markerChart,
+      flushDrawLog,
+    } = setupWithProfile(profile);
 
     dispatch(changeSelectedTab('marker-chart'));
-    dispatch(changeMarkersSearchString('MATCH_NOTHING'));
     markerChart.update();
-    console.log(markerChart.find(EmptyReasons).text());
-    expect(markerChart.find(EmptyReasons)).toMatchSnapshot();
+    flushRafCalls();
+    flushDrawLog();
+
+    // No tooltip displayed yet
+    expect(markerChart.find('Tooltip').exists()).toEqual(false);
+
+    // Move the mouse on top of an item.
+    markerChart.find('canvas').simulate('mousemove', {
+      nativeEvent: { offsetX: 50, offsetY: 5 },
+      pageX: 50,
+      pageY: 5,
+    });
+    markerChart.update();
+    flushRafCalls();
+
+    const drawCalls = flushDrawLog();
+    expect(drawCalls).toMatchSnapshot();
+
+    // The tooltip should be displayed
+    expect(markerChart.find('Tooltip').exists()).toEqual(true);
   });
 
-  it('shows a reason when a profile has no network markers', () => {
-    const profile = getProfileWithMarkers(MARKERS);
-    const { dispatch, markerChart } = setupWithProfile(profile);
+  describe('with search strings', function() {
+    function getFillTextCalls(drawCalls) {
+      return drawCalls
+        .filter(([methodName]) => methodName === 'fillText')
+        .map(([_, text]) => text);
+    }
 
-    dispatch(changeSelectedTab('network-chart'));
-    markerChart.update();
-    expect(markerChart.find(EmptyReasons)).toMatchSnapshot();
+    const searchString = 'Dot marker E';
+
+    it('renders lots of markers initially', function() {
+      const profile = getProfileWithMarkers(MARKERS);
+      const { flushRafCalls, flushDrawLog } = setupWithProfile(profile);
+
+      flushRafCalls();
+      const text = getFillTextCalls(flushDrawLog());
+      expect(text.length).toBeGreaterThan(1);
+      // Check that our test search string is in here:
+      expect(text.filter(t => t === searchString).length).toBe(1);
+    });
+
+    it('renders only the marker that was searched for', function() {
+      const profile = getProfileWithMarkers(MARKERS);
+      const {
+        flushRafCalls,
+        dispatch,
+        flushDrawLog,
+        markerChart,
+      } = setupWithProfile(profile);
+
+      // Flush out any existing draw calls.
+      flushRafCalls();
+      flushDrawLog();
+
+      // Update the chart with a search string.
+      dispatch(changeMarkersSearchString(searchString));
+      markerChart.update();
+      flushRafCalls();
+
+      const text = getFillTextCalls(flushDrawLog());
+      expect(text.length).toBe(1);
+      expect(text[0]).toBe(searchString);
+    });
   });
 
-  it("shows a reason when a profile's network markers have been filtered out", () => {
-    const profile = getProfileWithMarkers(NETWORK_MARKERS);
-    const { dispatch, markerChart } = setupWithProfile(profile);
+  describe('EmptyReasons', () => {
+    it('shows a reason when a profile has no markers', () => {
+      const profile = getProfileWithMarkers([]);
+      const { dispatch, markerChart } = setupWithProfile(profile);
 
-    dispatch(changeSelectedTab('network-chart'));
-    dispatch(changeMarkersSearchString('MATCH_NOTHING'));
-    markerChart.update();
-    expect(markerChart.find(EmptyReasons)).toMatchSnapshot();
+      dispatch(changeSelectedTab('marker-chart'));
+      markerChart.update();
+      expect(markerChart.find(EmptyReasons)).toMatchSnapshot();
+    });
+
+    it("shows a reason when a profile's markers have been filtered out", () => {
+      const profile = getProfileWithMarkers(MARKERS);
+      const { dispatch, markerChart } = setupWithProfile(profile);
+
+      dispatch(changeSelectedTab('marker-chart'));
+      dispatch(changeMarkersSearchString('MATCH_NOTHING'));
+      markerChart.update();
+      expect(markerChart.find(EmptyReasons)).toMatchSnapshot();
+    });
+
+    it('shows a reason when a profile has no network markers', () => {
+      const profile = getProfileWithMarkers(MARKERS);
+      const { dispatch, markerChart } = setupWithProfile(profile);
+
+      dispatch(changeSelectedTab('network-chart'));
+      markerChart.update();
+      expect(markerChart.find(EmptyReasons)).toMatchSnapshot();
+    });
+
+    it("shows a reason when a profile's network markers have been filtered out", () => {
+      const profile = getProfileWithMarkers(NETWORK_MARKERS);
+      const { dispatch, markerChart } = setupWithProfile(profile);
+
+      dispatch(changeSelectedTab('network-chart'));
+      dispatch(changeMarkersSearchString('MATCH_NOTHING'));
+      markerChart.update();
+      expect(markerChart.find(EmptyReasons)).toMatchSnapshot();
+    });
   });
 });

--- a/src/test/components/MarkerChart.test.js
+++ b/src/test/components/MarkerChart.test.js
@@ -7,9 +7,11 @@ import * as React from 'react';
 import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
 
+import { changeMarkersSearchString } from '../../actions/profile-view';
 import MarkerChart from '../../components/marker-chart';
 import { changeSelectedTab } from '../../actions/app';
 
+import EmptyReasons from '../../components/shared/EmptyReasons';
 import mockCanvasContext from '../fixtures/mocks/canvas-context';
 import { storeWithProfile } from '../fixtures/stores';
 import { getProfileWithMarkers } from '../fixtures/profiles/make-profile';
@@ -162,22 +164,43 @@ it('renders the hoveredItem markers properly', () => {
   expect(markerChart.find('Tooltip').exists()).toEqual(true);
 });
 
-describe('Empty Reasons', () => {
-  it('shows a reason when a profile has no marker', () => {
+describe('EmptyReasons', () => {
+  it('shows a reason when a profile has no markers', () => {
     const profile = getProfileWithMarkers([]);
     const { dispatch, markerChart } = setupWithProfile(profile);
 
     dispatch(changeSelectedTab('marker-chart'));
     markerChart.update();
-    expect(markerChart).toMatchSnapshot();
+    expect(markerChart.find(EmptyReasons)).toMatchSnapshot();
   });
 
-  it('shows a reason when a profil has no network markers', () => {
+  fit("shows a reason when a profile's markers have been filtered out", () => {
+    const profile = getProfileWithMarkers(MARKERS);
+    const { dispatch, markerChart } = setupWithProfile(profile);
+
+    dispatch(changeSelectedTab('marker-chart'));
+    dispatch(changeMarkersSearchString('MATCH_NOTHING'));
+    markerChart.update();
+    console.log(markerChart.find(EmptyReasons).text());
+    expect(markerChart.find(EmptyReasons)).toMatchSnapshot();
+  });
+
+  it('shows a reason when a profile has no network markers', () => {
     const profile = getProfileWithMarkers(MARKERS);
     const { dispatch, markerChart } = setupWithProfile(profile);
 
     dispatch(changeSelectedTab('network-chart'));
     markerChart.update();
-    expect(markerChart).toMatchSnapshot();
+    expect(markerChart.find(EmptyReasons)).toMatchSnapshot();
+  });
+
+  it("shows a reason when a profile's network markers have been filtered out", () => {
+    const profile = getProfileWithMarkers(NETWORK_MARKERS);
+    const { dispatch, markerChart } = setupWithProfile(profile);
+
+    dispatch(changeSelectedTab('network-chart'));
+    dispatch(changeMarkersSearchString('MATCH_NOTHING'));
+    markerChart.update();
+    expect(markerChart.find(EmptyReasons)).toMatchSnapshot();
   });
 });

--- a/src/test/components/__snapshots__/MarkerChart.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerChart.test.js.snap
@@ -1,23 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Empty Reasons shows a reason when a profil has no network markers 1`] = `
-<div
-  className="EmptyReasons"
->
-  <h3>
-    The 
-    network chart
-     is empty for “
-    Empty
-    ”
-  </h3>
-  <p>
-    This thread has no network markers.
-  </p>
-</div>
-`;
-
-exports[`Empty Reasons shows a reason when a profile has no marker 1`] = `
+exports[`MarkerChart EmptyReasons shows a reason when a profile has no markers 1`] = `
 <div
   className="EmptyReasons"
 >
@@ -29,55 +12,64 @@ exports[`Empty Reasons shows a reason when a profile has no marker 1`] = `
     ”
   </h3>
   <p>
-    This thread contains no markers.
+    This thread contains no markers for this chart.
   </p>
 </div>
 `;
 
-exports[`renders MarkerChart correctly 1`] = `
+exports[`MarkerChart EmptyReasons shows a reason when a profile has no network markers 1`] = `
 <div
-  className="markerChart"
+  className="EmptyReasons"
 >
-  <div
-    className="chartViewport"
-    onMouseDown={[Function]}
-    onWheel={[Function]}
-  >
-    <div>
-      <canvas
-        className="chartCanvas markerChartCanvas"
-        onDoubleClick={[Function]}
-        onMouseDown={[Function]}
-        onMouseMove={[Function]}
-        onMouseOut={[Function]}
-      />
-    </div>
-    <div
-      className="chartViewportShiftScroll hidden"
-    >
-      Zoom Chart:
-      <kbd
-        className="chartViewportShiftScrollKbd"
-      >
-        Shift
-      </kbd>
-      <kbd
-        className="chartViewportShiftScrollKbd"
-      >
-        Scroll
-      </kbd>
-    </div>
-  </div>
+  <h3>
+    The 
+    network chart
+     is empty for “
+    Empty
+    ”
+  </h3>
+  <p>
+    This thread has no network information.
+  </p>
 </div>
 `;
 
-exports[`renders MarkerChart correctly 2`] = `
+exports[`MarkerChart EmptyReasons shows a reason when a profile's markers have been filtered out 1`] = `
+<div
+  className="EmptyReasons"
+>
+  <h3>
+    The 
+    marker chart
+     is empty for “
+    Empty
+    ”
+  </h3>
+  <p>
+    All markers were filtered out by the current selection or search term.
+  </p>
+</div>
+`;
+
+exports[`MarkerChart EmptyReasons shows a reason when a profile's network markers have been filtered out 1`] = `
+<div
+  className="EmptyReasons"
+>
+  <h3>
+    The 
+    network chart
+     is empty for “
+    Empty
+    ”
+  </h3>
+  <p>
+    All network requests were filtered out by the current selection or search term.
+  </p>
+</div>
+`;
+
+exports[`MarkerChart renders the hoveredItem markers properly 1`] = `
 Array [
-  Array [
-    "scale",
-    1,
-    1,
-  ],
   Array [
     "set fillStyle",
     "#ffffff",
@@ -95,15 +87,7 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "#45a1ff",
-  ],
-  Array [
-    "measureText",
-    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.()< /:-_",
-  ],
-  Array [
-    "measureText",
-    "…",
+    "Highlight",
   ],
   Array [
     "fillRect",
@@ -230,10 +214,6 @@ Array [
     77,
     123,
     1,
-  ],
-  Array [
-    "measureText",
-    "click",
   ],
   Array [
     "set fillStyle",
@@ -432,10 +412,48 @@ Array [
 ]
 `;
 
-exports[`renders MarkerChart correctly 3`] = `
+exports[`MarkerChart renders the network marker chart and matches the snapshot 1`] = `
 <div
   className="markerChart"
 >
+  <div
+    className="markerSettings"
+  >
+    <div
+      className="markerSettingsSpacer"
+    />
+    <div
+      className="markerSettingsSearchbar"
+    >
+      <label
+        className="markerSettingsSearchbarLabel"
+      >
+        Filter Markers: 
+        <form
+          className="idleSearchField markerSettingsSearchField"
+          onSubmit={[Function]}
+        >
+          <input
+            className="idleSearchFieldInput"
+            name="search"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            required="required"
+            title="Only display markers that match a certain name"
+            type="search"
+            value=""
+          />
+          <input
+            className="idleSearchFieldButton"
+            onClick={[Function]}
+            onFocus={[Function]}
+            type="reset"
+          />
+        </form>
+      </label>
+    </div>
+  </div>
   <div
     className="chartViewport"
     onMouseDown={[Function]}
@@ -469,8 +487,13 @@ exports[`renders MarkerChart correctly 3`] = `
 </div>
 `;
 
-exports[`renders MarkerChart correctly 4`] = `
+exports[`MarkerChart renders the network marker chart and matches the snapshot 2`] = `
 Array [
+  Array [
+    "scale",
+    1,
+    1,
+  ],
   Array [
     "set fillStyle",
     "#ffffff",
@@ -488,12 +511,373 @@ Array [
   ],
   Array [
     "set fillStyle",
+    "#45a1ff",
+  ],
+  Array [
+    "measureText",
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.()< /:-_",
+  ],
+  Array [
+    "measureText",
+    "…",
+  ],
+  Array [
+    "fillRect",
+    76,
+    1,
+    23,
+    1,
+  ],
+  Array [
+    "fillRect",
+    75,
+    2,
+    25,
+    11,
+  ],
+  Array [
+    "fillRect",
+    76,
+    13,
+    23,
+    1,
+  ],
+  Array [
+    "measureText",
+    "",
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff",
+  ],
+  Array [
+    "fillRect",
+    78.5,
+    17,
+    22.99999999999999,
+    1,
+  ],
+  Array [
+    "fillRect",
+    77.5,
+    18,
+    24.99999999999999,
+    11,
+  ],
+  Array [
+    "fillRect",
+    78.5,
+    29,
+    22.99999999999999,
+    1,
+  ],
+  Array [
+    "measureText",
+    "",
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff",
+  ],
+  Array [
+    "fillRect",
+    81,
+    33,
+    23,
+    1,
+  ],
+  Array [
+    "fillRect",
+    80,
+    34,
+    25,
+    11,
+  ],
+  Array [
+    "fillRect",
+    81,
+    45,
+    23,
+    1,
+  ],
+  Array [
+    "measureText",
+    "",
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff",
+  ],
+  Array [
+    "fillRect",
+    83.5,
+    49,
+    23,
+    1,
+  ],
+  Array [
+    "fillRect",
+    82.5,
+    50,
+    25,
+    11,
+  ],
+  Array [
+    "fillRect",
+    83.5,
+    61,
+    23,
+    1,
+  ],
+  Array [
+    "measureText",
+    "",
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff",
+  ],
+  Array [
+    "fillRect",
+    86,
+    65,
+    23.00000000000001,
+    1,
+  ],
+  Array [
+    "fillRect",
+    85,
+    66,
+    25.00000000000001,
+    11,
+  ],
+  Array [
+    "fillRect",
+    86,
+    77,
+    23.00000000000001,
+    1,
+  ],
+  Array [
+    "measureText",
+    "",
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff",
+  ],
+  Array [
+    "fillRect",
+    88.5,
+    81,
+    23,
+    1,
+  ],
+  Array [
+    "fillRect",
+    87.5,
+    82,
+    25,
+    11,
+  ],
+  Array [
+    "fillRect",
+    88.5,
+    93,
+    23,
+    1,
+  ],
+  Array [
+    "measureText",
+    "",
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff",
+  ],
+  Array [
+    "fillRect",
+    91,
+    97,
+    22.99999999999999,
+    1,
+  ],
+  Array [
+    "fillRect",
+    90,
+    98,
+    24.99999999999999,
+    11,
+  ],
+  Array [
+    "fillRect",
+    91,
+    109,
+    22.99999999999999,
+    1,
+  ],
+  Array [
+    "measureText",
+    "",
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff",
+  ],
+  Array [
+    "fillRect",
+    93.5,
+    113,
+    23,
+    1,
+  ],
+  Array [
+    "fillRect",
+    92.5,
+    114,
+    25,
+    11,
+  ],
+  Array [
+    "fillRect",
+    93.5,
+    125,
+    23,
+    1,
+  ],
+  Array [
+    "measureText",
+    "",
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff",
+  ],
+  Array [
+    "fillRect",
+    96,
+    129,
+    23,
+    1,
+  ],
+  Array [
+    "fillRect",
+    95,
+    130,
+    25,
+    11,
+  ],
+  Array [
+    "fillRect",
+    96,
+    141,
+    23,
+    1,
+  ],
+  Array [
+    "measureText",
+    "",
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff",
+  ],
+  Array [
+    "fillRect",
+    98.5,
+    145,
+    23.00000000000001,
+    1,
+  ],
+  Array [
+    "fillRect",
+    97.5,
+    146,
+    25.00000000000001,
+    11,
+  ],
+  Array [
+    "fillRect",
+    98.5,
+    157,
+    23.00000000000001,
+    1,
+  ],
+  Array [
+    "measureText",
+    "",
+  ],
+  Array [
+    "set fillStyle",
     "#eee",
   ],
   Array [
     "fillRect",
     0,
     15,
+    200,
+    1,
+  ],
+  Array [
+    "fillRect",
+    0,
+    31,
+    200,
+    1,
+  ],
+  Array [
+    "fillRect",
+    0,
+    47,
+    200,
+    1,
+  ],
+  Array [
+    "fillRect",
+    0,
+    63,
+    200,
+    1,
+  ],
+  Array [
+    "fillRect",
+    0,
+    79,
+    200,
+    1,
+  ],
+  Array [
+    "fillRect",
+    0,
+    95,
+    200,
+    1,
+  ],
+  Array [
+    "fillRect",
+    0,
+    111,
+    200,
+    1,
+  ],
+  Array [
+    "fillRect",
+    0,
+    127,
+    200,
+    1,
+  ],
+  Array [
+    "fillRect",
+    0,
+    143,
+    200,
+    1,
+  ],
+  Array [
+    "fillRect",
+    0,
+    159,
     200,
     1,
   ],
@@ -549,20 +933,163 @@ Array [
     15,
   ],
   Array [
+    "fillRect",
+    0,
+    16,
+    150,
+    15,
+  ],
+  Array [
+    "fillRect",
+    0,
+    32,
+    150,
+    15,
+  ],
+  Array [
+    "fillRect",
+    0,
+    48,
+    150,
+    15,
+  ],
+  Array [
+    "fillRect",
+    0,
+    64,
+    150,
+    15,
+  ],
+  Array [
+    "fillRect",
+    0,
+    80,
+    150,
+    15,
+  ],
+  Array [
+    "fillRect",
+    0,
+    96,
+    150,
+    15,
+  ],
+  Array [
+    "fillRect",
+    0,
+    112,
+    150,
+    15,
+  ],
+  Array [
+    "fillRect",
+    0,
+    128,
+    150,
+    15,
+  ],
+  Array [
+    "fillRect",
+    0,
+    144,
+    150,
+    15,
+  ],
+  Array [
     "set fillStyle",
     "#000000",
   ],
   Array [
     "fillText",
-    "Load event",
+    "Network",
     5,
     11,
   ],
 ]
 `;
 
-exports[`renders the hoveredItem markers properly 1`] = `
+exports[`MarkerChart renders the normal marker chart and matches the snapshot 1`] = `
+<div
+  className="markerChart"
+>
+  <div
+    className="markerSettings"
+  >
+    <div
+      className="markerSettingsSpacer"
+    />
+    <div
+      className="markerSettingsSearchbar"
+    >
+      <label
+        className="markerSettingsSearchbarLabel"
+      >
+        Filter Markers: 
+        <form
+          className="idleSearchField markerSettingsSearchField"
+          onSubmit={[Function]}
+        >
+          <input
+            className="idleSearchFieldInput"
+            name="search"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            required="required"
+            title="Only display markers that match a certain name"
+            type="search"
+            value=""
+          />
+          <input
+            className="idleSearchFieldButton"
+            onClick={[Function]}
+            onFocus={[Function]}
+            type="reset"
+          />
+        </form>
+      </label>
+    </div>
+  </div>
+  <div
+    className="chartViewport"
+    onMouseDown={[Function]}
+    onWheel={[Function]}
+  >
+    <div>
+      <canvas
+        className="chartCanvas markerChartCanvas"
+        onDoubleClick={[Function]}
+        onMouseDown={[Function]}
+        onMouseMove={[Function]}
+        onMouseOut={[Function]}
+      />
+    </div>
+    <div
+      className="chartViewportShiftScroll hidden"
+    >
+      Zoom Chart:
+      <kbd
+        className="chartViewportShiftScrollKbd"
+      >
+        Shift
+      </kbd>
+      <kbd
+        className="chartViewportShiftScrollKbd"
+      >
+        Scroll
+      </kbd>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`MarkerChart renders the normal marker chart and matches the snapshot 2`] = `
 Array [
+  Array [
+    "scale",
+    1,
+    1,
+  ],
   Array [
     "set fillStyle",
     "#ffffff",
@@ -580,7 +1107,15 @@ Array [
   ],
   Array [
     "set fillStyle",
-    "Highlight",
+    "#45a1ff",
+  ],
+  Array [
+    "measureText",
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.()< /:-_",
+  ],
+  Array [
+    "measureText",
+    "…",
   ],
   Array [
     "fillRect",
@@ -707,6 +1242,10 @@ Array [
     77,
     123,
     1,
+  ],
+  Array [
+    "measureText",
+    "click",
   ],
   Array [
     "set fillStyle",

--- a/src/test/components/__snapshots__/MarkerTable.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerTable.test.js.snap
@@ -5,20 +5,20 @@ exports[`MarkerTable renders some basic markers 1`] = `
   className="markerTable"
 >
   <div
-    className="markerTableSettings"
+    className="markerSettings"
   >
     <div
-      className="markerTableSettingsSpacer"
+      className="markerSettingsSpacer"
     />
     <div
-      className="markerTableSettingsSearchbar"
+      className="markerSettingsSearchbar"
     >
       <label
-        className="markerTableSettingsSearchbarLabel"
+        className="markerSettingsSearchbarLabel"
       >
         Filter Markers: 
         <form
-          className="idleSearchField markerTableSettingsSearchField"
+          className="idleSearchField markerSettingsSearchField"
           onSubmit={[Function]}
         >
           <input

--- a/src/test/fixtures/profiles/make-profile.js
+++ b/src/test/fixtures/profiles/make-profile.js
@@ -511,7 +511,7 @@ function _buildThreadFromTextOnlyStacks(
   return thread;
 }
 
-function getNetworkMarker(startTime: number, id) {
+export function getNetworkMarker(startTime: number, id: number) {
   const payload: NetworkPayload = {
     type: 'Network',
     id,

--- a/src/test/store/__snapshots__/profile-view.test.js.snap
+++ b/src/test/store/__snapshots__/profile-view.test.js.snap
@@ -200,8 +200,24 @@ Object {
           null,
           null,
           null,
+          Object {
+            "endTime": 7,
+            "id": 6,
+            "pri": 0,
+            "startTime": 6,
+            "status": "STOP",
+            "type": "Network",
+          },
+          Object {
+            "endTime": 8,
+            "id": 7,
+            "pri": 0,
+            "startTime": 7,
+            "status": "STOP",
+            "type": "Network",
+          },
         ],
-        "length": 6,
+        "length": 8,
         "name": Array [
           0,
           1,
@@ -209,6 +225,8 @@ Object {
           3,
           4,
           5,
+          6,
+          6,
         ],
         "time": Array [
           0,
@@ -217,6 +235,8 @@ Object {
           3,
           4,
           5,
+          6,
+          7,
         ],
       },
       "name": "Thread with samples",
@@ -380,8 +400,24 @@ Object {
           null,
           null,
           null,
+          Object {
+            "endTime": 7,
+            "id": 6,
+            "pri": 0,
+            "startTime": 6,
+            "status": "STOP",
+            "type": "Network",
+          },
+          Object {
+            "endTime": 8,
+            "id": 7,
+            "pri": 0,
+            "startTime": 7,
+            "status": "STOP",
+            "type": "Network",
+          },
         ],
-        "length": 6,
+        "length": 8,
         "name": Array [
           0,
           1,
@@ -389,6 +425,8 @@ Object {
           3,
           4,
           5,
+          6,
+          6,
         ],
         "time": Array [
           0,
@@ -397,6 +435,8 @@ Object {
           3,
           4,
           5,
+          6,
+          7,
         ],
       },
       "name": "Thread with markers",
@@ -412,10 +452,14 @@ Object {
         "type": Array [],
       },
       "samples": Object {
-        "length": 12,
+        "length": 16,
         "responsiveness": Array [],
         "rss": Array [],
         "stack": Array [
+          null,
+          null,
+          null,
+          null,
           null,
           null,
           null,
@@ -442,6 +486,10 @@ Object {
           4,
           5,
           5,
+          6,
+          7,
+          7,
+          8,
         ],
         "uss": Array [],
       },
@@ -459,6 +507,7 @@ Object {
           "D",
           "E",
           "F",
+          "Network",
         ],
         "_stringToIndex": Map {
           "A" => 0,
@@ -467,6 +516,7 @@ Object {
           "D" => 3,
           "E" => 4,
           "F" => 5,
+          "Network" => 6,
         },
       },
       "tid": 0,
@@ -636,8 +686,24 @@ Array [
         null,
         null,
         null,
+        Object {
+          "endTime": 7,
+          "id": 6,
+          "pri": 0,
+          "startTime": 6,
+          "status": "STOP",
+          "type": "Network",
+        },
+        Object {
+          "endTime": 8,
+          "id": 7,
+          "pri": 0,
+          "startTime": 7,
+          "status": "STOP",
+          "type": "Network",
+        },
       ],
-      "length": 6,
+      "length": 8,
       "name": Array [
         0,
         1,
@@ -645,6 +711,8 @@ Array [
         3,
         4,
         5,
+        6,
+        6,
       ],
       "time": Array [
         0,
@@ -653,6 +721,8 @@ Array [
         3,
         4,
         5,
+        6,
+        7,
       ],
     },
     "name": "Thread with samples",
@@ -816,8 +886,24 @@ Array [
         null,
         null,
         null,
+        Object {
+          "endTime": 7,
+          "id": 6,
+          "pri": 0,
+          "startTime": 6,
+          "status": "STOP",
+          "type": "Network",
+        },
+        Object {
+          "endTime": 8,
+          "id": 7,
+          "pri": 0,
+          "startTime": 7,
+          "status": "STOP",
+          "type": "Network",
+        },
       ],
-      "length": 6,
+      "length": 8,
       "name": Array [
         0,
         1,
@@ -825,6 +911,8 @@ Array [
         3,
         4,
         5,
+        6,
+        6,
       ],
       "time": Array [
         0,
@@ -833,6 +921,8 @@ Array [
         3,
         4,
         5,
+        6,
+        7,
       ],
     },
     "name": "Thread with markers",
@@ -848,10 +938,14 @@ Array [
       "type": Array [],
     },
     "samples": Object {
-      "length": 12,
+      "length": 16,
       "responsiveness": Array [],
       "rss": Array [],
       "stack": Array [
+        null,
+        null,
+        null,
+        null,
         null,
         null,
         null,
@@ -878,6 +972,10 @@ Array [
         4,
         5,
         5,
+        6,
+        7,
+        7,
+        8,
       ],
       "uss": Array [],
     },
@@ -895,6 +993,7 @@ Array [
         "D",
         "E",
         "F",
+        "Network",
       ],
       "_stringToIndex": Map {
         "A" => 0,
@@ -903,6 +1002,7 @@ Array [
         "D" => 3,
         "E" => 4,
         "F" => 5,
+        "Network" => 6,
       },
     },
     "tid": 0,
@@ -1223,6 +1323,20 @@ Array [
     "start": 5,
     "title": null,
   },
+  Object {
+    "data": Object {
+      "endTime": 7,
+      "id": 6,
+      "pri": 0,
+      "startTime": 6,
+      "status": "STOP",
+      "type": "Network",
+    },
+    "dur": 1,
+    "name": "G",
+    "start": 6,
+    "title": null,
+  },
 ]
 `;
 
@@ -1409,17 +1523,27 @@ Object {
       null,
       null,
       null,
+      Object {
+        "endTime": 7,
+        "id": 6,
+        "pri": 0,
+        "startTime": 6,
+        "status": "STOP",
+        "type": "Network",
+      },
     ],
-    "length": 3,
+    "length": 4,
     "name": Array [
       3,
       4,
       5,
+      6,
     ],
     "time": Array [
       3,
       4,
       5,
+      6,
     ],
   },
   "name": "Thread with samples",
@@ -1605,62 +1729,14 @@ Array [
 ]
 `;
 
-exports[`snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getMarkerTiming 1`] = `
+exports[`snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getMarkerChartTiming 1`] = `
 Array [
   Object {
     "end": Array [
-      0,
-    ],
-    "index": Array [
-      0,
-    ],
-    "label": Array [
-      "",
-    ],
-    "length": 1,
-    "name": "A",
-    "start": Array [
-      0,
-    ],
-  },
-  Object {
-    "end": Array [
-      1,
-    ],
-    "index": Array [
-      1,
-    ],
-    "label": Array [
-      "",
-    ],
-    "length": 1,
-    "name": "B",
-    "start": Array [
-      1,
-    ],
-  },
-  Object {
-    "end": Array [
-      2,
-    ],
-    "index": Array [
-      2,
-    ],
-    "label": Array [
-      "",
-    ],
-    "length": 1,
-    "name": "C",
-    "start": Array [
-      2,
-    ],
-  },
-  Object {
-    "end": Array [
       3,
     ],
     "index": Array [
-      3,
+      0,
     ],
     "label": Array [
       "",
@@ -1676,7 +1752,7 @@ Array [
       4,
     ],
     "index": Array [
-      4,
+      1,
     ],
     "label": Array [
       "",
@@ -1692,7 +1768,7 @@ Array [
       5,
     ],
     "index": Array [
-      5,
+      2,
     ],
     "label": Array [
       "",
@@ -1701,6 +1777,27 @@ Array [
     "name": "F",
     "start": Array [
       5,
+    ],
+  },
+]
+`;
+
+exports[`snapshots of selectors/profile-view matches the last stored run of selectedThreadSelector.getNetworkChartTiming 1`] = `
+Array [
+  Object {
+    "end": Array [
+      7,
+    ],
+    "index": Array [
+      0,
+    ],
+    "label": Array [
+      "",
+    ],
+    "length": 1,
+    "name": "G",
+    "start": Array [
+      6,
     ],
   },
 ]
@@ -1978,8 +2075,24 @@ Object {
     null,
     null,
     null,
+    Object {
+      "endTime": 7,
+      "id": 6,
+      "pri": 0,
+      "startTime": 6,
+      "status": "STOP",
+      "type": "Network",
+    },
+    Object {
+      "endTime": 8,
+      "id": 7,
+      "pri": 0,
+      "startTime": 7,
+      "status": "STOP",
+      "type": "Network",
+    },
   ],
-  "length": 6,
+  "length": 8,
   "name": Array [
     0,
     1,
@@ -1987,6 +2100,8 @@ Object {
     3,
     4,
     5,
+    6,
+    6,
   ],
   "time": Array [
     0,
@@ -1995,6 +2110,8 @@ Object {
     3,
     4,
     5,
+    6,
+    7,
   ],
 }
 `;
@@ -2156,17 +2273,27 @@ Object {
       null,
       null,
       null,
+      Object {
+        "endTime": 7,
+        "id": 6,
+        "pri": 0,
+        "startTime": 6,
+        "status": "STOP",
+        "type": "Network",
+      },
     ],
-    "length": 3,
+    "length": 4,
     "name": Array [
       3,
       4,
       5,
+      6,
     ],
     "time": Array [
       3,
       4,
       5,
+      6,
     ],
   },
   "name": "Thread with samples",
@@ -2432,17 +2559,27 @@ Object {
       null,
       null,
       null,
+      Object {
+        "endTime": 7,
+        "id": 6,
+        "pri": 0,
+        "startTime": 6,
+        "status": "STOP",
+        "type": "Network",
+      },
     ],
-    "length": 3,
+    "length": 4,
     "name": Array [
       3,
       4,
       5,
+      6,
     ],
     "time": Array [
       3,
       4,
       5,
+      6,
     ],
   },
   "name": "Thread with samples",
@@ -2577,6 +2714,20 @@ Array [
     "start": 5,
     "title": null,
   },
+  Object {
+    "data": Object {
+      "endTime": 7,
+      "id": 6,
+      "pri": 0,
+      "startTime": 6,
+      "status": "STOP",
+      "type": "Network",
+    },
+    "dur": 1,
+    "name": "G",
+    "start": 6,
+    "title": null,
+  },
 ]
 `;
 
@@ -2627,6 +2778,34 @@ Array [
     "dur": 0,
     "name": "F",
     "start": 5,
+    "title": null,
+  },
+  Object {
+    "data": Object {
+      "endTime": 7,
+      "id": 6,
+      "pri": 0,
+      "startTime": 6,
+      "status": "STOP",
+      "type": "Network",
+    },
+    "dur": 1,
+    "name": "G",
+    "start": 6,
+    "title": null,
+  },
+  Object {
+    "data": Object {
+      "endTime": 8,
+      "id": 7,
+      "pri": 0,
+      "startTime": 7,
+      "status": "STOP",
+      "type": "Network",
+    },
+    "dur": 1,
+    "name": "G",
+    "start": 7,
     "title": null,
   },
 ]

--- a/src/test/store/markers.test.js
+++ b/src/test/store/markers.test.js
@@ -6,15 +6,15 @@ import { storeWithProfile } from '../fixtures/stores';
 import { selectedThreadSelectors } from '../../reducers/profile-view';
 import { getProfileWithMarkers } from '../fixtures/profiles/make-profile';
 
-describe('selectors/getMarkerTiming', function() {
-  function getMarkerTiming(testMarkers) {
+describe('selectors/getMarkerChartTiming', function() {
+  function getMarkerChartTiming(testMarkers) {
     const profile = getProfileWithMarkers(testMarkers);
     const { getState } = storeWithProfile(profile);
-    return selectedThreadSelectors.getMarkerTiming(getState());
+    return selectedThreadSelectors.getMarkerChartTiming(getState());
   }
 
   it('has no marker timing if no markers are present', function() {
-    expect(getMarkerTiming([])).toEqual([]);
+    expect(getMarkerChartTiming([])).toEqual([]);
   });
 
   describe('markers of the same name', function() {
@@ -22,7 +22,7 @@ describe('selectors/getMarkerTiming', function() {
       // The timing should look like this:
       // 'Marker Name': *------*
       //              : *------*
-      const markerTiming = getMarkerTiming([
+      const markerTiming = getMarkerChartTiming([
         ['Marker Name', 0, { startTime: 0, endTime: 10 }],
         ['Marker Name', 0, { startTime: 0, endTime: 10 }],
       ]);
@@ -32,7 +32,7 @@ describe('selectors/getMarkerTiming', function() {
     it('puts markers of disjoint times in one row', function() {
       // The timing should look like this:
       // 'Marker Name': *------*  *------*
-      const markerTiming = getMarkerTiming([
+      const markerTiming = getMarkerChartTiming([
         ['Marker Name', 0, { startTime: 0, endTime: 10 }],
         ['Marker Name', 0, { startTime: 15, endTime: 25 }],
       ]);
@@ -43,7 +43,7 @@ describe('selectors/getMarkerTiming', function() {
       // The timing should look like this:
       // 'Marker Name': *------*
       //              :     *------*
-      const markerTiming = getMarkerTiming([
+      const markerTiming = getMarkerChartTiming([
         ['Marker Name', 0, { startTime: 0, endTime: 10 }],
         ['Marker Name', 0, { startTime: 5, endTime: 15 }],
       ]);
@@ -54,7 +54,7 @@ describe('selectors/getMarkerTiming', function() {
       // The timing should look like this:
       // 'Marker Name': *--------*
       //              :   *---*
-      const markerTiming = getMarkerTiming([
+      const markerTiming = getMarkerChartTiming([
         ['Marker Name', 0, { startTime: 0, endTime: 20 }],
         ['Marker Name', 0, { startTime: 5, endTime: 15 }],
       ]);
@@ -67,7 +67,7 @@ describe('selectors/getMarkerTiming', function() {
       // The timing should look like this:
       // 'Marker Name A': *------*
       // 'Marker Name B':           *------*
-      const markerTiming = getMarkerTiming([
+      const markerTiming = getMarkerChartTiming([
         ['Marker Name A', 0, { startTime: 0, endTime: 10 }],
         ['Marker Name B', 0, { startTime: 20, endTime: 30 }],
       ]);
@@ -79,7 +79,7 @@ describe('selectors/getMarkerTiming', function() {
 
   describe('markers that are crossing the profile start or end', function() {
     it('renders properly markers starting before profile start', function() {
-      const markerTiming = getMarkerTiming([
+      const markerTiming = getMarkerChartTiming([
         [
           'Rasterize',
           1,
@@ -99,7 +99,7 @@ describe('selectors/getMarkerTiming', function() {
     });
 
     it('renders properly markers ending after profile end', function() {
-      const markerTiming = getMarkerTiming([
+      const markerTiming = getMarkerChartTiming([
         [
           'Rasterize',
           20,

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -981,10 +981,16 @@ describe('snapshots of selectors/profile-view', function() {
       selectedThreadSelectors.getTracingMarkers(getState())
     ).toMatchSnapshot();
   });
-  it('matches the last stored run of selectedThreadSelector.getMarkerTiming', function() {
+  it('matches the last stored run of selectedThreadSelector.getMarkerChartTiming', function() {
     const { getState } = setupStore();
     expect(
-      selectedThreadSelectors.getMarkerTiming(getState())
+      selectedThreadSelectors.getMarkerChartTiming(getState())
+    ).toMatchSnapshot();
+  });
+  it('matches the last stored run of selectedThreadSelector.getNetworkChartTiming', function() {
+    const { getState } = setupStore();
+    expect(
+      selectedThreadSelectors.getNetworkChartTiming(getState())
     ).toMatchSnapshot();
   });
   it('matches the last stored run of selectedThreadSelector.getCommittedRangeFilteredTracingMarkers', function() {

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -11,6 +11,7 @@ import {
   getProfileWithMarkers,
   getNetworkTrackProfile,
   getScreenshotTrackProfile,
+  getNetworkMarker,
 } from '../fixtures/profiles/make-profile';
 import { withAnalyticsMock } from '../fixtures/mocks/analytics';
 import { getProfileWithNiceTracks } from '../fixtures/profiles/tracks';
@@ -873,6 +874,8 @@ describe('snapshots of selectors/profile-view', function() {
       ['D', 3, null],
       ['E', 4, null],
       ['F', 5, null],
+      getNetworkMarker(6, 6),
+      getNetworkMarker(7, 7),
     ]);
     profile.threads.push(markersThread);
     const { getState, dispatch } = storeWithProfile(profile);


### PR DESCRIPTION
This PR adds the searching feature for the marker chart, which we already had for the marker table. Also note that this changes the behavior of the marker chart to use the committed selection range, which is the same feature as #865, but was implemented a bit differently due to changes to the codebase since then.

![image](https://user-images.githubusercontent.com/1588648/44482220-63907f80-a60d-11e8-9073-0ed9775be7a7.png)
