### PR TITLE
Sample selection in the stack graph

### DIFF
--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -14,10 +14,7 @@ import {
   getCategories,
 } from '../../reducers/profile-view';
 import { getSelectedThreadIndex } from '../../reducers/url-state';
-import {
-  getSampleIndexClosestToTime,
-  getCallNodePathFromIndex,
-} from '../../profile-logic/profile-data';
+import { getCallNodePathFromIndex } from '../../profile-logic/profile-data';
 import {
   TimelineTracingMarkersJank,
   TimelineTracingMarkersOverview,
@@ -32,7 +29,12 @@ import {
 import EmptyThreadIndicator from './EmptyThreadIndicator';
 import './TrackThread.css';
 
-import type { Thread, ThreadIndex, CategoryList } from '../../types/profile';
+import type {
+  Thread,
+  ThreadIndex,
+  CategoryList,
+  IndexIntoSamplesTable,
+} from '../../types/profile';
 import type { Milliseconds, StartEndRange } from '../../types/units';
 import type {
   CallNodeInfo,
@@ -70,19 +72,15 @@ type DispatchProps = {|
 type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
 
 class TimelineTrackThread extends PureComponent<Props> {
-  _onStackClick = (time: number) => {
-    const { threadIndex, interval } = this.props;
+  _onSampleClick = (sampleIndex: IndexIntoSamplesTable) => {
     const {
       thread,
+      threadIndex,
       callNodeInfo,
       changeSelectedCallNode,
       focusCallTree,
     } = this.props;
-    const sampleIndex = getSampleIndexClosestToTime(
-      thread.samples,
-      time,
-      interval
-    );
+
     const newSelectedStack = thread.samples.stack[sampleIndex];
     const newSelectedCallNode =
       newSelectedStack === null
@@ -171,7 +169,7 @@ class TimelineTrackThread extends PureComponent<Props> {
           callNodeInfo={callNodeInfo}
           selectedCallNodeIndex={selectedCallNodeIndex}
           categories={categories}
-          onStackClick={this._onStackClick}
+          onSampleClick={this._onSampleClick}
         />
         <EmptyThreadIndicator
           thread={thread}

--- a/src/test/components/GlobalTrack.test.js
+++ b/src/test/components/GlobalTrack.test.js
@@ -18,6 +18,7 @@ import {
   getRightClickedTrack,
 } from '../../reducers/profile-view';
 import { getSelectedThreadIndex } from '../../reducers/url-state';
+import mockCanvasContext from '../fixtures/mocks/canvas-context';
 import { getProfileWithNiceTracks } from '../fixtures/profiles/tracks';
 import { storeWithProfile } from '../fixtures/stores';
 import { getMouseEvent } from '../fixtures/utils';
@@ -49,6 +50,11 @@ describe('timeline/GlobalTrack', function() {
     if (threadIndex === null) {
       throw new Error('Expected the track to have a thread index.');
     }
+
+    // Some child components render to canvas.
+    jest
+      .spyOn(HTMLCanvasElement.prototype, 'getContext')
+      .mockImplementation(() => mockCanvasContext());
 
     // The assertions are simpler if this thread is not already selected.
     dispatch(changeSelectedThread(threadIndex + 1));

--- a/src/test/components/LocalTrack.test.js
+++ b/src/test/components/LocalTrack.test.js
@@ -23,6 +23,7 @@ import {
   getProfile,
 } from '../../reducers/profile-view';
 import { getSelectedThreadIndex } from '../../reducers/url-state';
+import mockCanvasContext from '../fixtures/mocks/canvas-context';
 import { getNetworkTrackProfile } from '../fixtures/profiles/make-profile';
 import { getProfileWithNiceTracks } from '../fixtures/profiles/tracks';
 import { storeWithProfile } from '../fixtures/stores';
@@ -123,6 +124,11 @@ function setup(
   const { threadIndex } = localTrack;
   // The assertions are simpler if this thread is not already selected.
   dispatch(changeSelectedThread(threadIndex + 1));
+
+  // Some child components render to canvas.
+  jest
+    .spyOn(HTMLCanvasElement.prototype, 'getContext')
+    .mockImplementation(() => mockCanvasContext());
 
   const view = mount(
     <Provider store={store}>

--- a/src/test/components/ZipFileTree.test.js
+++ b/src/test/components/ZipFileTree.test.js
@@ -21,6 +21,12 @@ describe('calltree/ZipFileTree', function() {
       'foo/profile2.json',
       'baz/profile3.json',
     ]);
+
+    // Some child components render to canvas.
+    jest
+      .spyOn(HTMLCanvasElement.prototype, 'getContext')
+      .mockImplementation(() => mockCanvasContext());
+
     const component = mount(
       <Provider store={store}>
         <ZipFileViewer />


### PR DESCRIPTION
This is in preparation of the ThreadActivityGraph from PR #1072. It
updates the stack graph to use sample selection.

The largest change from the original commits was to change the selection
state from a C enum-like value, with named variables, to strings. I felt
that this was more type-friendly for Flow, and shouldn't add any
overhead due to the nature of how JS creates strings.