### PR TITLE
Implementation radio buttons

### DIFF
--- a/src/components/shared/StackSettings.css
+++ b/src/components/shared/StackSettings.css
@@ -43,8 +43,15 @@
 .stackSettingsFilter {
   border-right: 1px solid var(--grey-20);
   padding-right: 10px;
+  white-space: nowrap;
 }
 
 .stackSettingsFilterLabel {
+  display: inline-flex;
+  align-items: center;
   padding-right: 5px;
+}
+
+.stackSettingsFilterInput {
+  margin: 0 4px;
 }

--- a/src/components/shared/StackSettings.css
+++ b/src/components/shared/StackSettings.css
@@ -36,11 +36,15 @@
   height: 25px;
 }
 
-.stackSettingsSelect {
-  margin: 0 5px;
-  font-size: 11px;
-}
-
 .stackSettingsCheckbox {
   margin: 0 5px;
+}
+
+.stackSettingsFilter {
+  border-right: 1px solid var(--grey-20);
+  padding-right: 10px;
+}
+
+.stackSettingsFilterLabel {
+  padding-right: 5px;
 }

--- a/src/components/shared/StackSettings.js
+++ b/src/components/shared/StackSettings.js
@@ -30,7 +30,7 @@ type Props = {|
 |};
 
 class StackSettings extends PureComponent<Props> {
-  _onImplementationFilterChange = (e: SyntheticEvent<HTMLSelectElement>) => {
+  _onImplementationFilterChange = (e: SyntheticEvent<HTMLInputElement>) => {
     this.props.changeImplementationFilter(
       // This function is here to satisfy Flow that we are getting a valid
       // implementation filter.
@@ -42,29 +42,37 @@ class StackSettings extends PureComponent<Props> {
     this.props.changeInvertCallstack(e.currentTarget.checked);
   };
 
+  _renderRadioButton(
+    label: string,
+    implementationFilter: ImplementationFilter
+  ) {
+    return (
+      <label className="stackSettingsFilterLabel">
+        <input
+          type="radio"
+          value={implementationFilter}
+          name="stack-settings-filter"
+          title="Filter stack frames to a type."
+          onChange={this._onImplementationFilterChange}
+          checked={this.props.implementationFilter === implementationFilter}
+        />
+        {label}
+      </label>
+    );
+  }
+
   render() {
-    const {
-      implementationFilter,
-      invertCallstack,
-      hideInvertCallstack,
-    } = this.props;
+    const { invertCallstack, hideInvertCallstack } = this.props;
 
     return (
       <div className="stackSettings">
         <ul className="stackSettingsList">
           <li className="stackSettingsListItem">
-            <label className="stackSettingsLabel">
-              Filter:
-              <select
-                className="stackSettingsSelect"
-                onChange={this._onImplementationFilterChange}
-                value={implementationFilter}
-              >
-                <option value="combined">Combined stacks</option>
-                <option value="js">JS only</option>
-                <option value="cpp">C++ only</option>
-              </select>
-            </label>
+            <div className="stackSettingsFilter">
+              {this._renderRadioButton('All stacks', 'combined')}
+              {this._renderRadioButton('JavaScript', 'js')}
+              {this._renderRadioButton('Native', 'cpp')}
+            </div>
           </li>
           {hideInvertCallstack ? null : (
             <li className="stackSettingsListItem">

--- a/src/components/shared/StackSettings.js
+++ b/src/components/shared/StackSettings.js
@@ -50,6 +50,7 @@ class StackSettings extends PureComponent<Props> {
       <label className="stackSettingsFilterLabel">
         <input
           type="radio"
+          className="stackSettingsFilterInput"
           value={implementationFilter}
           name="stack-settings-filter"
           title="Filter stack frames to a type."
@@ -67,12 +68,10 @@ class StackSettings extends PureComponent<Props> {
     return (
       <div className="stackSettings">
         <ul className="stackSettingsList">
-          <li className="stackSettingsListItem">
-            <div className="stackSettingsFilter">
-              {this._renderRadioButton('All stacks', 'combined')}
-              {this._renderRadioButton('JavaScript', 'js')}
-              {this._renderRadioButton('Native', 'cpp')}
-            </div>
+          <li className="stackSettingsListItem stackSettingsFilter">
+            {this._renderRadioButton('All stacks', 'combined')}
+            {this._renderRadioButton('JavaScript', 'js')}
+            {this._renderRadioButton('Native', 'cpp')}
           </li>
           {hideInvertCallstack ? null : (
             <li className="stackSettingsListItem">

--- a/src/test/components/__snapshots__/FlameGraph.test.js.snap
+++ b/src/test/components/__snapshots__/FlameGraph.test.js.snap
@@ -11,33 +11,49 @@ exports[`renders FlameGraph correctly 1`] = `
       className="stackSettingsList"
     >
       <li
-        className="stackSettingsListItem"
+        className="stackSettingsListItem stackSettingsFilter"
       >
         <label
-          className="stackSettingsLabel"
+          className="stackSettingsFilterLabel"
         >
-          Filter:
-          <select
-            className="stackSettingsSelect"
+          <input
+            checked={true}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
             onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
             value="combined"
-          >
-            <option
-              value="combined"
-            >
-              Combined stacks
-            </option>
-            <option
-              value="js"
-            >
-              JS only
-            </option>
-            <option
-              value="cpp"
-            >
-              C++ only
-            </option>
-          </select>
+          />
+          All stacks
+        </label>
+        <label
+          className="stackSettingsFilterLabel"
+        >
+          <input
+            checked={false}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
+            onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
+            value="js"
+          />
+          JavaScript
+        </label>
+        <label
+          className="stackSettingsFilterLabel"
+        >
+          <input
+            checked={false}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
+            onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
+            value="cpp"
+          />
+          Native
         </label>
       </li>
     </ul>
@@ -506,33 +522,49 @@ exports[`renders a message instead of FlameGraph when call stack is inverted 1`]
       className="stackSettingsList"
     >
       <li
-        className="stackSettingsListItem"
+        className="stackSettingsListItem stackSettingsFilter"
       >
         <label
-          className="stackSettingsLabel"
+          className="stackSettingsFilterLabel"
         >
-          Filter:
-          <select
-            className="stackSettingsSelect"
+          <input
+            checked={true}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
             onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
             value="combined"
-          >
-            <option
-              value="combined"
-            >
-              Combined stacks
-            </option>
-            <option
-              value="js"
-            >
-              JS only
-            </option>
-            <option
-              value="cpp"
-            >
-              C++ only
-            </option>
-          </select>
+          />
+          All stacks
+        </label>
+        <label
+          className="stackSettingsFilterLabel"
+        >
+          <input
+            checked={false}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
+            onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
+            value="js"
+          />
+          JavaScript
+        </label>
+        <label
+          className="stackSettingsFilterLabel"
+        >
+          <input
+            checked={false}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
+            onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
+            value="cpp"
+          />
+          Native
         </label>
       </li>
     </ul>

--- a/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
+++ b/src/test/components/__snapshots__/ProfileCallTreeView.test.js.snap
@@ -11,33 +11,49 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows a reason for a call tre
       className="stackSettingsList"
     >
       <li
-        className="stackSettingsListItem"
+        className="stackSettingsListItem stackSettingsFilter"
       >
         <label
-          className="stackSettingsLabel"
+          className="stackSettingsFilterLabel"
         >
-          Filter:
-          <select
-            className="stackSettingsSelect"
+          <input
+            checked={true}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
             onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
             value="combined"
-          >
-            <option
-              value="combined"
-            >
-              Combined stacks
-            </option>
-            <option
-              value="js"
-            >
-              JS only
-            </option>
-            <option
-              value="cpp"
-            >
-              C++ only
-            </option>
-          </select>
+          />
+          All stacks
+        </label>
+        <label
+          className="stackSettingsFilterLabel"
+        >
+          <input
+            checked={false}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
+            onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
+            value="js"
+          />
+          JavaScript
+        </label>
+        <label
+          className="stackSettingsFilterLabel"
+        >
+          <input
+            checked={false}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
+            onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
+            value="cpp"
+          />
+          Native
         </label>
       </li>
       <li
@@ -137,33 +153,49 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows reasons for being out o
       className="stackSettingsList"
     >
       <li
-        className="stackSettingsListItem"
+        className="stackSettingsListItem stackSettingsFilter"
       >
         <label
-          className="stackSettingsLabel"
+          className="stackSettingsFilterLabel"
         >
-          Filter:
-          <select
-            className="stackSettingsSelect"
+          <input
+            checked={true}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
             onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
             value="combined"
-          >
-            <option
-              value="combined"
-            >
-              Combined stacks
-            </option>
-            <option
-              value="js"
-            >
-              JS only
-            </option>
-            <option
-              value="cpp"
-            >
-              C++ only
-            </option>
-          </select>
+          />
+          All stacks
+        </label>
+        <label
+          className="stackSettingsFilterLabel"
+        >
+          <input
+            checked={false}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
+            onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
+            value="js"
+          />
+          JavaScript
+        </label>
+        <label
+          className="stackSettingsFilterLabel"
+        >
+          <input
+            checked={false}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
+            onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
+            value="cpp"
+          />
+          Native
         </label>
       </li>
       <li
@@ -263,33 +295,49 @@ exports[`calltree/ProfileCallTreeView EmptyReasons shows reasons for when sample
       className="stackSettingsList"
     >
       <li
-        className="stackSettingsListItem"
+        className="stackSettingsListItem stackSettingsFilter"
       >
         <label
-          className="stackSettingsLabel"
+          className="stackSettingsFilterLabel"
         >
-          Filter:
-          <select
-            className="stackSettingsSelect"
+          <input
+            checked={false}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
             onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
+            value="combined"
+          />
+          All stacks
+        </label>
+        <label
+          className="stackSettingsFilterLabel"
+        >
+          <input
+            checked={true}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
+            onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
             value="js"
-          >
-            <option
-              value="combined"
-            >
-              Combined stacks
-            </option>
-            <option
-              value="js"
-            >
-              JS only
-            </option>
-            <option
-              value="cpp"
-            >
-              C++ only
-            </option>
-          </select>
+          />
+          JavaScript
+        </label>
+        <label
+          className="stackSettingsFilterLabel"
+        >
+          <input
+            checked={false}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
+            onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
+            value="cpp"
+          />
+          Native
         </label>
       </li>
       <li
@@ -389,33 +437,49 @@ exports[`calltree/ProfileCallTreeView computes a width for a call tree of a real
       className="stackSettingsList"
     >
       <li
-        className="stackSettingsListItem"
+        className="stackSettingsListItem stackSettingsFilter"
       >
         <label
-          className="stackSettingsLabel"
+          className="stackSettingsFilterLabel"
         >
-          Filter:
-          <select
-            className="stackSettingsSelect"
+          <input
+            checked={true}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
             onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
             value="combined"
-          >
-            <option
-              value="combined"
-            >
-              Combined stacks
-            </option>
-            <option
-              value="js"
-            >
-              JS only
-            </option>
-            <option
-              value="cpp"
-            >
-              C++ only
-            </option>
-          </select>
+          />
+          All stacks
+        </label>
+        <label
+          className="stackSettingsFilterLabel"
+        >
+          <input
+            checked={false}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
+            onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
+            value="js"
+          />
+          JavaScript
+        </label>
+        <label
+          className="stackSettingsFilterLabel"
+        >
+          <input
+            checked={false}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
+            onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
+            value="cpp"
+          />
+          Native
         </label>
       </li>
       <li
@@ -2050,33 +2114,49 @@ exports[`calltree/ProfileCallTreeView renders an inverted call tree 1`] = `
       className="stackSettingsList"
     >
       <li
-        className="stackSettingsListItem"
+        className="stackSettingsListItem stackSettingsFilter"
       >
         <label
-          className="stackSettingsLabel"
+          className="stackSettingsFilterLabel"
         >
-          Filter:
-          <select
-            className="stackSettingsSelect"
+          <input
+            checked={true}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
             onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
             value="combined"
-          >
-            <option
-              value="combined"
-            >
-              Combined stacks
-            </option>
-            <option
-              value="js"
-            >
-              JS only
-            </option>
-            <option
-              value="cpp"
-            >
-              C++ only
-            </option>
-          </select>
+          />
+          All stacks
+        </label>
+        <label
+          className="stackSettingsFilterLabel"
+        >
+          <input
+            checked={false}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
+            onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
+            value="js"
+          />
+          JavaScript
+        </label>
+        <label
+          className="stackSettingsFilterLabel"
+        >
+          <input
+            checked={false}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
+            onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
+            value="cpp"
+          />
+          Native
         </label>
       </li>
       <li
@@ -2791,33 +2871,49 @@ exports[`calltree/ProfileCallTreeView renders an unfiltered call tree 1`] = `
       className="stackSettingsList"
     >
       <li
-        className="stackSettingsListItem"
+        className="stackSettingsListItem stackSettingsFilter"
       >
         <label
-          className="stackSettingsLabel"
+          className="stackSettingsFilterLabel"
         >
-          Filter:
-          <select
-            className="stackSettingsSelect"
+          <input
+            checked={true}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
             onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
             value="combined"
-          >
-            <option
-              value="combined"
-            >
-              Combined stacks
-            </option>
-            <option
-              value="js"
-            >
-              JS only
-            </option>
-            <option
-              value="cpp"
-            >
-              C++ only
-            </option>
-          </select>
+          />
+          All stacks
+        </label>
+        <label
+          className="stackSettingsFilterLabel"
+        >
+          <input
+            checked={false}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
+            onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
+            value="js"
+          />
+          JavaScript
+        </label>
+        <label
+          className="stackSettingsFilterLabel"
+        >
+          <input
+            checked={false}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
+            onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
+            value="cpp"
+          />
+          Native
         </label>
       </li>
       <li
@@ -3532,33 +3628,49 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
       className="stackSettingsList"
     >
       <li
-        className="stackSettingsListItem"
+        className="stackSettingsListItem stackSettingsFilter"
       >
         <label
-          className="stackSettingsLabel"
+          className="stackSettingsFilterLabel"
         >
-          Filter:
-          <select
-            className="stackSettingsSelect"
+          <input
+            checked={true}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
             onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
             value="combined"
-          >
-            <option
-              value="combined"
-            >
-              Combined stacks
-            </option>
-            <option
-              value="js"
-            >
-              JS only
-            </option>
-            <option
-              value="cpp"
-            >
-              C++ only
-            </option>
-          </select>
+          />
+          All stacks
+        </label>
+        <label
+          className="stackSettingsFilterLabel"
+        >
+          <input
+            checked={false}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
+            onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
+            value="js"
+          />
+          JavaScript
+        </label>
+        <label
+          className="stackSettingsFilterLabel"
+        >
+          <input
+            checked={false}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
+            onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
+            value="cpp"
+          />
+          Native
         </label>
       </li>
       <li
@@ -4273,33 +4385,49 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
       className="stackSettingsList"
     >
       <li
-        className="stackSettingsListItem"
+        className="stackSettingsListItem stackSettingsFilter"
       >
         <label
-          className="stackSettingsLabel"
+          className="stackSettingsFilterLabel"
         >
-          Filter:
-          <select
-            className="stackSettingsSelect"
+          <input
+            checked={true}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
             onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
             value="combined"
-          >
-            <option
-              value="combined"
-            >
-              Combined stacks
-            </option>
-            <option
-              value="js"
-            >
-              JS only
-            </option>
-            <option
-              value="cpp"
-            >
-              C++ only
-            </option>
-          </select>
+          />
+          All stacks
+        </label>
+        <label
+          className="stackSettingsFilterLabel"
+        >
+          <input
+            checked={false}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
+            onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
+            value="js"
+          />
+          JavaScript
+        </label>
+        <label
+          className="stackSettingsFilterLabel"
+        >
+          <input
+            checked={false}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
+            onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
+            value="cpp"
+          />
+          Native
         </label>
       </li>
       <li
@@ -4943,33 +5071,49 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
       className="stackSettingsList"
     >
       <li
-        className="stackSettingsListItem"
+        className="stackSettingsListItem stackSettingsFilter"
       >
         <label
-          className="stackSettingsLabel"
+          className="stackSettingsFilterLabel"
         >
-          Filter:
-          <select
-            className="stackSettingsSelect"
+          <input
+            checked={true}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
             onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
             value="combined"
-          >
-            <option
-              value="combined"
-            >
-              Combined stacks
-            </option>
-            <option
-              value="js"
-            >
-              JS only
-            </option>
-            <option
-              value="cpp"
-            >
-              C++ only
-            </option>
-          </select>
+          />
+          All stacks
+        </label>
+        <label
+          className="stackSettingsFilterLabel"
+        >
+          <input
+            checked={false}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
+            onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
+            value="js"
+          />
+          JavaScript
+        </label>
+        <label
+          className="stackSettingsFilterLabel"
+        >
+          <input
+            checked={false}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
+            onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
+            value="cpp"
+          />
+          Native
         </label>
       </li>
       <li
@@ -5613,33 +5757,49 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
       className="stackSettingsList"
     >
       <li
-        className="stackSettingsListItem"
+        className="stackSettingsListItem stackSettingsFilter"
       >
         <label
-          className="stackSettingsLabel"
+          className="stackSettingsFilterLabel"
         >
-          Filter:
-          <select
-            className="stackSettingsSelect"
+          <input
+            checked={true}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
             onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
             value="combined"
-          >
-            <option
-              value="combined"
-            >
-              Combined stacks
-            </option>
-            <option
-              value="js"
-            >
-              JS only
-            </option>
-            <option
-              value="cpp"
-            >
-              C++ only
-            </option>
-          </select>
+          />
+          All stacks
+        </label>
+        <label
+          className="stackSettingsFilterLabel"
+        >
+          <input
+            checked={false}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
+            onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
+            value="js"
+          />
+          JavaScript
+        </label>
+        <label
+          className="stackSettingsFilterLabel"
+        >
+          <input
+            checked={false}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
+            onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
+            value="cpp"
+          />
+          Native
         </label>
       </li>
       <li
@@ -6136,33 +6296,49 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
       className="stackSettingsList"
     >
       <li
-        className="stackSettingsListItem"
+        className="stackSettingsListItem stackSettingsFilter"
       >
         <label
-          className="stackSettingsLabel"
+          className="stackSettingsFilterLabel"
         >
-          Filter:
-          <select
-            className="stackSettingsSelect"
+          <input
+            checked={true}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
             onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
             value="combined"
-          >
-            <option
-              value="combined"
-            >
-              Combined stacks
-            </option>
-            <option
-              value="js"
-            >
-              JS only
-            </option>
-            <option
-              value="cpp"
-            >
-              C++ only
-            </option>
-          </select>
+          />
+          All stacks
+        </label>
+        <label
+          className="stackSettingsFilterLabel"
+        >
+          <input
+            checked={false}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
+            onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
+            value="js"
+          />
+          JavaScript
+        </label>
+        <label
+          className="stackSettingsFilterLabel"
+        >
+          <input
+            checked={false}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
+            onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
+            value="cpp"
+          />
+          Native
         </label>
       </li>
       <li
@@ -6659,33 +6835,49 @@ exports[`calltree/ProfileCallTreeView renders call tree with some search strings
       className="stackSettingsList"
     >
       <li
-        className="stackSettingsListItem"
+        className="stackSettingsListItem stackSettingsFilter"
       >
         <label
-          className="stackSettingsLabel"
+          className="stackSettingsFilterLabel"
         >
-          Filter:
-          <select
-            className="stackSettingsSelect"
+          <input
+            checked={true}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
             onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
             value="combined"
-          >
-            <option
-              value="combined"
-            >
-              Combined stacks
-            </option>
-            <option
-              value="js"
-            >
-              JS only
-            </option>
-            <option
-              value="cpp"
-            >
-              C++ only
-            </option>
-          </select>
+          />
+          All stacks
+        </label>
+        <label
+          className="stackSettingsFilterLabel"
+        >
+          <input
+            checked={false}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
+            onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
+            value="js"
+          />
+          JavaScript
+        </label>
+        <label
+          className="stackSettingsFilterLabel"
+        >
+          <input
+            checked={false}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
+            onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
+            value="cpp"
+          />
+          Native
         </label>
       </li>
       <li

--- a/src/test/components/__snapshots__/StackChart.test.js.snap
+++ b/src/test/components/__snapshots__/StackChart.test.js.snap
@@ -11,33 +11,49 @@ exports[`StackChart matches the snapshot 1`] = `
       className="stackSettingsList"
     >
       <li
-        className="stackSettingsListItem"
+        className="stackSettingsListItem stackSettingsFilter"
       >
         <label
-          className="stackSettingsLabel"
+          className="stackSettingsFilterLabel"
         >
-          Filter:
-          <select
-            className="stackSettingsSelect"
+          <input
+            checked={true}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
             onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
             value="combined"
-          >
-            <option
-              value="combined"
-            >
-              Combined stacks
-            </option>
-            <option
-              value="js"
-            >
-              JS only
-            </option>
-            <option
-              value="cpp"
-            >
-              C++ only
-            </option>
-          </select>
+          />
+          All stacks
+        </label>
+        <label
+          className="stackSettingsFilterLabel"
+        >
+          <input
+            checked={false}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
+            onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
+            value="js"
+          />
+          JavaScript
+        </label>
+        <label
+          className="stackSettingsFilterLabel"
+        >
+          <input
+            checked={false}
+            className="stackSettingsFilterInput"
+            name="stack-settings-filter"
+            onChange={[Function]}
+            title="Filter stack frames to a type."
+            type="radio"
+            value="cpp"
+          />
+          Native
         </label>
       </li>
       <li


### PR DESCRIPTION
I was reading through [Microsoft's guidelines for radio buttons](https://docs.microsoft.com/en-us/windows/uwp/design/controls-and-patterns/radio-button) and realized our implementation filter might be better served as radio buttons.

Benefits:
 * It makes it one less click to toggle between the filters.
 * All options are visible to a user

Drawbacks:
 * Visually larger, and messier.

[Deploy preview](https://deploy-preview-1278--perf-html.netlify.com/public/7d87329a81bd81e5ebd4bc8f404f53c7e553bae1/calltree/?globalTrackOrder=0-1-2-3-4-5&hiddenGlobalTracks=0-1-2-3-4&hiddenLocalTracksByPid=7999-0&implementation=js&localTrackOrderByPid=7620-1-0~7999-0~&range=3.2784_5.4240&thread=6&v=3)