### PR TITLE
Integrate the Redux devtools extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "react-splitter-layout": "^3.0.0",
     "react-transition-group": "^2.2.1",
     "redux": "^3.7.2",
+    "redux-devtools-extension": "^2.13.5",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.2.0",
     "reselect": "^3.0.1",

--- a/src/app-logic/create-store.js
+++ b/src/app-logic/create-store.js
@@ -7,6 +7,7 @@
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 import { createLogger } from 'redux-logger';
+import { composeWithDevTools } from 'redux-devtools-extension/developmentOnly';
 import reducers from '../reducers';
 import type { Store } from '../types/store';
 
@@ -30,7 +31,10 @@ export default function initializeStore(): Store {
     );
   }
 
-  const store = createStore(reducers, applyMiddleware(...middlewares));
+  const store = createStore(
+    reducers,
+    composeWithDevTools(applyMiddleware(...middlewares))
+  );
 
   return store;
 }

--- a/src/types/libdef/npm/redux-devtools-extension_v2.x.x.js
+++ b/src/types/libdef/npm/redux-devtools-extension_v2.x.x.js
@@ -1,0 +1,127 @@
+// flow-typed signature: 263123e4b3d2cb666a60f721c2da5354
+// flow-typed version: e1af06321a/redux-devtools-extension_v2.x.x/flow_>=v0.47.x
+
+import type { ActionCreator, StoreEnhancer } from 'redux';
+import typeof { compose } from 'redux';
+
+declare type $npm$ReduxDevtoolsExtension$DevToolsOptions = {
+  name?: string,
+  actionCreators?: Array<ActionCreator<any>> | { [string]: ActionCreator<any> },
+  latency?: number,
+  maxAge?: number,
+  serialize?: boolean | {
+    date?: boolean;
+    regex?: boolean;
+    undefined?: boolean;
+    error?: boolean;
+    symbol?: boolean;
+    map?: boolean;
+    set?: boolean;
+    function?: boolean | Function;
+  },
+  actionSanitizer?: <A: { type: $Subtype<string> }>(action: A, id: number) => A,
+  stateSanitizer?: <S>(state: S, index: number) => S,
+  actionsBlacklist?: string | string[],
+  actionsWhitelist?: string | string[],
+  predicate?: <S, A: { type: $Subtype<string> }>(state: S, action: A) => boolean,
+  shouldRecordChanges?: boolean,
+  pauseActionType?: string,
+  autoPause?: boolean,
+  shouldStartLocked?: boolean,
+  shouldHotReload?: boolean,
+  shouldCatchErrors?: boolean,
+  features?: {
+    pause?: boolean,
+    lock?: boolean,
+    persist?: boolean,
+    export?: boolean | "custom",
+    import?: boolean | "custom",
+    jump?: boolean,
+    skip?: boolean,
+    reorder?: boolean,
+    dispatch?: boolean,
+    test?: boolean
+  }
+};
+
+declare function $npm$ReduxDevtoolsExtension$composeWithDevTools<A, B>(ab: A => B): A => B;
+declare function $npm$ReduxDevtoolsExtension$composeWithDevTools(options: $npm$ReduxDevtoolsExtension$DevToolsOptions): compose;
+declare function $npm$ReduxDevtoolsExtension$composeWithDevTools<A, B, C>(
+  bc: B => C,
+  ab: A => B
+): A => C;
+declare function $npm$ReduxDevtoolsExtension$composeWithDevTools<A, B, C, D>(
+  cd: C => D,
+  bc: B => C,
+  ab: A => B
+): A => D;
+declare function $npm$ReduxDevtoolsExtension$composeWithDevTools<A, B, C, D, E>(
+  de: D => E,
+  cd: C => D,
+  bc: B => C,
+  ab: A => B
+): A => E;
+declare function $npm$ReduxDevtoolsExtension$composeWithDevTools<A, B, C, D, E, F>(
+  ef: E => F,
+  de: D => E,
+  cd: C => D,
+  bc: B => C,
+  ab: A => B
+): A => F;
+declare function $npm$ReduxDevtoolsExtension$composeWithDevTools<A, B, C, D, E, F, G>(
+  fg: F => G,
+  ef: E => F,
+  de: D => E,
+  cd: C => D,
+  bc: B => C,
+  ab: A => B
+): A => G;
+declare function $npm$ReduxDevtoolsExtension$composeWithDevTools<A, B, C, D, E, F, G, H>(
+  gh: G => H,
+  fg: F => G,
+  ef: E => F,
+  de: D => E,
+  cd: C => D,
+  bc: B => C,
+  ab: A => B
+): A => H;
+declare function $npm$ReduxDevtoolsExtension$composeWithDevTools<A, B, C, D, E, F, G, H, I>(
+  hi: H => I,
+  gh: G => H,
+  fg: F => G,
+  ef: E => F,
+  de: D => E,
+  cd: C => D,
+  bc: B => C,
+  ab: A => B
+): A => H;
+
+declare function $npm$ReduxDevtoolsExtension$devToolsEnhancer<S, A>(options?: $npm$ReduxDevtoolsExtension$DevToolsOptions): StoreEnhancer<S, A>;
+
+declare module 'redux-devtools-extension' {
+  declare export type DevToolsOptions = $npm$ReduxDevtoolsExtension$DevToolsOptions;
+
+  declare export var composeWithDevTools: typeof $npm$ReduxDevtoolsExtension$composeWithDevTools;
+  declare export var devToolsEnhancer: typeof $npm$ReduxDevtoolsExtension$devToolsEnhancer;
+}
+
+declare module 'redux-devtools-extension/developmentOnly' {
+  declare export type DevToolsOptions = $npm$ReduxDevtoolsExtension$DevToolsOptions;
+
+  declare export var composeWithDevTools: typeof $npm$ReduxDevtoolsExtension$composeWithDevTools;
+  declare export var devToolsEnhancer: typeof $npm$ReduxDevtoolsExtension$devToolsEnhancer;
+}
+
+declare module 'redux-devtools-extension/logOnly' {
+  declare export type DevToolsOptions = $npm$ReduxDevtoolsExtension$DevToolsOptions;
+
+  declare export var composeWithDevTools: typeof $npm$ReduxDevtoolsExtension$composeWithDevTools;
+  declare export var devToolsEnhancer: typeof $npm$ReduxDevtoolsExtension$devToolsEnhancer;
+}
+
+declare module 'redux-devtools-extension/logOnlyInProduction' {
+  declare export type DevToolsOptions = $npm$ReduxDevtoolsExtension$DevToolsOptions;
+
+  declare export var composeWithDevTools: typeof $npm$ReduxDevtoolsExtension$composeWithDevTools;
+  declare export var devToolsEnhancer: typeof $npm$ReduxDevtoolsExtension$devToolsEnhancer;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,7 +30,7 @@
   dependencies:
     "@babel/highlight" "7.0.0-beta.47"
 
-"@babel/core@7.0.0", "@babel/core@^7.0.0":
+"@babel/core@7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.0.0.tgz#0cb0c0fd2e78a0a2bec97698f549ae9ce0b99515"
   dependencies:
@@ -612,18 +612,6 @@
     "@babel/plugin-transform-react-jsx" "^7.0.0"
     "@babel/plugin-transform-react-jsx-self" "^7.0.0"
     "@babel/plugin-transform-react-jsx-source" "^7.0.0"
-
-"@babel/register@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.0.0.tgz#fa634bae1bfa429f60615b754fc1f1d745edd827"
-  dependencies:
-    core-js "^2.5.7"
-    find-cache-dir "^1.0.0"
-    home-or-tmp "^3.0.0"
-    lodash "^4.17.10"
-    mkdirp "^0.5.1"
-    pirates "^4.0.0"
-    source-map-support "^0.5.9"
 
 "@babel/template@^7.0.0":
   version "7.0.0"
@@ -1402,7 +1390,7 @@ babel-preset-jest@^23.2.0:
     babel-plugin-jest-hoist "^23.2.0"
     babel-plugin-syntax-object-rest-spread "^6.13.0"
 
-babel-register@^6.26.0:
+babel-register@^6.18.0, babel-register@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.26.0.tgz#6ed021173e2fcb486d7acb45c6009a856f647071"
   dependencies:
@@ -4412,10 +4400,6 @@ home-or-tmp@^2.0.0:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
 
-home-or-tmp@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-3.0.0.tgz#57a8fe24cf33cdd524860a15821ddc25c86671fb"
-
 home-path@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/home-path/-/home-path-1.0.5.tgz#788b29815b12d53bacf575648476e6f9041d133f"
@@ -6735,10 +6719,6 @@ node-libs-browser@^2.0.0:
     util "^0.10.3"
     vm-browserify "0.0.4"
 
-node-modules-regexp@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
-
 node-notifier@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.2.1.tgz#fa313dd08f5517db0e2502e5758d664ac69f9dea"
@@ -7355,12 +7335,6 @@ pinkie-promise@^2.0.0:
 pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
-
-pirates@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.0.tgz#850b18781b4ac6ec58a43c9ed9ec5fe6796addbd"
-  dependencies:
-    node-modules-regexp "^1.0.0"
 
 pkg-dir@^1.0.0:
   version "1.0.0"
@@ -8232,6 +8206,10 @@ reduce-function-call@^1.0.1:
   dependencies:
     balanced-match "^0.4.2"
 
+redux-devtools-extension@^2.13.5:
+  version "2.13.5"
+  resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-2.13.5.tgz#3ff34f7227acfeef3964194f5f7fc2765e5c5a39"
+
 redux-logger@^3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"
@@ -8929,7 +8907,7 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.6, source-map-support@^0.5.9:
+source-map-support@^0.5.6:
   version "0.5.9"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.9.tgz#41bc953b2534267ea2d605bccfa7bfa3111ced5f"
   dependencies:
@@ -10188,8 +10166,7 @@ worker-farm@^1.5.2:
   version "0.1.2"
   resolved "https://codeload.github.com/jasonLaster/workerjs/tar.gz/8c7df3e465b1d096d5134c648287d4a6f9c3e4ea"
   dependencies:
-    "@babel/core" "^7.0.0"
-    "@babel/register" "^7.0.0"
+    babel-register "^6.18.0"
 
 wrap-ansi@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
To use them we still need to disable the CSP because of a [gecko bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1267027). This works in Chrome with the CSP though.