### PR TITLE
Label GPU thread on Windows

### DIFF
--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -1210,6 +1210,9 @@ export function getFriendlyThreadName(
         case 'default':
           label = 'Main Thread';
           break;
+        case 'gpu':
+          label = 'GPU Process';
+          break;
         case 'tab': {
           const contentThreads = threads.filter(thread => {
             return thread.name === 'GeckoMain' && thread.processType === 'tab';


### PR DESCRIPTION
This PR labels the GPU thread on Windows.

Partially fulfills #338.