### PR TITLE
Thread activity graph

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -63,6 +63,9 @@ import type { Transform } from '../types/transforms';
 /**
  * Select a call node for a given thread. An optional call node path can be provided
  * to expand child nodes beyond the selected call node path.
+ *
+ * Note that optionalExpandedToCallNodePath, if specified, must be a descendant call node
+ * of selectedCallNodePath.
  */
 export function changeSelectedCallNode(
   threadIndex: ThreadIndex,
@@ -72,7 +75,7 @@ export function changeSelectedCallNode(
   if (optionalExpandedToCallNodePath) {
     for (let i = 0; i < selectedCallNodePath.length; i++) {
       if (selectedCallNodePath[i] !== optionalExpandedToCallNodePath[i]) {
-        // This assertions ensures that the selectedCallNode will be correctly expanded.
+        // This assertion ensures that the selectedCallNode will be correctly expanded.
         throw new Error(
           oneLine`
             The optional expanded call node path provided to the changeSelectedCallNode
@@ -91,7 +94,8 @@ export function changeSelectedCallNode(
 }
 
 /**
- * Given a sample index, select the leaf most call node for a thread.
+ * Given a threadIndex and a sampleIndex, select the call node at the top ("leaf")
+ * of that sample's stack.
  */
 export function selectLeafCallNode(
   threadIndex: ThreadIndex,

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -30,6 +30,7 @@ import type {
   PreviewSelection,
   ImplementationFilter,
   TrackReference,
+  TimelineType,
 } from '../types/actions';
 import type { State } from '../types/reducers';
 import type { Action, ThunkAction } from '../types/store';
@@ -832,5 +833,12 @@ export function popTransformsFromStack(
       threadIndex,
       firstPoppedFilterIndex,
     });
+  };
+}
+
+export function changeTimelineType(timelineType: TimelineType): Action {
+  return {
+    type: 'CHANGE_TIMELINE_TYPE',
+    timelineType,
   };
 }

--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
+import { oneLine } from 'common-tags';
 import { getLastVisibleThreadTabSlug } from '../reducers/app';
 import {
   selectorsForThread,
@@ -22,7 +23,12 @@ import {
   getHiddenLocalTracks,
   getSelectedTab,
 } from '../reducers/url-state';
-import { getCallNodePathFromIndex } from '../profile-logic/profile-data';
+import {
+  getCallNodePathFromIndex,
+  getSampleCallNodes,
+  getSampleCategories,
+  findBestAncestorCallNode,
+} from '../profile-logic/profile-data';
 import { ensureExists, assertExhaustiveCheck } from '../utils/flow';
 import { sendAnalytics } from '../utils/analytics';
 
@@ -34,7 +40,12 @@ import type {
 } from '../types/actions';
 import type { State } from '../types/reducers';
 import type { Action, ThunkAction } from '../types/store';
-import type { ThreadIndex, IndexIntoMarkersTable, Pid } from '../types/profile';
+import type {
+  ThreadIndex,
+  IndexIntoMarkersTable,
+  Pid,
+  IndexIntoSamplesTable,
+} from '../types/profile';
 import type {
   CallNodePath,
   CallNodeInfo,
@@ -44,18 +55,128 @@ import type {
 import type { Transform } from '../types/transforms';
 
 /**
- * The actions that pertain to changing the view on the profile, including searching
- * and filtering. Currently the call tree's actions are in this file, but should be
- * split apart. These actions should most likely affect every panel.
+ * This file contains actions that pertain to changing the view on the profile, including
+ * searching and filtering. Currently the call tree's actions are in this file, but
+ * should be split apart. These actions should most likely affect every panel.
+ */
+
+/**
+ * Select a call node for a given thread. An optional call node path can be provided
+ * to expand child nodes beyond the selected call node path.
  */
 export function changeSelectedCallNode(
   threadIndex: ThreadIndex,
-  selectedCallNodePath: CallNodePath
+  selectedCallNodePath: CallNodePath,
+  optionalExpandedToCallNodePath?: CallNodePath
 ): Action {
+  if (optionalExpandedToCallNodePath) {
+    for (let i = 0; i < selectedCallNodePath.length; i++) {
+      if (selectedCallNodePath[i] !== optionalExpandedToCallNodePath[i]) {
+        // This assertions ensures that the selectedCallNode will be correctly expanded.
+        throw new Error(
+          oneLine`
+            The optional expanded call node path provided to the changeSelectedCallNode
+            must contain the selected call node path.
+          `
+        );
+      }
+    }
+  }
   return {
     type: 'CHANGE_SELECTED_CALL_NODE',
     selectedCallNodePath,
+    optionalExpandedToCallNodePath,
     threadIndex,
+  };
+}
+
+/**
+ * Given a sample index, select the leaf most call node for a thread.
+ */
+export function selectLeafCallNode(
+  threadIndex: ThreadIndex,
+  sampleIndex: IndexIntoSamplesTable
+): ThunkAction<void> {
+  return (dispatch, getState) => {
+    const threadSelectors = selectorsForThread(threadIndex);
+    const filteredThread = threadSelectors.getFilteredThread(getState());
+    const callNodeInfo = threadSelectors.getCallNodeInfo(getState());
+
+    const newSelectedStack = filteredThread.samples.stack[sampleIndex];
+    const newSelectedCallNode =
+      newSelectedStack === null
+        ? -1
+        : callNodeInfo.stackIndexToCallNodeIndex[newSelectedStack];
+    dispatch(
+      changeSelectedCallNode(
+        threadIndex,
+        getCallNodePathFromIndex(
+          newSelectedCallNode,
+          callNodeInfo.callNodeTable
+        )
+      )
+    );
+  };
+}
+
+/**
+ * This function provides a different strategy for selecting call nodes. It selects
+ * a "best" ancestor call node, but also expands out its children nodes to the
+ * actual call node that was clicked. See findBestAncestorCallNode for more
+ * on the "best" call node.
+ */
+export function selectBestAncestorCallNodeAndExpandCallTree(
+  threadIndex: ThreadIndex,
+  sampleIndex: IndexIntoSamplesTable
+): ThunkAction<boolean> {
+  return (dispatch, getState) => {
+    const threadSelectors = selectorsForThread(threadIndex);
+    const fullThread = threadSelectors.getRangeFilteredThread(getState());
+    const filteredThread = threadSelectors.getFilteredThread(getState());
+    const unfilteredStack = fullThread.samples.stack[sampleIndex];
+    const callNodeInfo = threadSelectors.getCallNodeInfo(getState());
+
+    if (unfilteredStack === null) {
+      return false;
+    }
+
+    const { callNodeTable, stackIndexToCallNodeIndex } = callNodeInfo;
+    const sampleCallNodes = getSampleCallNodes(
+      filteredThread.samples,
+      stackIndexToCallNodeIndex
+    );
+    const clickedCallNode = sampleCallNodes[sampleIndex];
+    const clickedCategory = fullThread.stackTable.category[unfilteredStack];
+
+    if (clickedCallNode === null) {
+      return false;
+    }
+
+    const sampleCategories = getSampleCategories(
+      fullThread.samples,
+      fullThread.stackTable
+    );
+    const bestAncestorCallNode = findBestAncestorCallNode(
+      callNodeInfo,
+      sampleCallNodes,
+      sampleCategories,
+      clickedCallNode,
+      clickedCategory
+    );
+
+    // In one dispatch, change the selected call node to the best ancestor call node, but
+    // also expand out to the clicked call node.
+    dispatch(
+      changeSelectedCallNode(
+        threadIndex,
+        // Select the best ancestor call node.
+        getCallNodePathFromIndex(bestAncestorCallNode, callNodeTable),
+        // Also expand the children nodes out further below it to what was actually
+        // clicked.
+        getCallNodePathFromIndex(clickedCallNode, callNodeTable)
+      )
+    );
+    return true;
   };
 }
 

--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -51,6 +51,7 @@ type BaseQuery = {|
   file?: string, // Path into a zip file.
   react_perf?: null, // Flag to activate react's UserTimings profiler.
   transforms?: string,
+  timelineType?: string,
   // The following values are legacy, and will be converted to track-based values. These
   // value can't be upgraded using the typical URL upgrading process, as the full profile
   // must be fetched to compute the tracks.
@@ -133,6 +134,12 @@ export function urlStateToUrlObject(urlState: UrlState): UrlObject {
     // Only add to the query string if something was actually hidden.
     // Also, slice off the last '~'.
     query.hiddenLocalTracksByPid = hiddenLocalTracksByPid.slice(0, -1);
+  }
+
+  if (urlState.profileSpecific.timelineType === 'stack') {
+    // The default is the category view, so only add it to the URL if it's the
+    // stack view.
+    query.timelineType = 'stack';
   }
 
   query.localTrackOrderByPid = '';
@@ -286,6 +293,7 @@ export function stateFromLocation(location: Location): UrlState {
         : new Map(),
       markersSearchString: query.markerSearch || '',
       transforms,
+      timelineType: query.timelineType === 'stack' ? 'stack' : 'category',
       legacyThreadOrder: query.threadOrder
         ? query.threadOrder.split('-').map(index => Number(index))
         : null,

--- a/src/components/calltree/ProfileCallTreeView.js
+++ b/src/components/calltree/ProfileCallTreeView.js
@@ -10,11 +10,18 @@ import StackSettings from '../shared/StackSettings';
 import TransformNavigator from '../shared/TransformNavigator';
 import SelectedThreadActivityGraph from '../shared/thread/SelectedActivityGraph';
 
-const ProfileCallTreeView = () => (
+type Props = {|
+  // Allow tests to not render the thread activity graph.
+  +hideThreadActivityGraph?: boolean,
+|};
+
+const ProfileCallTreeView = (props: Props) => (
   <div className="treeAndSidebarWrapper">
     <StackSettings />
     <TransformNavigator />
-    <SelectedThreadActivityGraph />
+    {props && props.hideThreadActivityGraph ? null : (
+      <SelectedThreadActivityGraph />
+    )}
     <CallTree />
   </div>
 );

--- a/src/components/calltree/ProfileCallTreeView.js
+++ b/src/components/calltree/ProfileCallTreeView.js
@@ -8,11 +8,13 @@ import React from 'react';
 import CallTree from './CallTree';
 import StackSettings from '../shared/StackSettings';
 import TransformNavigator from '../shared/TransformNavigator';
+import SelectedThreadActivityGraph from '../shared/thread/SelectedActivityGraph';
 
 const ProfileCallTreeView = () => (
   <div className="treeAndSidebarWrapper">
     <StackSettings />
     <TransformNavigator />
+    <SelectedThreadActivityGraph />
     <CallTree />
   </div>
 );

--- a/src/components/shared/thread/ActivityGraph.css
+++ b/src/components/shared/thread/ActivityGraph.css
@@ -2,12 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-.timelineStackGraph {
-  height: 25px;
+.threadActivityGraph {
+  height: 20px;
 }
 
-.timelineStackGraphCanvas {
+.threadActivityGraphCanvas {
   display: block;
-  height: 25px;
+  height: 100%;
   width: 100%;
+}
+
+.chartViewport.selectedThreadActivityGraphViewport {
+  flex: auto 0 0;
+}
+
+.selectedThreadActivityGraph {
+  height: 30px;
+  -moz-user-focus: ignore;
 }

--- a/src/components/shared/thread/ActivityGraph.css
+++ b/src/components/shared/thread/ActivityGraph.css
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 .threadActivityGraph {
-  height: 20px;
+  height: 25px;
 }
 
 .threadActivityGraphCanvas {

--- a/src/components/shared/thread/ActivityGraph.js
+++ b/src/components/shared/thread/ActivityGraph.js
@@ -1,0 +1,322 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+
+import React, { PureComponent } from 'react';
+import { ActivityGraphFills } from './ActivityGraphFills';
+import { timeCode } from '../../../utils/time-code';
+import classNames from 'classnames';
+import photonColors from 'photon-colors';
+
+import './ActivityGraph.css';
+
+import type {
+  Thread,
+  CategoryList,
+  IndexIntoSamplesTable,
+} from '../../../types/profile';
+import type { Milliseconds } from '../../../types/units';
+import type { CategoryDrawStyle } from './ActivityGraphFills';
+
+// Export these for the ActivityGraphFills.
+export type ActivityGraphProps = {|
+  +className: string,
+  +fullThread: Thread,
+  +interval: Milliseconds,
+  +rangeStart: Milliseconds,
+  +rangeEnd: Milliseconds,
+  +onSampleClick: (sampleIndex: IndexIntoSamplesTable) => void,
+  +categories: CategoryList,
+  +samplesSelectedStates?: boolean[],
+  +treeOrderSampleComparator?: (
+    IndexIntoSamplesTable,
+    IndexIntoSamplesTable
+  ) => number,
+|};
+
+class ThreadActivityGraph extends PureComponent<ActivityGraphProps> {
+  _canvas: null | HTMLCanvasElement = null;
+  _resizeListener = () => this.forceUpdate();
+  _categoryDrawStyles: null | CategoryDrawStyle[] = null;
+  _activityGraphFills: null | ActivityGraphFills = null;
+
+  _takeCanvasRef = (canvas: HTMLCanvasElement | null) => {
+    this._canvas = canvas;
+  };
+
+  _renderCanvas() {
+    const canvas = this._canvas;
+    if (canvas !== null) {
+      timeCode('ThreadActivityGraph render', () => {
+        this.drawCanvas(canvas);
+      });
+    }
+  }
+
+  componentDidMount() {
+    window.addEventListener('resize', this._resizeListener);
+    this.forceUpdate(); // for initial size
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this._resizeListener);
+  }
+
+  /**
+   * Get or lazily create the category info. It requires the 2d ctx to exist in order
+   * to create the fill patterns.
+   */
+  _getCategoryDrawStyles(ctx: CanvasRenderingContext2D): CategoryDrawStyle[] {
+    if (this._categoryDrawStyles === null) {
+      // Lazily initialize this list.
+      this._categoryDrawStyles = this.props.categories.map(
+        ({ color: colorName }, categoryIndex) => {
+          const styles = _mapColorNameToStyles(colorName);
+          return {
+            ...styles,
+            category: categoryIndex,
+            filteredOutFillStyle: _createDiagonalStripePattern(
+              ctx,
+              styles.unselectedFillStyle
+            ),
+          };
+        }
+      );
+    }
+
+    return this._categoryDrawStyles;
+  }
+
+  drawCanvas(canvas: HTMLCanvasElement) {
+    const { fullThread } = this.props;
+    const { samples } = fullThread;
+
+    if (samples.length === 0) {
+      // Do not attempt to render when there are no samples.
+      return;
+    }
+    const rect = canvas.getBoundingClientRect();
+    const ctx = canvas.getContext('2d');
+    const canvasPixelWidth = Math.round(rect.width * window.devicePixelRatio);
+    const canvasPixelHeight = Math.round(rect.height * window.devicePixelRatio);
+    canvas.width = canvasPixelWidth;
+    canvas.height = canvasPixelHeight;
+
+    this._activityGraphFills = new ActivityGraphFills(
+      canvasPixelWidth,
+      canvasPixelHeight,
+      this.props,
+      this._getCategoryDrawStyles(ctx)
+    );
+
+    const fillResult = this._activityGraphFills.computeFills();
+    let { lastCumulativeArray } = fillResult;
+    const { categoryFills } = fillResult;
+
+    // Draw adjacent filled paths using Operator ADD and disjoint paths.
+    // This avoids any bleeding and seams.
+    // lighter === OP_ADD
+    ctx.globalCompositeOperation = 'lighter';
+    lastCumulativeArray = new Float32Array(canvasPixelWidth);
+    for (const { fillStyle, perPixelContribution } of categoryFills) {
+      const cumulativeArray = perPixelContribution;
+      ctx.fillStyle = fillStyle;
+      let lastNonZeroRangeEnd = 0;
+      while (lastNonZeroRangeEnd < canvasPixelWidth) {
+        const currentNonZeroRangeStart = _findNextDifferentIndex(
+          cumulativeArray,
+          lastCumulativeArray,
+          lastNonZeroRangeEnd
+        );
+        if (currentNonZeroRangeStart >= canvasPixelWidth) {
+          break;
+        }
+        let currentNonZeroRangeEnd = canvasPixelWidth;
+        ctx.beginPath();
+        ctx.moveTo(
+          currentNonZeroRangeStart,
+          (1 - lastCumulativeArray[currentNonZeroRangeStart]) *
+            canvasPixelHeight
+        );
+        for (let i = currentNonZeroRangeStart + 1; i < canvasPixelWidth; i++) {
+          const lastVal = lastCumulativeArray[i];
+          const thisVal = cumulativeArray[i];
+          ctx.lineTo(i, (1 - lastVal) * canvasPixelHeight);
+          if (lastVal === thisVal) {
+            currentNonZeroRangeEnd = i;
+            break;
+          }
+        }
+        for (
+          let i = currentNonZeroRangeEnd - 1;
+          i >= currentNonZeroRangeStart;
+          i--
+        ) {
+          ctx.lineTo(i, (1 - cumulativeArray[i]) * canvasPixelHeight);
+        }
+        ctx.closePath();
+        ctx.fill();
+
+        lastNonZeroRangeEnd = currentNonZeroRangeEnd;
+      }
+      lastCumulativeArray = cumulativeArray;
+    }
+  }
+
+  _onMouseUp = (e: SyntheticMouseEvent<>) => {
+    const activityGraphFills = this._activityGraphFills;
+    const canvas = this._canvas;
+    if (!canvas || !activityGraphFills) {
+      return;
+    }
+    // Re-measure the canvas and get the coordinates and time for the click.
+    const { rangeStart, rangeEnd } = this.props;
+    const rect = canvas.getBoundingClientRect();
+    const x = e.pageX - rect.left;
+    const y = e.pageY - rect.top;
+    const time = rangeStart + x / rect.width * (rangeEnd - rangeStart);
+
+    const sample = activityGraphFills.getSampleAtClick(x, y, time);
+    if (sample !== null) {
+      this.props.onSampleClick(sample);
+    }
+  };
+
+  render() {
+    this._renderCanvas();
+    return (
+      <div className={this.props.className}>
+        <canvas
+          className={classNames(
+            `${this.props.className}Canvas`,
+            'threadActivityGraphCanvas'
+          )}
+          ref={this._takeCanvasRef}
+          onMouseUp={this._onMouseUp}
+        />
+      </div>
+    );
+  }
+}
+
+export default ThreadActivityGraph;
+
+/**
+ * Filtered out samples use a diagonal stripe pattern, create that here.
+ */
+function _createDiagonalStripePattern(
+  chartCtx: CanvasRenderingContext2D,
+  color: string
+): CanvasPattern {
+  // Create a second canvas, draw to it in order to create a pattern. This canvas
+  // and context will be discarded after the pattern is created.
+  const patternCanvas = document.createElement('canvas');
+  const dpr = Math.round(window.devicePixelRatio);
+  patternCanvas.width = 4 * dpr;
+  patternCanvas.height = 4 * dpr;
+  const patternContext = patternCanvas.getContext('2d');
+  patternContext.scale(dpr, dpr);
+
+  const linear = patternContext.createLinearGradient(0, 0, 4, 4);
+  linear.addColorStop(0, color);
+  linear.addColorStop(0.25, color);
+  linear.addColorStop(0.25, 'transparent');
+  linear.addColorStop(0.5, 'transparent');
+  linear.addColorStop(0.5, color);
+  linear.addColorStop(0.75, color);
+  linear.addColorStop(0.75, 'transparent');
+  linear.addColorStop(1, 'transparent');
+  patternContext.fillStyle = linear;
+  patternContext.fillRect(0, 0, 4, 4);
+
+  return chartCtx.createPattern(patternCanvas, 'repeat');
+}
+
+/**
+ * Map a color name, which comes from Gecko, into a CSS style color. These colors cannot
+ * be changed without considering the values coming from Gecko, and from old profiles
+ * that already have their category colors saved into the profile.
+ *
+ * Category color names come from:
+ * https://searchfox.org/mozilla-central/rev/0b8ed772d24605d7cb44c1af6d59e4ca023bd5f5/tools/profiler/core/platform.cpp#1593-1627
+ */
+function _mapColorNameToStyles(colorName: string) {
+  switch (colorName) {
+    case 'transparent':
+      return {
+        selectedFillStyle: 'transparent',
+        unselectedFillStyle: 'transparent',
+        gravity: 0,
+      };
+    case 'purple':
+      return {
+        selectedFillStyle: photonColors.PURPLE_70,
+        unselectedFillStyle: photonColors.PURPLE_70 + '60',
+        gravity: 5,
+      };
+    case 'green':
+      return {
+        selectedFillStyle: photonColors.GREEN_60,
+        unselectedFillStyle: photonColors.GREEN_60 + '60',
+        gravity: 4,
+      };
+    case 'orange':
+      return {
+        selectedFillStyle: photonColors.ORANGE_50,
+        unselectedFillStyle: photonColors.ORANGE_50 + '60',
+        gravity: 2,
+      };
+    case 'yellow':
+      return {
+        selectedFillStyle: photonColors.YELLOW_50,
+        unselectedFillStyle: photonColors.YELLOW_50 + '60',
+        gravity: 6,
+      };
+    case 'lightblue':
+      return {
+        selectedFillStyle: photonColors.BLUE_40,
+        unselectedFillStyle: photonColors.BLUE_40 + '60',
+        gravity: 1,
+      };
+    case 'grey':
+      return {
+        selectedFillStyle: photonColors.GREY_30,
+        unselectedFillStyle: photonColors.GREY_30 + '60',
+        gravity: 8,
+      };
+    case 'blue':
+      return {
+        selectedFillStyle: photonColors.BLUE_60,
+        unselectedFillStyle: photonColors.BLUE_60 + '60',
+        gravity: 3,
+      };
+    case 'brown':
+      return {
+        selectedFillStyle: photonColors.MAGENTA_60,
+        unselectedFillStyle: photonColors.MAGENTA_60 + '60',
+        gravity: 7,
+      };
+    default:
+      console.error(
+        'Unknown color name encountered. Consider updating this code to handle it.'
+      );
+      return {
+        selectedFillStyle: photonColors.GREY_30,
+        unselectedFillStyle: photonColors.GREY_30 + '60',
+        gravity: 8,
+      };
+  }
+}
+
+/**
+ * Search an array from a starting index to find where two arrays are not sharing.
+ */
+function _findNextDifferentIndex(arr1, arr2, startIndex) {
+  for (let i = startIndex; i < arr1.length; i++) {
+    if (arr1[i] !== arr2[i]) {
+      return i;
+    }
+  }
+  return arr1.length;
+}

--- a/src/components/shared/thread/ActivityGraphFills.js
+++ b/src/components/shared/thread/ActivityGraphFills.js
@@ -96,6 +96,7 @@ export class ActivityGraphFills {
       categories,
       interval,
       samplesSelectedStates,
+      treeOrderSampleComparator,
       fullThread: { samples, stackTable },
     }: ActivityGraphProps,
     categoryDrawStyles: CategoryDrawStyle[]
@@ -114,6 +115,7 @@ export class ActivityGraphFills {
     this.samplesSelectedStates = samplesSelectedStates;
     this.greyCategoryIndex = categories.findIndex(c => c.color === 'grey') || 0;
     this.devicePixelRatio = window.devicePixelRatio;
+    this.treeOrderSampleComparator = treeOrderSampleComparator;
     this.percentageBuffers = _createSelectedPercentageAtPixelBuffers(
       categoryDrawStyles,
       this.canvasPixelWidth
@@ -448,10 +450,7 @@ export class ActivityGraphFills {
   /**
    * Compute a list of the fills that need to be drawn for the ThreadActivityGraph.
    */
-  computeFills(): {
-    categoryFills: CategoryFill[],
-    lastCumulativeArray: Float32Array,
-  } {
+  computeFills(): CategoryFill[] {
     const { categoryFills, canvasPixelWidth } = this;
 
     // First go through each sample, and set the buffers that contain the percentage
@@ -473,7 +472,7 @@ export class ActivityGraphFills {
       lastCumulativeArray = perPixelContribution;
     }
 
-    return { categoryFills, lastCumulativeArray };
+    return categoryFills;
   }
 
   /**

--- a/src/components/shared/thread/ActivityGraphFills.js
+++ b/src/components/shared/thread/ActivityGraphFills.js
@@ -1,0 +1,653 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+
+import bisection from 'bisection';
+import clamp from 'clamp';
+
+import './ActivityGraph.css';
+
+import type {
+  IndexIntoSamplesTable,
+  IndexIntoCategoryList,
+  SamplesTable,
+  StackTable,
+} from '../../../types/profile';
+import type {
+  Milliseconds,
+  DevicePixels,
+  CssPixels,
+} from '../../../types/units';
+import type { ActivityGraphProps } from './ActivityGraph';
+
+type SampleContributionToPixel = {|
+  sample: IndexIntoSamplesTable,
+  contribution: number,
+|};
+
+type CategoryFill = {|
+  category: IndexIntoCategoryList,
+  perPixelContribution: Float32Array,
+  fillStyle: string | CanvasPattern,
+|};
+
+export type CategoryDrawStyle = {|
+  +category: number,
+  +gravity: number,
+  +selectedFillStyle: string,
+  +unselectedFillStyle: string,
+  +filteredOutFillStyle: CanvasPattern,
+|};
+
+type SelectedPercentageAtPixelBuffers = {|
+  // The following arrays get recreated when the canvas gets resized.
+  +beforeSelectedPercentageAtPixel: Float32Array,
+  +selectedPercentageAtPixel: Float32Array,
+  +afterSelectedPercentageAtPixel: Float32Array,
+  +filteredOutPercentageAtPixel: Float32Array,
+|};
+
+const BOX_BLUR_RADII = [3, 2, 2];
+const SMOOTHING_RADIUS = 3 + 2 + 2;
+const SMOOTHING_KERNEL: Float32Array = _getSmoothingKernel(
+  SMOOTHING_RADIUS,
+  BOX_BLUR_RADII
+);
+
+/**
+ * A lot of logic and mutation goes into computing the fills in the ThreadActivityGraph.
+ * This class breaks out the fill computations separately from the component logic. This
+ * makes it easier to to have lots of shared mutable state between the various
+ * calculations.
+ *
+ * Note that this class should be recreated for every new computation of the fills.
+ * It computes the category percentages inside a set of Float32Array buffers. These
+ * should be discarded after use. This class has lots of mutation, so there shouldn't
+ * be any assumptions made about the validity of strict equalities.
+ */
+export class ActivityGraphFills {
+  rangeStart: Milliseconds;
+  rangeEnd: Milliseconds;
+  rangeLength: Milliseconds;
+  canvasPixelWidth: DevicePixels;
+  canvasPixelHeight: DevicePixels;
+  devicePixelRatio: number;
+  xPixelsPerMs: number;
+  categoryDrawStyles: CategoryDrawStyle[];
+  percentageBuffers: SelectedPercentageAtPixelBuffers[];
+  samples: SamplesTable;
+  stackTable: StackTable;
+  interval: Milliseconds;
+  greyCategoryIndex: IndexIntoCategoryList;
+  samplesSelectedStates: ?Array<boolean>;
+  categoryFills: CategoryFill[];
+  treeOrderSampleComparator: ?(
+    IndexIntoSamplesTable,
+    IndexIntoSamplesTable
+  ) => number;
+
+  constructor(
+    canvasPixelWidth: DevicePixels,
+    canvasPixelHeight: DevicePixels,
+    {
+      rangeEnd,
+      rangeStart,
+      categories,
+      interval,
+      samplesSelectedStates,
+      fullThread: { samples, stackTable },
+    }: ActivityGraphProps,
+    categoryDrawStyles: CategoryDrawStyle[]
+  ) {
+    // Collect the common variables used on the various methods.
+    this.canvasPixelWidth = canvasPixelWidth;
+    this.canvasPixelHeight = canvasPixelHeight;
+    this.rangeEnd = rangeEnd;
+    this.rangeStart = rangeStart;
+    this.rangeLength = rangeEnd - rangeStart;
+    this.categoryDrawStyles = categoryDrawStyles;
+    this.interval = interval;
+    this.xPixelsPerMs = this.canvasPixelWidth / this.rangeLength;
+    this.samples = samples;
+    this.stackTable = stackTable;
+    this.samplesSelectedStates = samplesSelectedStates;
+    this.greyCategoryIndex = categories.findIndex(c => c.color === 'grey') || 0;
+    this.devicePixelRatio = window.devicePixelRatio;
+    this.percentageBuffers = _createSelectedPercentageAtPixelBuffers(
+      categoryDrawStyles,
+      this.canvasPixelWidth
+    );
+    this.categoryFills = _getCategoryFills(
+      categoryDrawStyles,
+      this.percentageBuffers
+    );
+  }
+
+  /**
+   * Go through each sample, and apply its category percentages to the category
+   * percentage buffers. These percentage buffers determine the overall percentage
+   * that a category contributes to a single pixel. These buffers are mutated in place
+   * with these methods.
+   */
+  accumulateSampleCategories() {
+    const { samples, interval, stackTable, greyCategoryIndex } = this;
+
+    let prevSampleTime = samples.time[0] - interval;
+    let sampleTime = samples.time[0];
+
+    // Go through the samples and accumulate the category into the percentageBuffers.
+    for (let i = 0; i < samples.length - 1; i++) {
+      const nextSampleTime = samples.time[i + 1];
+      const stackIndex = samples.stack[i];
+      const category =
+        stackIndex === null
+          ? greyCategoryIndex
+          : stackTable.category[stackIndex];
+
+      // Mutate the percentage buffers.
+      this._accumulateInCategory(
+        category,
+        i,
+        prevSampleTime,
+        sampleTime,
+        nextSampleTime
+      );
+
+      prevSampleTime = sampleTime;
+      sampleTime = nextSampleTime;
+    }
+
+    // Handle the last sample, which was not covered by the for loop above.
+    const lastSampleStack = samples.stack[samples.length - 1];
+    const lastSampleCategory =
+      lastSampleStack !== null
+        ? stackTable.category[lastSampleStack]
+        : greyCategoryIndex;
+
+    this._accumulateInCategory(
+      lastSampleCategory,
+      samples.length - 1,
+      prevSampleTime,
+      sampleTime,
+      sampleTime + interval
+    );
+  }
+
+  /**
+   * Mutate the percentage buffers, by taking this category, and accumulating its
+   * percentage into the buffer.
+   */
+  _accumulateInCategory(
+    category: IndexIntoCategoryList,
+    sampleIndex: IndexIntoSamplesTable,
+    prevSampleTime: Milliseconds,
+    sampleTime: Milliseconds,
+    nextSampleTime: Milliseconds
+  ) {
+    const {
+      rangeEnd,
+      rangeStart,
+      categoryDrawStyles,
+      xPixelsPerMs,
+      canvasPixelWidth,
+    } = this;
+    if (sampleTime < rangeStart || sampleTime >= rangeEnd) {
+      return;
+    }
+
+    const categoryDrawStyle = categoryDrawStyles[category];
+    const percentageBuffers = this.percentageBuffers[category];
+
+    if (categoryDrawStyle.selectedFillStyle === 'transparent') {
+      return;
+    }
+
+    const sampleStart = (prevSampleTime + sampleTime) / 2;
+    const sampleEnd = (sampleTime + nextSampleTime) / 2;
+    let pixelStart = (sampleStart - rangeStart) * xPixelsPerMs;
+    let pixelEnd = (sampleEnd - rangeStart) * xPixelsPerMs;
+    pixelStart = Math.max(0, pixelStart);
+    pixelEnd = Math.min(canvasPixelWidth - 1, pixelEnd);
+    const intPixelStart = Math.floor(pixelStart);
+    const intPixelEnd = Math.floor(pixelEnd);
+
+    // For every sample, we have a fractional interval of this sample's
+    // contribution to the graph's pixels.
+    //
+    // v       v       v       v       v       v       v       v       v
+    // +-------+-------+-----+-+-------+-------+-----+-+-------+-------+
+    // |       |       |     |///////////////////////| |       |       |
+    // |       |       |     |///////////////////////| |       |       |
+    // |       |       |     |///////////////////////| |       |       |
+    // +-------+-------+-----+///////////////////////+-+-------+-------+
+    //
+    // We have a device-pixel array of contributions. We map the fractional
+    // interval to this array of device pixels: Fully overlapping pixels are
+    // 1, and the partial overlapping pixels are the degree of overlap.
+
+    //                                 |
+    //                                 v
+    //
+    // +-------+-------+-------+-------+-------+-------+-------+-------+
+    // |       |       |       |///////////////+-------+       |       |
+    // |       |       |       |///////////////////////|       |       |
+    // |       |       +-------+///////////////////////|       |       |
+    // +-------+-------+///////////////////////////////+-------+-------+
+    const percentageBuffer = this._pickPercentageBuffer(
+      percentageBuffers,
+      sampleIndex
+    );
+    for (let i = intPixelStart; i <= intPixelEnd; i++) {
+      percentageBuffer[i] += 1;
+    }
+    percentageBuffer[intPixelStart] -= pixelStart - intPixelStart;
+    percentageBuffer[intPixelEnd] -= 1 - (pixelEnd - intPixelEnd);
+  }
+
+  /**
+   * Pick the correct percentage buffer based on the sample state.
+   */
+  _pickPercentageBuffer(
+    percentageBuffers: SelectedPercentageAtPixelBuffers,
+    sampleIndex: IndexIntoSamplesTable
+  ): Float32Array {
+    const { samplesSelectedStates } = this;
+    if (!samplesSelectedStates) {
+      return percentageBuffers.selectedPercentageAtPixel;
+    }
+    switch (samplesSelectedStates[sampleIndex]) {
+      case 'FILTERED_OUT':
+        return percentageBuffers.filteredOutPercentageAtPixel;
+      case 'UNSELECTED_ORDERED_BEFORE_SELECTED':
+        return percentageBuffers.beforeSelectedPercentageAtPixel;
+      case 'SELECTED':
+        return percentageBuffers.selectedPercentageAtPixel;
+      case 'UNSELECTED_ORDERED_AFTER_SELECTED':
+        return percentageBuffers.afterSelectedPercentageAtPixel;
+      default:
+        throw new Error('Unexpected samplesSelectedStates value');
+    }
+  }
+
+  /**
+   * Find a specific category at a pixel location.
+   */
+  categoryAtPixel(
+    x: number,
+    y: number
+  ): null | {
+    category: IndexIntoCategoryList,
+    offsetToCategoryStart: DevicePixels,
+  } {
+    const deviceX = Math.round(x * this.devicePixelRatio);
+    const deviceY = Math.round(y * this.devicePixelRatio);
+
+    if (
+      !this.categoryFills ||
+      deviceX < 0 ||
+      deviceX >= this.canvasPixelWidth ||
+      deviceY < 0 ||
+      deviceY >= this.canvasPixelHeight
+    ) {
+      return null;
+    }
+
+    const valueToFind = 1 - deviceY / this.canvasPixelHeight;
+    let currentCategory = null;
+    let currentCategoryStart = 0.0;
+    let previousFillEnd = 0.0;
+    for (const { category, perPixelContribution } of this.categoryFills) {
+      const fillEnd = perPixelContribution[deviceX];
+
+      if (category !== currentCategory) {
+        currentCategory = category;
+        currentCategoryStart = previousFillEnd;
+      }
+
+      if (fillEnd >= valueToFind) {
+        return {
+          category,
+          offsetToCategoryStart: valueToFind - currentCategoryStart,
+        };
+      }
+
+      previousFillEnd = fillEnd;
+    }
+
+    return null;
+  }
+
+  /**
+   * Determine which samples contributed to a given categoy at a specific time. The result
+   * is an array of all candidate samples, with their contribution amount.
+   */
+  _getCategoriesSamplesAtTime(
+    time: number,
+    category: IndexIntoCategoryList
+  ): Array<SampleContributionToPixel> {
+    const {
+      rangeStart,
+      rangeEnd,
+      treeOrderSampleComparator,
+      greyCategoryIndex,
+      samples,
+      stackTable,
+      canvasPixelWidth,
+    } = this;
+
+    const rangeLength = rangeEnd - rangeStart;
+    const xPixelsPerMs = canvasPixelWidth / rangeLength;
+    const xPixel = ((time - rangeStart) * xPixelsPerMs) | 0;
+    const [
+      sampleRangeStart,
+      sampleRangeEnd,
+    ] = this._getSampleRangeContributingToPixelWhenSmoothed(xPixel);
+
+    const sampleContributions = [];
+    for (let sample = sampleRangeStart; sample < sampleRangeEnd; sample++) {
+      const stackIndex = samples.stack[sample];
+      const sampleCategory =
+        stackIndex !== null
+          ? stackTable.category[stackIndex]
+          : greyCategoryIndex;
+      if (sampleCategory === category) {
+        sampleContributions.push({
+          sample,
+          contribution: this._getSmoothedContributionFromSampleToPixel(
+            xPixel,
+            xPixelsPerMs,
+            sample
+          ),
+        });
+      }
+    }
+    if (treeOrderSampleComparator) {
+      sampleContributions.sort((a, b) => {
+        const sampleA = a.sample;
+        const sampleB = b.sample;
+        return treeOrderSampleComparator(sampleA, sampleB);
+      });
+    }
+    return sampleContributions;
+  }
+
+  /**
+   * Apply the smoothing to a pixel position to determine the start and end time range
+   * that could affect that pixel.
+   */
+  _getSampleRangeContributingToPixelWhenSmoothed(
+    xPixel: number
+  ): [IndexIntoSamplesTable, IndexIntoSamplesTable] {
+    const { samples, rangeStart, xPixelsPerMs } = this;
+    const contributionTimeRangeStart =
+      rangeStart + (xPixel - SMOOTHING_RADIUS) / xPixelsPerMs;
+    const contributionTimeRangeEnd =
+      rangeStart + (xPixel + SMOOTHING_RADIUS) / xPixelsPerMs;
+
+    // Now find the samples where the range [mid(previousSample.time, thisSample.time), mid(thisSample.time, nextSample.time)]
+    // overlaps with contributionTimeRange.
+    const firstSampleAfterContributionTimeRangeStart = bisection.right(
+      samples.time,
+      contributionTimeRangeStart
+    );
+    const firstSampleAfterContributionTimeRangeEnd = bisection.right(
+      samples.time,
+      contributionTimeRangeEnd
+    );
+    return [
+      Math.max(0, firstSampleAfterContributionTimeRangeStart - 1),
+      Math.min(samples.length - 1, firstSampleAfterContributionTimeRangeEnd) +
+        1,
+    ];
+  }
+
+  /**
+   * Compute how much a sample contributes to a given pixel after smoothing has
+   * been applied.
+   */
+  _getSmoothedContributionFromSampleToPixel(
+    xPixel: number,
+    xPixelsPerMs: number,
+    sample: IndexIntoSamplesTable
+  ): number {
+    const { samples, rangeStart } = this;
+    const kernelPos = xPixel - SMOOTHING_RADIUS;
+    const pixelsAroundX = new Float32Array(SMOOTHING_KERNEL.length);
+    const sampleTime = samples.time[sample];
+    // xPixel in graph space maps to kernel[smoothingRadius]
+    const sampleTimeRangeStart =
+      sample > 0 ? (samples.time[sample - 1] + sampleTime) / 2 : -Infinity;
+    const sampleTimeRangeEnd =
+      sample < samples.length
+        ? (samples.time[sample + 1] + sampleTime) / 2
+        : Infinity;
+
+    let pixelStart =
+      (sampleTimeRangeStart - rangeStart) * xPixelsPerMs - kernelPos;
+    let pixelEnd = (sampleTimeRangeEnd - rangeStart) * xPixelsPerMs - kernelPos;
+    pixelStart = clamp(pixelStart, 0, SMOOTHING_KERNEL.length - 1);
+    pixelEnd = clamp(pixelEnd, 0, SMOOTHING_KERNEL.length - 1);
+    const intPixelStart = pixelStart | 0;
+    const intPixelEnd = pixelEnd | 0;
+
+    for (let i = intPixelStart; i <= intPixelEnd; i++) {
+      pixelsAroundX[i] += 1;
+    }
+    pixelsAroundX[intPixelStart] -= pixelStart - intPixelStart;
+    pixelsAroundX[intPixelEnd] -= 1 - (pixelEnd - intPixelEnd);
+
+    let sum = 0;
+    for (let i = 0; i < SMOOTHING_KERNEL.length; i++) {
+      sum += SMOOTHING_KERNEL[i] * pixelsAroundX[i];
+    }
+
+    return sum;
+  }
+
+  /**
+   * Compute a list of the fills that need to be drawn for the ThreadActivityGraph.
+   */
+  computeFills(): {
+    categoryFills: CategoryFill[],
+    lastCumulativeArray: Float32Array,
+  } {
+    const { categoryFills, canvasPixelWidth } = this;
+
+    // First go through each sample, and set the buffers that contain the percentage
+    // that a category contributes to a given place in the X axis of the chart.
+    this.accumulateSampleCategories();
+
+    // Smooth the graphs by applying a 1D gaussian blur to the per-pixel
+    // contribution of each fill.
+    for (const fill of categoryFills) {
+      _applyGaussianBlur1D(fill.perPixelContribution, BOX_BLUR_RADII);
+    }
+
+    // Finally compute the last cumulative array.
+    let lastCumulativeArray = categoryFills[0].perPixelContribution;
+    for (const { perPixelContribution } of categoryFills.slice(1)) {
+      for (let i = 0; i < canvasPixelWidth; i++) {
+        perPixelContribution[i] += lastCumulativeArray[i];
+      }
+      lastCumulativeArray = perPixelContribution;
+    }
+
+    return { categoryFills, lastCumulativeArray };
+  }
+
+  /**
+   * Given a click in CssPixels coordinates, look up the sample in the graph.
+   */
+  getSampleAtClick(
+    x: CssPixels,
+    y: CssPixels,
+    time: Milliseconds
+  ): IndexIntoSamplesTable | null {
+    const categoryUnderMouse = this.categoryAtPixel(x, y);
+    if (categoryUnderMouse === null) {
+      return null;
+    }
+
+    let { offsetToCategoryStart } = categoryUnderMouse;
+    const candidateSamples = this._getCategoriesSamplesAtTime(
+      time,
+      categoryUnderMouse.category
+    );
+
+    for (let i = 0; i < candidateSamples.length; i++) {
+      const { sample, contribution } = candidateSamples[i];
+      if (offsetToCategoryStart <= contribution) {
+        return sample;
+      }
+      offsetToCategoryStart -= contribution;
+    }
+
+    return null;
+  }
+}
+
+/**
+ * Get a smoothing kernel. This is a list of values ranged from 0 to 1 that are
+ * smoothed by a gaussian blur.
+ */
+function _getSmoothingKernel(
+  smoothingRadius: number,
+  boxBlurRadii: number[]
+): Float32Array {
+  const kernelWidth = smoothingRadius + 1 + smoothingRadius;
+  const kernel = new Float32Array(kernelWidth);
+  kernel[smoothingRadius] = 1;
+  _applyGaussianBlur1D(kernel, boxBlurRadii);
+  return kernel;
+}
+
+/**
+ * Create the buffers that hold the percentage of a category at a given device pixel.
+ * These buffers can only be used once per fill computation. The buffer values are
+ * updated across various method calls.
+ */
+function _createSelectedPercentageAtPixelBuffers(
+  categoryDrawStyles: CategoryDrawStyle[],
+  canvasPixelWidth: DevicePixels
+): SelectedPercentageAtPixelBuffers[] {
+  return categoryDrawStyles.map(() => ({
+    beforeSelectedPercentageAtPixel: new Float32Array(canvasPixelWidth),
+    selectedPercentageAtPixel: new Float32Array(canvasPixelWidth),
+    afterSelectedPercentageAtPixel: new Float32Array(canvasPixelWidth),
+    filteredOutPercentageAtPixel: new Float32Array(canvasPixelWidth),
+  }));
+}
+
+/**
+ * For each category, create a fill style for each of 4 draw states. These fill styles
+ * are sorted by their gravity.
+ *
+ * 'UNSELECTED_ORDERED_BEFORE_SELECTED',
+ * 'SELECTED',
+ * 'UNSELECTED_ORDERED_AFTER_SELECTED',
+ * 'FILTERED_OUT'
+ */
+function _getCategoryFills(
+  categoryDrawStyles: CategoryDrawStyle[],
+  percentageBuffers: SelectedPercentageAtPixelBuffers[]
+): CategoryFill[] {
+  // Sort all of the categories by their gravity.
+  const categoryIndexesByGravity = categoryDrawStyles
+    .map((_, i) => i)
+    .sort(
+      (a, b) => categoryDrawStyles[b].gravity - categoryDrawStyles[a].gravity
+    );
+
+  const nestedFills: CategoryFill[][] = categoryIndexesByGravity.map(
+    categoryIndex => {
+      const categoryDrawStyle = categoryDrawStyles[categoryIndex];
+      const buffer = percentageBuffers[categoryIndex];
+      // For every category we draw four fills, for the four selection kinds:
+      return [
+        {
+          category: categoryDrawStyle.category,
+          fillStyle: categoryDrawStyle.unselectedFillStyle,
+          perPixelContribution: buffer.beforeSelectedPercentageAtPixel,
+        },
+        {
+          category: categoryDrawStyle.category,
+          fillStyle: categoryDrawStyle.selectedFillStyle,
+          perPixelContribution: buffer.selectedPercentageAtPixel,
+        },
+        {
+          category: categoryDrawStyle.category,
+          fillStyle: categoryDrawStyle.unselectedFillStyle,
+          perPixelContribution: buffer.afterSelectedPercentageAtPixel,
+        },
+        {
+          category: categoryDrawStyle.category,
+          fillStyle: categoryDrawStyle.filteredOutFillStyle,
+          perPixelContribution: buffer.filteredOutPercentageAtPixel,
+        },
+      ];
+    }
+  );
+
+  // Flatten out the fills into a single array.
+  return [].concat(...nestedFills);
+}
+
+/**
+ * Apply a 1d box blur to a destination array.
+ */
+function _boxBlur1D(
+  srcArray: Float32Array,
+  destArray: Float32Array,
+  radius: number
+): void {
+  if (srcArray.length < radius) {
+    destArray.set(srcArray);
+    return;
+  }
+
+  // We treat values outside the range as zero.
+  let total = 0;
+  for (let kx = 0; kx <= radius; ++kx) {
+    total += srcArray[kx];
+  }
+  destArray[0] = total / (radius * 2 + 1);
+
+  for (let x = 1; x < radius + 1; ++x) {
+    total += srcArray[x + radius];
+    destArray[x] = total / (radius * 2 + 1);
+  }
+  for (let x = radius + 1; x < srcArray.length - radius; ++x) {
+    total -= srcArray[x - radius - 1];
+    total += srcArray[x + radius];
+    destArray[x] = total / (radius * 2 + 1);
+  }
+  for (let x = srcArray.length - radius; x < srcArray.length; ++x) {
+    total -= srcArray[x - radius - 1];
+    destArray[x] = total / (radius * 2 + 1);
+  }
+}
+
+/**
+ * Apply a blur with a gaussian distribution to a destination array.
+ */
+function _applyGaussianBlur1D(
+  srcArray: Float32Array,
+  boxBlurRadii: number[]
+): void {
+  let a = srcArray;
+  let b = new Float32Array(srcArray.length);
+  for (const radius of boxBlurRadii) {
+    _boxBlur1D(a, b, radius);
+    [b, a] = [a, b];
+  }
+
+  if (b === srcArray) {
+    // The last blur was applied to the temporary array, blit the final values back
+    // to the srcArray. This ensures that we are always mutating the values of the
+    // src array, and not returning the newly created array.
+    for (let i = 0; i < srcArray.length; i++) {
+      srcArray[i] = a[i];
+    }
+  }
+}

--- a/src/components/shared/thread/SelectedActivityGraph.js
+++ b/src/components/shared/thread/SelectedActivityGraph.js
@@ -85,13 +85,11 @@ class SelectedThreadActivityGraphCanvas extends PureComponent<Props> {
       selectBestAncestorCallNodeAndExpandCallTree,
       focusCallTree,
     } = this.props;
-    const isBestCallNodeFound = selectBestAncestorCallNodeAndExpandCallTree(
+    selectBestAncestorCallNodeAndExpandCallTree(
       selectedThreadIndex,
       sampleIndex
     );
-    if (isBestCallNodeFound) {
-      focusCallTree();
-    }
+    focusCallTree();
   };
 
   _onStackSampleClick = (sampleIndex: IndexIntoSamplesTable) => {

--- a/src/components/shared/thread/SelectedActivityGraph.js
+++ b/src/components/shared/thread/SelectedActivityGraph.js
@@ -44,8 +44,14 @@ import type {
   ExplicitConnectOptions,
   ConnectedProps,
 } from '../../../utils/connect';
+import type { Viewport } from '../chart/Viewport';
 
-type OwnProps = {||};
+type OwnProps = {|
+  // The viewport property is injected by the withViewport component, but is not
+  // actually used or needed in this case. However, withViewport has side effects
+  // of enabling event listeners for adjusting the view.
+  +viewport: Viewport,
+|};
 
 type StateProps = {|
   +selectedThreadIndex: ThreadIndex,
@@ -148,12 +154,7 @@ function getSampleCategories(
 }
 
 class SelectedThreadActivityGraphCanvas extends PureComponent<Props> {
-  constructor(props) {
-    super(props);
-    (this: any)._onSampleClick = this._onSampleClick.bind(this);
-  }
-
-  _onSampleClick(sampleIndex: IndexIntoSamplesTable) {
+  _onSampleClick = (sampleIndex: IndexIntoSamplesTable) => {
     const {
       fullThread,
       filteredThread,
@@ -201,7 +202,7 @@ class SelectedThreadActivityGraphCanvas extends PureComponent<Props> {
       getCallNodePathFromIndex(chosenCallNode, callNodeTable)
     );
     focusCallTree();
-  }
+  };
   render() {
     const {
       fullThread,

--- a/src/components/shared/thread/SelectedActivityGraph.js
+++ b/src/components/shared/thread/SelectedActivityGraph.js
@@ -1,0 +1,352 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import React, { PureComponent } from 'react';
+import explicitConnect from '../../../utils/connect';
+import ThreadActivityGraph from './ActivityGraph';
+import ThreadStackGraph from './StackGraph';
+import { withChartViewport } from '../chart/Viewport';
+import {
+  selectedThreadSelectors,
+  getPreviewSelection,
+  getProfile,
+  getCommittedRange,
+} from '../../../reducers/profile-view';
+import { getSelectedThreadIndex } from '../../../reducers/url-state';
+import {
+  getCallNodePathFromIndex,
+  getSampleCallNodes,
+} from '../../../profile-logic/profile-data';
+import {
+  changeSelectedCallNode,
+  focusCallTree,
+} from '../../../actions/profile-view';
+
+import type {
+  Thread,
+  ThreadIndex,
+  CategoryList,
+  StackTable,
+  SamplesTable,
+  IndexIntoSamplesTable,
+  IndexIntoCategoryList,
+} from '../../../types/profile';
+import type { Milliseconds } from '../../../types/units';
+import type {
+  CallNodeInfo,
+  IndexIntoCallNodeTable,
+} from '../../../types/profile-derived';
+import type { State } from '../../../types/reducers';
+import type {
+  ExplicitConnectOptions,
+  ConnectedProps,
+} from '../../../utils/connect';
+
+type OwnProps = {||};
+
+type StateProps = {|
+  +selectedThreadIndex: ThreadIndex,
+  +interval: Milliseconds,
+  +rangeStart: Milliseconds,
+  +rangeEnd: Milliseconds,
+  +fullThread: Thread,
+  +filteredThread: Thread,
+  +callNodeInfo: CallNodeInfo,
+  +selectedCallNodeIndex: IndexIntoCallNodeTable | null,
+  +categories: CategoryList,
+  +samplesSelectedStates: boolean[],
+  +treeOrderSampleComparator: (
+    IndexIntoSamplesTable,
+    IndexIntoSamplesTable
+  ) => number,
+|};
+
+type DispatchProps = {|
+  +changeSelectedCallNode: typeof changeSelectedCallNode,
+  +focusCallTree: typeof focusCallTree,
+|};
+
+type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
+
+function findBestCallNode(
+  callNodeInfo: CallNodeInfo,
+  sampleCallNodes: Array<IndexIntoCallNodeTable | null>,
+  sampleCategories: Array<IndexIntoCategoryList | null>,
+  clickedCallNode: IndexIntoCallNodeTable,
+  clickedCategory: IndexIntoCategoryList
+): IndexIntoCallNodeTable {
+  const { callNodeTable } = callNodeInfo;
+  if (callNodeTable.category[clickedCallNode] !== clickedCategory) {
+    return clickedCallNode;
+  }
+
+  const clickedDepth = callNodeTable.depth[clickedCallNode];
+  const callNodesOnSameCategoryPath = [clickedCallNode];
+  let callNode = clickedCallNode;
+  while (true) {
+    const parentCallNode = callNodeTable.prefix[callNode];
+    if (parentCallNode === -1) {
+      // The entire call path is just clickedCategory.
+      return clickedCallNode; // TODO: is this a useful behavior?
+    }
+    if (callNodeTable.category[parentCallNode] !== clickedCategory) {
+      break;
+    }
+    callNodesOnSameCategoryPath.push(parentCallNode);
+    callNode = parentCallNode;
+  }
+
+  // Now find the callNode in callNodesOnSameCategoryPath with the lowest depth
+  // such that selecting it will not highlight any samples whose unfiltered
+  // category is different from clickedCategory. If no such callNode exists,
+  // return clickedCallNode.
+
+  const handledCallNodes = new Uint8Array(callNodeTable.length);
+  function limitSameCategoryPathToCommonAncestor(callNode) {
+    const walkUpToDepth =
+      clickedDepth - (callNodesOnSameCategoryPath.length - 1);
+    let depth = callNodeTable.depth[callNode];
+    while (depth >= walkUpToDepth) {
+      if (handledCallNodes[callNode]) {
+        return;
+      }
+      handledCallNodes[callNode] = 1;
+      if (depth <= clickedDepth) {
+        if (callNode === callNodesOnSameCategoryPath[clickedDepth - depth]) {
+          callNodesOnSameCategoryPath.length = clickedDepth - depth;
+          return;
+        }
+      }
+      callNode = callNodeTable.prefix[callNode];
+      depth--;
+    }
+  }
+
+  for (let sample = 0; sample < sampleCallNodes.length; sample++) {
+    if (
+      sampleCategories[sample] !== clickedCategory &&
+      sampleCallNodes[sample] !== null
+    ) {
+      limitSameCategoryPathToCommonAncestor(sampleCallNodes[sample]);
+    }
+  }
+
+  if (callNodesOnSameCategoryPath.length > 0) {
+    return callNodesOnSameCategoryPath[callNodesOnSameCategoryPath.length - 1];
+  }
+  return clickedCallNode;
+}
+
+function getSampleCategories(
+  samples: SamplesTable,
+  stackTable: StackTable
+): Array<IndexIntoSamplesTable | null> {
+  return samples.stack.map(s => (s !== null ? stackTable.category[s] : null));
+}
+
+class SelectedThreadActivityGraphCanvas extends PureComponent<Props> {
+  constructor(props) {
+    super(props);
+    (this: any)._onSampleClick = this._onSampleClick.bind(this);
+  }
+
+  _onSampleClick(sampleIndex: IndexIntoSamplesTable) {
+    const {
+      fullThread,
+      filteredThread,
+      callNodeInfo,
+      selectedThreadIndex,
+      changeSelectedCallNode,
+      focusCallTree,
+    } = this.props;
+    const unfilteredStack = fullThread.samples.stack[sampleIndex];
+    if (unfilteredStack === null) {
+      return;
+    }
+
+    const clickedCategory = fullThread.stackTable.category[unfilteredStack];
+    const { callNodeTable, stackIndexToCallNodeIndex } = callNodeInfo;
+    const sampleCallNodes = getSampleCallNodes(
+      filteredThread.samples,
+      stackIndexToCallNodeIndex
+    );
+    const clickedCallNode = sampleCallNodes[sampleIndex];
+    if (clickedCallNode === null) {
+      return;
+    }
+
+    const sampleCategories = getSampleCategories(
+      fullThread.samples,
+      fullThread.stackTable
+    );
+    const chosenCallNode = findBestCallNode(
+      callNodeInfo,
+      sampleCallNodes,
+      sampleCategories,
+      clickedCallNode,
+      clickedCategory
+    );
+    // Change selection twice: First, to clickedCallNode, in order to expand
+    // the whole call path. Then, to chosenCallNode, to get the large-area
+    // graph highlighting.
+    changeSelectedCallNode(
+      selectedThreadIndex,
+      getCallNodePathFromIndex(clickedCallNode, callNodeTable)
+    );
+    changeSelectedCallNode(
+      selectedThreadIndex,
+      getCallNodePathFromIndex(chosenCallNode, callNodeTable)
+    );
+    focusCallTree();
+  }
+  render() {
+    const {
+      fullThread,
+      filteredThread,
+      interval,
+      rangeStart,
+      rangeEnd,
+      callNodeInfo,
+      selectedCallNodeIndex,
+      categories,
+      samplesSelectedStates,
+      treeOrderSampleComparator,
+    } = this.props;
+
+    return (
+      <div>
+        <ThreadActivityGraph
+          interval={interval}
+          fullThread={fullThread}
+          className="selectedThreadActivityGraph"
+          rangeStart={rangeStart}
+          rangeEnd={rangeEnd}
+          onSampleClick={this._onSampleClick}
+          categories={categories}
+          samplesSelectedStates={samplesSelectedStates}
+          treeOrderSampleComparator={treeOrderSampleComparator}
+        />
+        <ThreadStackGraph
+          interval={interval}
+          thread={filteredThread}
+          className="selectedThreadStackGraph"
+          rangeStart={rangeStart}
+          rangeEnd={rangeEnd}
+          callNodeInfo={callNodeInfo}
+          selectedCallNodeIndex={selectedCallNodeIndex}
+          onSampleClick={this._onSampleClick}
+          categories={categories}
+          upsideDown={true}
+        />
+      </div>
+    );
+  }
+}
+
+const SelectedThreadActivityGraphCanvasWithViewport = withChartViewport(
+  SelectedThreadActivityGraphCanvas
+);
+
+function viewportNeedsUpdate() {
+  // By always returning false we prevent the viewport from being
+  // reset and scrolled all the way to the bottom when doing
+  // operations like changing the time selection or applying a
+  // transform.
+  return false;
+}
+
+class SelectedThreadActivityGraph extends PureComponent<*> {
+  render() {
+    const {
+      interval,
+      selectedThreadIndex,
+      fullThread,
+      filteredThread,
+      rangeStart,
+      rangeEnd,
+      callNodeInfo,
+      selectedCallNodeIndex,
+      categories,
+      samplesSelectedStates,
+      treeOrderSampleComparator,
+      previewSelection,
+      changeSelectedCallNode,
+      focusCallTree,
+      timeRange,
+    } = this.props;
+    return (
+      <SelectedThreadActivityGraphCanvasWithViewport
+        chartProps={{
+          interval,
+          selectedThreadIndex,
+          fullThread,
+          filteredThread,
+          rangeStart,
+          rangeEnd,
+          callNodeInfo,
+          selectedCallNodeIndex,
+          categories,
+          samplesSelectedStates,
+          treeOrderSampleComparator,
+          changeSelectedCallNode,
+          focusCallTree,
+        }}
+        viewportProps={{
+          timeRange: timeRange,
+          maxViewportHeight: 0,
+          maximumZoom: 0.0001,
+          previewSelection,
+          startsAtBottom: true,
+          disableHorizontalMovement: false,
+          className: 'selectedThreadActivityGraphViewport',
+          viewportNeedsUpdate,
+          marginLeft: 0,
+          marginRight: 0,
+        }}
+      />
+    );
+  }
+}
+
+const options: ExplicitConnectOptions<*, *, *> = {
+  mapStateToProps: (state: State) => {
+    const committedRange = getCommittedRange(state);
+    const previewSelection = getPreviewSelection(state);
+    const rangeStart = previewSelection.hasSelection
+      ? previewSelection.selectionStart
+      : committedRange.start;
+    const rangeEnd = previewSelection.hasSelection
+      ? previewSelection.selectionEnd
+      : committedRange.end;
+    return {
+      interval: getProfile(state).meta.interval,
+      selectedThreadIndex: getSelectedThreadIndex(state),
+      fullThread: selectedThreadSelectors.getRangeFilteredThread(state),
+      filteredThread: selectedThreadSelectors.getFilteredThread(state),
+      rangeStart,
+      rangeEnd,
+      callNodeInfo: selectedThreadSelectors.getCallNodeInfo(state),
+      selectedCallNodeIndex: selectedThreadSelectors.getSelectedCallNodeIndex(
+        state
+      ),
+      categories: getProfile(state).meta.categories,
+      samplesSelectedStates: selectedThreadSelectors.getSamplesSelectedStatesInFilteredThread(
+        state
+      ),
+      treeOrderSampleComparator: selectedThreadSelectors.getTreeOrderComparatorInFilteredThread(
+        state
+      ),
+      timeRange: getCommittedRange(state),
+      previewSelection,
+    };
+  },
+  mapDispatchToProps: {
+    changeSelectedCallNode,
+    focusCallTree,
+  },
+  component: SelectedThreadActivityGraph,
+};
+export default explicitConnect(options);

--- a/src/components/shared/thread/SelectedActivityGraph.js
+++ b/src/components/shared/thread/SelectedActivityGraph.js
@@ -240,7 +240,7 @@ class SelectedThreadActivityGraphCanvas extends PureComponent<Props> {
           selectedCallNodeIndex={selectedCallNodeIndex}
           onSampleClick={this._onSampleClick}
           categories={categories}
-          upsideDown={true}
+          stacksGrowFromCeiling={true}
         />
       </div>
     );
@@ -251,11 +251,11 @@ const SelectedThreadActivityGraphCanvasWithViewport = withChartViewport(
   SelectedThreadActivityGraphCanvas
 );
 
+/**
+ * The viewport contents never change size from this component, so it never needs
+ * explicit updating, outside of how the viewport manages its own size and positioning.
+ */
 function viewportNeedsUpdate() {
-  // By always returning false we prevent the viewport from being
-  // reset and scrolled all the way to the bottom when doing
-  // operations like changing the time selection or applying a
-  // transform.
   return false;
 }
 

--- a/src/components/shared/thread/StackGraph.css
+++ b/src/components/shared/thread/StackGraph.css
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+.threadStackGraph {
+  height: 25px;
+}
+
+.threadStackGraphCanvas {
+  display: block;
+  height: 25px;
+  width: 100%;
+}

--- a/src/components/shared/thread/StackGraph.js
+++ b/src/components/shared/thread/StackGraph.js
@@ -37,7 +37,8 @@ type Props = {|
   +selectedCallNodeIndex: IndexIntoCallNodeTable | null,
   +categories: CategoryList,
   +onSampleClick: (sampleIndex: IndexIntoSamplesTable) => void,
-  +upsideDown?: boolean,
+  // Decide which way the stacks grow up from the floor, or down from the ceiling.
+  +stacksGrowFromCeiling?: boolean,
 |};
 
 class StackGraph extends PureComponent<Props> {
@@ -74,7 +75,7 @@ class StackGraph extends PureComponent<Props> {
       callNodeInfo,
       selectedCallNodeIndex,
       categories,
-      upsideDown,
+      stacksGrowFromCeiling,
     } = this.props;
 
     const devicePixelRatio = canvas.ownerDocument
@@ -181,7 +182,7 @@ class StackGraph extends PureComponent<Props> {
       ctx.fillStyle = color;
       for (let i = 0; i < samplesBucket.height.length; i++) {
         const height = samplesBucket.height[i];
-        const startY = upsideDown ? 0 : canvas.height - height;
+        const startY = stacksGrowFromCeiling ? 0 : canvas.height - height;
         const xPos = samplesBucket.xPos[i];
         ctx.fillRect(xPos, startY, drawnIntervalWidth, height);
       }

--- a/src/components/shared/thread/StackGraph.js
+++ b/src/components/shared/thread/StackGraph.js
@@ -5,13 +5,14 @@
 
 import React, { PureComponent } from 'react';
 import bisection from 'bisection';
-import { ensureExists } from '../../utils/flow';
-import { timeCode } from '../../utils/time-code';
+import classNames from 'classnames';
+import { ensureExists } from '../../../utils/flow';
+import { timeCode } from '../../../utils/time-code';
 import {
   getSampleCallNodes,
   getSamplesSelectedStates,
   getSampleIndexClosestToTime,
-} from '../../profile-logic/profile-data';
+} from '../../../profile-logic/profile-data';
 import { BLUE_70, BLUE_40 } from 'photon-colors';
 import './StackGraph.css';
 
@@ -19,14 +20,15 @@ import type {
   Thread,
   CategoryList,
   IndexIntoSamplesTable,
-} from '../../types/profile';
-import type { Milliseconds } from '../../types/units';
+} from '../../../types/profile';
+import type { Milliseconds } from '../../../types/units';
 import type {
   CallNodeInfo,
   IndexIntoCallNodeTable,
-} from '../../types/profile-derived';
+} from '../../../types/profile-derived';
 
 type Props = {|
+  +className: string,
   +thread: Thread,
   +interval: Milliseconds,
   +rangeStart: Milliseconds,
@@ -35,6 +37,7 @@ type Props = {|
   +selectedCallNodeIndex: IndexIntoCallNodeTable | null,
   +categories: CategoryList,
   +onSampleClick: (sampleIndex: IndexIntoSamplesTable) => void,
+  +upsideDown?: boolean,
 |};
 
 class StackGraph extends PureComponent<Props> {
@@ -71,6 +74,7 @@ class StackGraph extends PureComponent<Props> {
       callNodeInfo,
       selectedCallNodeIndex,
       categories,
+      upsideDown,
     } = this.props;
 
     const devicePixelRatio = canvas.ownerDocument
@@ -177,7 +181,7 @@ class StackGraph extends PureComponent<Props> {
       ctx.fillStyle = color;
       for (let i = 0; i < samplesBucket.height.length; i++) {
         const height = samplesBucket.height[i];
-        const startY = canvas.height - height;
+        const startY = upsideDown ? 0 : canvas.height - height;
         const xPos = samplesBucket.xPos[i];
         ctx.fillRect(xPos, startY, drawnIntervalWidth, height);
       }
@@ -213,9 +217,12 @@ class StackGraph extends PureComponent<Props> {
   render() {
     this._renderCanvas();
     return (
-      <div className="timelineStackGraph">
+      <div className={this.props.className}>
         <canvas
-          className="timelineStackGraphCanvas"
+          className={classNames(
+            `${this.props.className}Canvas`,
+            'threadStackGraphCanvas'
+          )}
           ref={this._takeCanvasRef}
           onMouseUp={this._onMouseUp}
         />

--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -6,7 +6,7 @@
 
 import React, { PureComponent } from 'react';
 import explicitConnect from '../../utils/connect';
-// import ThreadStackGraph from '../shared/thread/StackGraph';
+import ThreadStackGraph from '../shared/thread/StackGraph';
 import ThreadActivityGraph from '../shared/thread/ActivityGraph';
 import {
   selectorsForThread,
@@ -14,7 +14,10 @@ import {
   getCommittedRange,
   getCategories,
 } from '../../reducers/profile-view';
-import { getSelectedThreadIndex } from '../../reducers/url-state';
+import {
+  getSelectedThreadIndex,
+  getTimelineType,
+} from '../../reducers/url-state';
 import { getCallNodePathFromIndex } from '../../profile-logic/profile-data';
 import {
   TimelineTracingMarkersJank,
@@ -29,6 +32,7 @@ import {
 import EmptyThreadIndicator from './EmptyThreadIndicator';
 import './TrackThread.css';
 
+import type { TimelineType } from '../../types/actions';
 import type {
   Thread,
   ThreadIndex,
@@ -60,6 +64,7 @@ type StateProps = {|
   +rangeStart: Milliseconds,
   +rangeEnd: Milliseconds,
   +categories: CategoryList,
+  +timelineType: TimelineType,
 |};
 
 type DispatchProps = {|
@@ -115,10 +120,11 @@ class TimelineTrackThread extends PureComponent<Props> {
       interval,
       rangeStart,
       rangeEnd,
-      // callNodeInfo,
-      // selectedCallNodeIndex,
+      callNodeInfo,
+      selectedCallNodeIndex,
       unfilteredSamplesRange,
       categories,
+      timelineType,
     } = this.props;
 
     const processType = filteredThread.processType;
@@ -158,25 +164,29 @@ class TimelineTrackThread extends PureComponent<Props> {
             onSelect={this._onIntervalMarkerSelect}
           />
         ) : null}
-        <ThreadActivityGraph
-          className="threadActivityGraph"
-          interval={interval}
-          fullThread={fullThread}
-          rangeStart={rangeStart}
-          rangeEnd={rangeEnd}
-          onSampleClick={this._onSampleClick}
-          categories={categories}
-        />
-        {/* <ThreadStackGraph
-          interval={interval}
-          thread={thread}
-          rangeStart={rangeStart}
-          rangeEnd={rangeEnd}
-          callNodeInfo={callNodeInfo}
-          selectedCallNodeIndex={selectedCallNodeIndex}
-          categories={categories}
-          onSampleClick={this._onSampleClick}
-        /> */}
+        {timelineType === 'category' ? (
+          <ThreadActivityGraph
+            className="threadActivityGraph"
+            interval={interval}
+            fullThread={fullThread}
+            rangeStart={rangeStart}
+            rangeEnd={rangeEnd}
+            onSampleClick={this._onSampleClick}
+            categories={categories}
+          />
+        ) : (
+          <ThreadStackGraph
+            className="threadStackGraph"
+            interval={interval}
+            thread={fullThread}
+            rangeStart={rangeStart}
+            rangeEnd={rangeEnd}
+            callNodeInfo={callNodeInfo}
+            selectedCallNodeIndex={selectedCallNodeIndex}
+            categories={categories}
+            onSampleClick={this._onSampleClick}
+          />
+        )}
         <EmptyThreadIndicator
           thread={filteredThread}
           interval={interval}
@@ -208,6 +218,7 @@ const options: ExplicitConnectOptions<OwnProps, StateProps, DispatchProps> = {
       rangeStart: committedRange.start,
       rangeEnd: committedRange.end,
       categories: getCategories(state),
+      timelineType: getTimelineType(state),
     };
   },
   mapDispatchToProps: {

--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -80,7 +80,7 @@ type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
 class TimelineTrackThread extends PureComponent<Props> {
   /**
    * Handle when a sample is clicked in the ThreadStackGraph. This will select
-   * the leaf-most stack.
+   * the leaf-most stack frame or call node.
    */
   _onSampleClick = (sampleIndex: IndexIntoSamplesTable) => {
     const { threadIndex, selectLeafCallNode, focusCallTree } = this.props;

--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -18,7 +18,6 @@ import {
   getSelectedThreadIndex,
   getTimelineType,
 } from '../../reducers/url-state';
-import { getCallNodePathFromIndex } from '../../profile-logic/profile-data';
 import {
   TimelineTracingMarkersJank,
   TimelineTracingMarkersOverview,
@@ -28,6 +27,7 @@ import {
   changeRightClickedTrack,
   changeSelectedCallNode,
   focusCallTree,
+  selectLeafCallNode,
 } from '../../actions/profile-view';
 import EmptyThreadIndicator from './EmptyThreadIndicator';
 import './TrackThread.css';
@@ -72,29 +72,19 @@ type DispatchProps = {|
   +updatePreviewSelection: typeof updatePreviewSelection,
   +changeSelectedCallNode: typeof changeSelectedCallNode,
   +focusCallTree: typeof focusCallTree,
+  +selectLeafCallNode: typeof selectLeafCallNode,
 |};
 
 type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
 
 class TimelineTrackThread extends PureComponent<Props> {
+  /**
+   * Handle when a sample is clicked in the ThreadStackGraph. This will select
+   * the leaf-most stack.
+   */
   _onSampleClick = (sampleIndex: IndexIntoSamplesTable) => {
-    const {
-      filteredThread,
-      threadIndex,
-      callNodeInfo,
-      changeSelectedCallNode,
-      focusCallTree,
-    } = this.props;
-
-    const newSelectedStack = filteredThread.samples.stack[sampleIndex];
-    const newSelectedCallNode =
-      newSelectedStack === null
-        ? -1
-        : callNodeInfo.stackIndexToCallNodeIndex[newSelectedStack];
-    changeSelectedCallNode(
-      threadIndex,
-      getCallNodePathFromIndex(newSelectedCallNode, callNodeInfo.callNodeTable)
-    );
+    const { threadIndex, selectLeafCallNode, focusCallTree } = this.props;
+    selectLeafCallNode(threadIndex, sampleIndex);
     focusCallTree();
   };
 
@@ -226,6 +216,7 @@ const options: ExplicitConnectOptions<OwnProps, StateProps, DispatchProps> = {
     changeRightClickedTrack,
     changeSelectedCallNode,
     focusCallTree,
+    selectLeafCallNode,
   },
   component: TimelineTrackThread,
 };

--- a/src/components/timeline/TrackThread.js
+++ b/src/components/timeline/TrackThread.js
@@ -178,7 +178,7 @@ class TimelineTrackThread extends PureComponent<Props> {
           <ThreadStackGraph
             className="threadStackGraph"
             interval={interval}
-            thread={fullThread}
+            thread={filteredThread}
             rangeStart={rangeStart}
             rangeEnd={rangeEnd}
             callNodeInfo={callNodeInfo}

--- a/src/components/timeline/index.css
+++ b/src/components/timeline/index.css
@@ -21,3 +21,25 @@
   box-shadow: inset 0 1px var(--grey-30);
   background-color: var(--grey-20);
 }
+
+.timelineToggle {
+  position: absolute;
+  top: 0;
+  left: -150px;
+  width: 150px;
+  height: 22px;
+  display: flex;
+  font-size: 9px;
+}
+
+.timelineToggleInput {
+  height: 12px;
+  width: 12px;
+  margin: 0 3px;
+  vertical-align: middle;
+}
+
+.timelineToggleLabel {
+  display: flex;
+  align-items: center;
+}

--- a/src/components/timeline/index.js
+++ b/src/components/timeline/index.js
@@ -72,6 +72,18 @@ class Timeline extends PureComponent<Props> {
 
     return (
       <TimelineSelection width={width}>
+        <div className="timelineToggle">
+          <form>
+            <label>
+              <input type="radio" name="timelineToggle" checked />
+              Stacks
+            </label>
+            <label>
+              <input type="radio" name="timelineToggle" />
+              Categories
+            </label>
+          </form>
+        </div>
         <TimelineRuler
           zeroAt={zeroAt}
           rangeStart={committedRange.start}

--- a/src/components/timeline/index.js
+++ b/src/components/timeline/index.js
@@ -19,7 +19,7 @@ import {
   getGlobalTracks,
   getGlobalTrackReferences,
 } from '../../reducers/profile-view';
-import { getGlobalTrackOrder } from '../../reducers/url-state';
+import { getGlobalTrackOrder, getTimelineType } from '../../reducers/url-state';
 import './index.css';
 
 import type { SizeProps } from '../shared/WithSize';
@@ -28,10 +28,11 @@ import {
   changeGlobalTrackOrder,
   updatePreviewSelection,
   commitRange,
+  changeTimelineType,
 } from '../../actions/profile-view';
 
 import type { TrackIndex, GlobalTrack } from '../../types/profile-derived';
-import type { TrackReference } from '../../types/actions';
+import type { TrackReference, TimelineType } from '../../types/actions';
 import type { Milliseconds, StartEndRange } from '../../types/units';
 import type {
   ExplicitConnectOptions,
@@ -47,17 +48,22 @@ type StateProps = {|
   +globalTrackReferences: TrackReference[],
   +panelLayoutGeneration: number,
   +zeroAt: Milliseconds,
+  +timelineType: TimelineType,
 |};
 
 type DispatchProps = {|
   +changeGlobalTrackOrder: typeof changeGlobalTrackOrder,
   +commitRange: typeof commitRange,
   +updatePreviewSelection: typeof updatePreviewSelection,
+  +changeTimelineType: typeof changeTimelineType,
 |};
 
 type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
 
 class Timeline extends PureComponent<Props> {
+  _changeToCategories = () => this.props.changeTimelineType('category');
+  _changeToStacks = () => this.props.changeTimelineType('stack');
+
   render() {
     const {
       globalTracks,
@@ -68,22 +74,35 @@ class Timeline extends PureComponent<Props> {
       width,
       globalTrackReferences,
       panelLayoutGeneration,
+      timelineType,
     } = this.props;
 
     return (
       <TimelineSelection width={width}>
-        <div className="timelineToggle">
-          <form>
-            <label>
-              <input type="radio" name="timelineToggle" checked />
-              Stacks
-            </label>
-            <label>
-              <input type="radio" name="timelineToggle" />
+        <form>
+          <div className="timelineToggle">
+            <label className="timelineToggleLabel">
+              <input
+                type="radio"
+                name="timelineToggle"
+                className="timelineToggleInput"
+                checked={timelineType === 'category'}
+                onChange={this._changeToCategories}
+              />
               Categories
             </label>
-          </form>
-        </div>
+            <label className="timelineToggleLabel">
+              <input
+                type="radio"
+                name="timelineToggle"
+                className="timelineToggleInput"
+                checked={timelineType === 'stack'}
+                onChange={this._changeToStacks}
+              />
+              Stack height
+            </label>
+          </div>
+        </form>
         <TimelineRuler
           zeroAt={zeroAt}
           rangeStart={committedRange.start}
@@ -126,11 +145,13 @@ const options: ExplicitConnectOptions<OwnProps, StateProps, DispatchProps> = {
     committedRange: getCommittedRange(state),
     zeroAt: getZeroAt(state),
     panelLayoutGeneration: getPanelLayoutGeneration(state),
+    timelineType: getTimelineType(state),
   }),
   mapDispatchToProps: {
     changeGlobalTrackOrder,
     updatePreviewSelection,
     commitRange,
+    changeTimelineType,
   },
   component: Timeline,
 };

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -184,34 +184,44 @@ function viewOptionsPerThread(
       });
     }
     case 'CHANGE_SELECTED_CALL_NODE': {
-      const { selectedCallNodePath, threadIndex } = action;
+      const {
+        selectedCallNodePath,
+        threadIndex,
+        optionalExpandedToCallNodePath,
+      } = action;
 
       const threadState = state[threadIndex];
       const previousSelectedCallNodePath = threadState.selectedCallNodePath;
 
       // If the selected node doesn't actually change, let's return the previous
       // state to avoid rerenders.
-      if (arePathsEqual(selectedCallNodePath, previousSelectedCallNodePath)) {
+      if (
+        arePathsEqual(selectedCallNodePath, previousSelectedCallNodePath) &&
+        !optionalExpandedToCallNodePath
+      ) {
         return state;
       }
 
       let { expandedCallNodePaths } = threadState;
+      const expandToNode = optionalExpandedToCallNodePath
+        ? optionalExpandedToCallNodePath
+        : selectedCallNodePath;
 
       /* Looking into the current state to know whether we want to generate a
        * new one. It can be expensive to clone when we have a lot of expanded
        * lines, but it's very infrequent that we actually want to expand new
        * lines as a result of a selection. */
-      const selectedNodeParentPaths = [];
-      for (let i = 1; i < selectedCallNodePath.length; i++) {
-        selectedNodeParentPaths.push(selectedCallNodePath.slice(0, i));
+      const expandToNodeParentPaths = [];
+      for (let i = 1; i < expandToNode.length; i++) {
+        expandToNodeParentPaths.push(expandToNode.slice(0, i));
       }
-      const hasNewExpandedPaths = selectedNodeParentPaths.some(
+      const hasNewExpandedPaths = expandToNodeParentPaths.some(
         path => !expandedCallNodePaths.has(path)
       );
 
       if (hasNewExpandedPaths) {
         expandedCallNodePaths = new PathSet(expandedCallNodePaths);
-        selectedNodeParentPaths.forEach(path =>
+        expandToNodeParentPaths.forEach(path =>
           expandedCallNodePaths.add(path)
         );
       }

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -21,6 +21,7 @@ import type {
   Action,
   DataSource,
   ImplementationFilter,
+  TimelineType,
 } from '../types/actions';
 import type { State, UrlState, Reducer } from '../types/reducers';
 import type { TabSlug } from '../app-logic/tabs-handling';
@@ -132,6 +133,18 @@ function transforms(state: TransformStacksPerThread = {}, action: Action) {
         [threadIndex]: transforms.slice(0, firstPoppedFilterIndex),
       });
     }
+    default:
+      return state;
+  }
+}
+
+function timelineType(
+  state: TimelineType = 'category',
+  action: Action
+): TimelineType {
+  switch (action.type) {
+    case 'CHANGE_TIMELINE_TYPE':
+      return action.timelineType;
     default:
       return state;
   }
@@ -277,6 +290,7 @@ const profileSpecific = combineReducers({
   callTreeSearchString,
   markersSearchString,
   transforms,
+  timelineType,
   // The timeline tracks used to be hidden and sorted by thread indexes, rather than
   // track indexes. The only way to migrate this information to tracks-based data is to
   // first retrieve the profile, so they can't be upgraded by the normal url upgrading
@@ -390,6 +404,9 @@ export const getTransformStack = (
     EMPTY_TRANSFORM_STACK
   );
 };
+
+export const getTimelineType = (state: State): TimelineType =>
+  getProfileSpecificState(state).timelineType;
 
 export const getLegacyThreadOrder = (state: State) =>
   getProfileSpecificState(state).legacyThreadOrder;

--- a/src/test/components/ProfileCallTreeView.test.js
+++ b/src/test/components/ProfileCallTreeView.test.js
@@ -8,6 +8,7 @@ import { mount } from 'enzyme';
 
 import ProfileCallTreeView from '../../components/calltree/ProfileCallTreeView';
 import { Provider } from 'react-redux';
+import mockCanvasContext from '../fixtures/mocks/canvas-context';
 import { storeWithProfile } from '../fixtures/stores';
 import { getBoundingBox } from '../fixtures/utils';
 import {
@@ -31,10 +32,17 @@ describe('calltree/ProfileCallTreeView', function() {
     E  E
   `);
 
+  beforeEach(() => {
+    // Mock out the 2d canvas for the loupe view.
+    jest
+      .spyOn(HTMLCanvasElement.prototype, 'getContext')
+      .mockImplementation(() => mockCanvasContext());
+  });
+
   it('renders an unfiltered call tree', () => {
     const calltree = mount(
       <Provider store={storeWithProfile(profile)}>
-        <ProfileCallTreeView />
+        <ProfileCallTreeView hideThreadActivityGraph={true} />
       </Provider>
     );
 
@@ -55,7 +63,7 @@ describe('calltree/ProfileCallTreeView', function() {
 
     const calltree = mount(
       <Provider store={store}>
-        <ProfileCallTreeView />
+        <ProfileCallTreeView hideThreadActivityGraph={true} />
       </Provider>
     );
 
@@ -66,7 +74,7 @@ describe('calltree/ProfileCallTreeView', function() {
     const store = storeWithProfile(profile);
     const calltree = mount(
       <Provider store={store}>
-        <ProfileCallTreeView />
+        <ProfileCallTreeView hideThreadActivityGraph={true} />
       </Provider>
     );
 
@@ -97,7 +105,7 @@ describe('calltree/ProfileCallTreeView', function() {
     const store = storeWithProfile(profile);
     const calltree = mount(
       <Provider store={store}>
-        <ProfileCallTreeView />
+        <ProfileCallTreeView hideThreadActivityGraph={true} />
       </Provider>
     );
 
@@ -106,6 +114,13 @@ describe('calltree/ProfileCallTreeView', function() {
 });
 
 describe('calltree/ProfileCallTreeView EmptyReasons', function() {
+  beforeEach(() => {
+    // Mock out the 2d canvas for the loupe view.
+    jest
+      .spyOn(HTMLCanvasElement.prototype, 'getContext')
+      .mockImplementation(() => mockCanvasContext());
+  });
+
   const { profile } = getProfileFromTextSamples(`
     A  A  A
     B  B  B
@@ -118,7 +133,7 @@ describe('calltree/ProfileCallTreeView EmptyReasons', function() {
   function renderWithStore(store) {
     return mount(
       <Provider store={store}>
-        <ProfileCallTreeView />
+        <ProfileCallTreeView hideThreadActivityGraph={true} />
       </Provider>
     );
   }
@@ -147,6 +162,13 @@ describe('calltree/ProfileCallTreeView EmptyReasons', function() {
 });
 
 describe('calltree/ProfileCallTreeView navigation keys', () => {
+  beforeEach(() => {
+    // Mock out the 2d canvas for the loupe view.
+    jest
+      .spyOn(HTMLCanvasElement.prototype, 'getContext')
+      .mockImplementation(() => mockCanvasContext());
+  });
+
   function setup(profileString: string) {
     // This makes the bounding box large enough so that we don't trigger
     // VirtualList's virtualization. We assert this above.
@@ -158,7 +180,7 @@ describe('calltree/ProfileCallTreeView navigation keys', () => {
     const store = storeWithProfile(profile);
     const callTree = mount(
       <Provider store={store}>
-        <ProfileCallTreeView />
+        <ProfileCallTreeView hideThreadActivityGraph={true} />
       </Provider>
     );
 

--- a/src/test/components/Timeline.test.js
+++ b/src/test/components/Timeline.test.js
@@ -73,6 +73,11 @@ describe('Timeline', function() {
       }: any);
       return mockEl;
     });
+
+    // Mock out the 2d canvas for the loupe view.
+    jest
+      .spyOn(HTMLCanvasElement.prototype, 'getContext')
+      .mockImplementation(() => mockCanvasContext());
   });
   it('renders the header', () => {
     const flushRafCalls = mockRaf();

--- a/src/test/components/TrackThread.test.js
+++ b/src/test/components/TrackThread.test.js
@@ -10,6 +10,7 @@ import * as React from 'react';
 import { Provider } from 'react-redux';
 import { mount } from 'enzyme';
 
+import { changeTimelineType } from '../../actions/profile-view';
 import TrackThread from '../../components/timeline/TrackThread';
 import {
   selectedThreadSelectors,
@@ -40,6 +41,11 @@ const STACK_2_X_POSITION = 150;
 const STACK_3_X_POSITION = 250;
 const STACK_4_X_POSITION = 350;
 
+/**
+ * This test is asserting behavior more for the ThreadStackGraph component. The
+ * ThreadActivityGraph component was added as a new default. Currently this test
+ * only checks the older behavior.
+ */
 describe('timeline/TrackThread', function() {
   beforeEach(addRootOverlayElement);
   afterEach(removeRootOverlayElement);
@@ -79,6 +85,11 @@ describe('timeline/TrackThread', function() {
       .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
       .mockImplementation(() => getBoundingBox(GRAPH_WIDTH, GRAPH_HEIGHT));
 
+    // Note: These tests were first written with the timeline using the ThreadStackGraph.
+    // This is not the default view, so dispatch an action to change to the older default
+    // view.
+    store.dispatch(changeTimelineType('stack'));
+
     const view = mount(
       <Provider store={store}>
         <TrackThread threadIndex={threadIndex} />
@@ -89,7 +100,7 @@ describe('timeline/TrackThread', function() {
     flushRafCalls();
     view.update();
 
-    const stackGraphCanvas = view.find('.timelineStackGraphCanvas').first();
+    const stackGraphCanvas = view.find('.threadStackGraphCanvas').first();
     const tracingMarkersCanvas = view
       .find(
         [

--- a/src/test/components/__snapshots__/GlobalTrack.test.js.snap
+++ b/src/test/components/__snapshots__/GlobalTrack.test.js.snap
@@ -57,10 +57,10 @@ process: \\"tab\\" (222)"
           />
         </div>
         <div
-          className="timelineStackGraph"
+          className="threadActivityGraph"
         >
           <canvas
-            className="timelineStackGraphCanvas"
+            className="threadActivityGraphCanvas threadActivityGraphCanvas"
             onMouseUp={[Function]}
           />
         </div>
@@ -116,10 +116,10 @@ process: \\"tab\\" (222)"
               />
             </div>
             <div
-              className="timelineStackGraph"
+              className="threadActivityGraph"
             >
               <canvas
-                className="timelineStackGraphCanvas"
+                className="threadActivityGraphCanvas threadActivityGraphCanvas"
                 onMouseUp={[Function]}
               />
             </div>
@@ -172,10 +172,10 @@ process: \\"tab\\" (222)"
               />
             </div>
             <div
-              className="timelineStackGraph"
+              className="threadActivityGraph"
             >
               <canvas
-                className="timelineStackGraphCanvas"
+                className="threadActivityGraphCanvas threadActivityGraphCanvas"
                 onMouseUp={[Function]}
               />
             </div>

--- a/src/test/components/__snapshots__/LocalTrack.test.js.snap
+++ b/src/test/components/__snapshots__/LocalTrack.test.js.snap
@@ -87,10 +87,10 @@ process: \\"tab\\" (222)"
           />
         </div>
         <div
-          className="timelineStackGraph"
+          className="threadActivityGraph"
         >
           <canvas
-            className="timelineStackGraphCanvas"
+            className="threadActivityGraphCanvas threadActivityGraphCanvas"
             onMouseUp={[Function]}
           />
         </div>

--- a/src/test/components/__snapshots__/Timeline.test.js.snap
+++ b/src/test/components/__snapshots__/Timeline.test.js.snap
@@ -6,6 +6,36 @@ exports[`Timeline renders the header 1`] = `
   onMouseDown={[Function]}
   onMouseMove={[Function]}
 >
+  <form>
+    <div
+      className="timelineToggle"
+    >
+      <label
+        className="timelineToggleLabel"
+      >
+        <input
+          checked={true}
+          className="timelineToggleInput"
+          name="timelineToggle"
+          onChange={[Function]}
+          type="radio"
+        />
+        Categories
+      </label>
+      <label
+        className="timelineToggleLabel"
+      >
+        <input
+          checked={false}
+          className="timelineToggleInput"
+          name="timelineToggle"
+          onChange={[Function]}
+          type="radio"
+        />
+        Stack height
+      </label>
+    </div>
+  </form>
   <div
     className="timelineRuler"
   >
@@ -187,10 +217,10 @@ process: \\"default\\" (0)"
                         />
                       </div>
                       <div
-                        className="timelineStackGraph"
+                        className="threadActivityGraph"
                       >
                         <canvas
-                          className="timelineStackGraphCanvas"
+                          className="threadActivityGraphCanvas threadActivityGraphCanvas"
                           onMouseUp={[Function]}
                         />
                       </div>
@@ -243,10 +273,10 @@ process: \\"default\\" (0)"
                         />
                       </div>
                       <div
-                        className="timelineStackGraph"
+                        className="threadActivityGraph"
                       >
                         <canvas
-                          className="timelineStackGraphCanvas"
+                          className="threadActivityGraphCanvas threadActivityGraphCanvas"
                           onMouseUp={[Function]}
                         />
                       </div>
@@ -333,10 +363,10 @@ process: \\"default\\" (0)"
                         />
                       </div>
                       <div
-                        className="timelineStackGraph"
+                        className="threadActivityGraph"
                       >
                         <canvas
-                          className="timelineStackGraphCanvas"
+                          className="threadActivityGraphCanvas threadActivityGraphCanvas"
                           onMouseUp={[Function]}
                         />
                       </div>
@@ -402,145 +432,3874 @@ process: \\"default\\" (0)"
 exports[`Timeline renders the header 2`] = `
 Array [
   Array [
-    "set fillStyle",
-    "#45a1ff",
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
   ],
   Array [
-    "fillRect",
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "set globalCompositeOperation",
+    "lighter",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db60",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db",
+  ],
+  Array [
+    "beginPath",
+  ],
+  Array [
+    "moveTo",
     0,
-    NaN,
-    22.22222222222222,
-    NaN,
-  ],
-  Array [
-    "fillRect",
-    22.22222222222222,
-    NaN,
-    22.22222222222222,
-    NaN,
-  ],
-  Array [
-    "fillRect",
-    44.44444444444444,
-    NaN,
-    22.22222222222222,
-    NaN,
-  ],
-  Array [
-    "fillRect",
-    66.66666666666666,
-    NaN,
-    22.22222222222222,
-    NaN,
-  ],
-  Array [
-    "fillRect",
-    88.88888888888889,
-    NaN,
-    22.22222222222222,
-    NaN,
-  ],
-  Array [
-    "fillRect",
-    111.11111111111111,
-    NaN,
-    22.22222222222222,
-    NaN,
-  ],
-  Array [
-    "fillRect",
-    133.33333333333331,
-    NaN,
-    22.22222222222222,
-    NaN,
-  ],
-  Array [
-    "fillRect",
-    155.55555555555554,
-    NaN,
-    22.22222222222222,
-    NaN,
-  ],
-  Array [
-    "fillRect",
-    177.77777777777777,
-    NaN,
-    22.22222222222222,
-    NaN,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "set fillStyle",
-    "#c5e1fe",
-  ],
-  Array [
-    "set fillStyle",
-    "#45a1ff",
-  ],
-  Array [
-    "fillRect",
-    88.88888888888889,
-    0,
-    22.22222222222222,
     300,
   ],
   Array [
-    "fillRect",
-    111.11111111111111,
-    0,
-    22.22222222222222,
+    "lineTo",
+    1,
     300,
   ],
   Array [
-    "fillRect",
-    133.33333333333331,
+    "lineTo",
+    2,
+    300,
+  ],
+  Array [
+    "lineTo",
+    3,
+    300,
+  ],
+  Array [
+    "lineTo",
+    4,
+    300,
+  ],
+  Array [
+    "lineTo",
+    5,
+    300,
+  ],
+  Array [
+    "lineTo",
+    6,
+    300,
+  ],
+  Array [
+    "lineTo",
+    7,
+    300,
+  ],
+  Array [
+    "lineTo",
+    8,
+    300,
+  ],
+  Array [
+    "lineTo",
+    9,
+    300,
+  ],
+  Array [
+    "lineTo",
+    10,
+    300,
+  ],
+  Array [
+    "lineTo",
+    11,
+    300,
+  ],
+  Array [
+    "lineTo",
+    12,
+    300,
+  ],
+  Array [
+    "lineTo",
+    13,
+    300,
+  ],
+  Array [
+    "lineTo",
+    14,
+    300,
+  ],
+  Array [
+    "lineTo",
+    15,
+    300,
+  ],
+  Array [
+    "lineTo",
+    16,
+    300,
+  ],
+  Array [
+    "lineTo",
+    17,
+    300,
+  ],
+  Array [
+    "lineTo",
+    18,
+    300,
+  ],
+  Array [
+    "lineTo",
+    19,
+    300,
+  ],
+  Array [
+    "lineTo",
+    20,
+    300,
+  ],
+  Array [
+    "lineTo",
+    21,
+    300,
+  ],
+  Array [
+    "lineTo",
+    22,
+    300,
+  ],
+  Array [
+    "lineTo",
+    23,
+    300,
+  ],
+  Array [
+    "lineTo",
+    24,
+    300,
+  ],
+  Array [
+    "lineTo",
+    25,
+    300,
+  ],
+  Array [
+    "lineTo",
+    26,
+    300,
+  ],
+  Array [
+    "lineTo",
+    27,
+    300,
+  ],
+  Array [
+    "lineTo",
+    28,
+    300,
+  ],
+  Array [
+    "lineTo",
+    29,
+    300,
+  ],
+  Array [
+    "lineTo",
+    30,
+    300,
+  ],
+  Array [
+    "lineTo",
+    31,
+    300,
+  ],
+  Array [
+    "lineTo",
+    32,
+    300,
+  ],
+  Array [
+    "lineTo",
+    33,
+    300,
+  ],
+  Array [
+    "lineTo",
+    34,
+    300,
+  ],
+  Array [
+    "lineTo",
+    35,
+    300,
+  ],
+  Array [
+    "lineTo",
+    36,
+    300,
+  ],
+  Array [
+    "lineTo",
+    37,
+    300,
+  ],
+  Array [
+    "lineTo",
+    38,
+    300,
+  ],
+  Array [
+    "lineTo",
+    39,
+    300,
+  ],
+  Array [
+    "lineTo",
+    40,
+    300,
+  ],
+  Array [
+    "lineTo",
+    41,
+    300,
+  ],
+  Array [
+    "lineTo",
+    42,
+    300,
+  ],
+  Array [
+    "lineTo",
+    43,
+    300,
+  ],
+  Array [
+    "lineTo",
+    44,
+    300,
+  ],
+  Array [
+    "lineTo",
+    45,
+    300,
+  ],
+  Array [
+    "lineTo",
+    46,
+    300,
+  ],
+  Array [
+    "lineTo",
+    47,
+    300,
+  ],
+  Array [
+    "lineTo",
+    48,
+    300,
+  ],
+  Array [
+    "lineTo",
+    49,
+    300,
+  ],
+  Array [
+    "lineTo",
+    50,
+    300,
+  ],
+  Array [
+    "lineTo",
+    51,
+    300,
+  ],
+  Array [
+    "lineTo",
+    52,
+    300,
+  ],
+  Array [
+    "lineTo",
+    53,
+    300,
+  ],
+  Array [
+    "lineTo",
+    54,
+    300,
+  ],
+  Array [
+    "lineTo",
+    55,
+    300,
+  ],
+  Array [
+    "lineTo",
+    56,
+    300,
+  ],
+  Array [
+    "lineTo",
+    57,
+    300,
+  ],
+  Array [
+    "lineTo",
+    58,
+    300,
+  ],
+  Array [
+    "lineTo",
+    59,
+    300,
+  ],
+  Array [
+    "lineTo",
+    60,
+    300,
+  ],
+  Array [
+    "lineTo",
+    61,
+    300,
+  ],
+  Array [
+    "lineTo",
+    62,
+    300,
+  ],
+  Array [
+    "lineTo",
+    63,
+    300,
+  ],
+  Array [
+    "lineTo",
+    64,
+    300,
+  ],
+  Array [
+    "lineTo",
+    65,
+    300,
+  ],
+  Array [
+    "lineTo",
+    66,
+    300,
+  ],
+  Array [
+    "lineTo",
+    67,
+    300,
+  ],
+  Array [
+    "lineTo",
+    68,
+    300,
+  ],
+  Array [
+    "lineTo",
+    69,
+    300,
+  ],
+  Array [
+    "lineTo",
+    70,
+    300,
+  ],
+  Array [
+    "lineTo",
+    71,
+    300,
+  ],
+  Array [
+    "lineTo",
+    72,
+    300,
+  ],
+  Array [
+    "lineTo",
+    73,
+    300,
+  ],
+  Array [
+    "lineTo",
+    74,
+    300,
+  ],
+  Array [
+    "lineTo",
     75,
-    22.22222222222222,
-    225,
-  ],
-  Array [
-    "set fillStyle",
-    "#003eaa",
-  ],
-  Array [
-    "set fillStyle",
-    "#c5e1fe",
-  ],
-  Array [
-    "set fillStyle",
-    "#45a1ff",
-  ],
-  Array [
-    "fillRect",
-    88.88888888888889,
-    0,
-    22.22222222222222,
     300,
   ],
   Array [
-    "fillRect",
-    111.11111111111111,
-    0,
-    22.22222222222222,
+    "lineTo",
+    76,
     300,
   ],
   Array [
-    "fillRect",
-    133.33333333333331,
+    "lineTo",
+    77,
+    300,
+  ],
+  Array [
+    "lineTo",
+    78,
+    300,
+  ],
+  Array [
+    "lineTo",
+    79,
+    300,
+  ],
+  Array [
+    "lineTo",
+    80,
+    300,
+  ],
+  Array [
+    "lineTo",
+    81,
+    300,
+  ],
+  Array [
+    "lineTo",
+    82,
+    300,
+  ],
+  Array [
+    "lineTo",
+    83,
+    300,
+  ],
+  Array [
+    "lineTo",
+    84,
+    300,
+  ],
+  Array [
+    "lineTo",
+    85,
+    300,
+  ],
+  Array [
+    "lineTo",
+    86,
+    300,
+  ],
+  Array [
+    "lineTo",
+    87,
+    300,
+  ],
+  Array [
+    "lineTo",
+    88,
+    300,
+  ],
+  Array [
+    "lineTo",
+    89,
+    300,
+  ],
+  Array [
+    "lineTo",
+    90,
+    300,
+  ],
+  Array [
+    "lineTo",
+    91,
+    300,
+  ],
+  Array [
+    "lineTo",
+    92,
+    300,
+  ],
+  Array [
+    "lineTo",
+    93,
+    300,
+  ],
+  Array [
+    "lineTo",
+    94,
+    300,
+  ],
+  Array [
+    "lineTo",
+    95,
+    300,
+  ],
+  Array [
+    "lineTo",
+    96,
+    300,
+  ],
+  Array [
+    "lineTo",
+    97,
+    300,
+  ],
+  Array [
+    "lineTo",
+    98,
+    300,
+  ],
+  Array [
+    "lineTo",
+    99,
+    300,
+  ],
+  Array [
+    "lineTo",
+    100,
+    300,
+  ],
+  Array [
+    "lineTo",
+    101,
+    300,
+  ],
+  Array [
+    "lineTo",
+    102,
+    300,
+  ],
+  Array [
+    "lineTo",
+    103,
+    300,
+  ],
+  Array [
+    "lineTo",
+    104,
+    300,
+  ],
+  Array [
+    "lineTo",
+    105,
+    300,
+  ],
+  Array [
+    "lineTo",
+    106,
+    300,
+  ],
+  Array [
+    "lineTo",
+    107,
+    300,
+  ],
+  Array [
+    "lineTo",
+    108,
+    300,
+  ],
+  Array [
+    "lineTo",
+    109,
+    300,
+  ],
+  Array [
+    "lineTo",
+    110,
+    300,
+  ],
+  Array [
+    "lineTo",
+    111,
+    300,
+  ],
+  Array [
+    "lineTo",
+    112,
+    300,
+  ],
+  Array [
+    "lineTo",
+    113,
+    300,
+  ],
+  Array [
+    "lineTo",
+    114,
+    300,
+  ],
+  Array [
+    "lineTo",
+    115,
+    300,
+  ],
+  Array [
+    "lineTo",
+    116,
+    300,
+  ],
+  Array [
+    "lineTo",
+    117,
+    300,
+  ],
+  Array [
+    "lineTo",
+    118,
+    300,
+  ],
+  Array [
+    "lineTo",
+    119,
+    300,
+  ],
+  Array [
+    "lineTo",
+    120,
+    300,
+  ],
+  Array [
+    "lineTo",
+    121,
+    300,
+  ],
+  Array [
+    "lineTo",
+    122,
+    300,
+  ],
+  Array [
+    "lineTo",
+    123,
+    300,
+  ],
+  Array [
+    "lineTo",
+    124,
+    300,
+  ],
+  Array [
+    "lineTo",
+    125,
+    300,
+  ],
+  Array [
+    "lineTo",
+    126,
+    300,
+  ],
+  Array [
+    "lineTo",
+    127,
+    300,
+  ],
+  Array [
+    "lineTo",
+    128,
+    300,
+  ],
+  Array [
+    "lineTo",
+    129,
+    300,
+  ],
+  Array [
+    "lineTo",
+    130,
+    300,
+  ],
+  Array [
+    "lineTo",
+    131,
+    300,
+  ],
+  Array [
+    "lineTo",
+    132,
+    300,
+  ],
+  Array [
+    "lineTo",
+    133,
+    300,
+  ],
+  Array [
+    "lineTo",
+    134,
+    300,
+  ],
+  Array [
+    "lineTo",
+    135,
+    300,
+  ],
+  Array [
+    "lineTo",
+    136,
+    300,
+  ],
+  Array [
+    "lineTo",
+    137,
+    300,
+  ],
+  Array [
+    "lineTo",
+    138,
+    300,
+  ],
+  Array [
+    "lineTo",
+    139,
+    300,
+  ],
+  Array [
+    "lineTo",
+    140,
+    300,
+  ],
+  Array [
+    "lineTo",
+    141,
+    300,
+  ],
+  Array [
+    "lineTo",
+    142,
+    300,
+  ],
+  Array [
+    "lineTo",
+    143,
+    300,
+  ],
+  Array [
+    "lineTo",
+    144,
+    300,
+  ],
+  Array [
+    "lineTo",
+    145,
+    300,
+  ],
+  Array [
+    "lineTo",
+    146,
+    300,
+  ],
+  Array [
+    "lineTo",
+    147,
+    300,
+  ],
+  Array [
+    "lineTo",
+    148,
+    300,
+  ],
+  Array [
+    "lineTo",
+    149,
+    300,
+  ],
+  Array [
+    "lineTo",
+    150,
+    300,
+  ],
+  Array [
+    "lineTo",
+    151,
+    300,
+  ],
+  Array [
+    "lineTo",
+    152,
+    300,
+  ],
+  Array [
+    "lineTo",
+    153,
+    300,
+  ],
+  Array [
+    "lineTo",
+    154,
+    300,
+  ],
+  Array [
+    "lineTo",
+    155,
+    300,
+  ],
+  Array [
+    "lineTo",
+    156,
+    300,
+  ],
+  Array [
+    "lineTo",
+    157,
+    300,
+  ],
+  Array [
+    "lineTo",
+    158,
+    300,
+  ],
+  Array [
+    "lineTo",
+    159,
+    300,
+  ],
+  Array [
+    "lineTo",
+    160,
+    300,
+  ],
+  Array [
+    "lineTo",
+    161,
+    300,
+  ],
+  Array [
+    "lineTo",
+    162,
+    300,
+  ],
+  Array [
+    "lineTo",
+    163,
+    300,
+  ],
+  Array [
+    "lineTo",
+    164,
+    300,
+  ],
+  Array [
+    "lineTo",
+    165,
+    300,
+  ],
+  Array [
+    "lineTo",
+    166,
+    300,
+  ],
+  Array [
+    "lineTo",
+    167,
+    300,
+  ],
+  Array [
+    "lineTo",
+    168,
+    300,
+  ],
+  Array [
+    "lineTo",
+    169,
+    300,
+  ],
+  Array [
+    "lineTo",
+    170,
+    300,
+  ],
+  Array [
+    "lineTo",
+    171,
+    300,
+  ],
+  Array [
+    "lineTo",
+    172,
+    300,
+  ],
+  Array [
+    "lineTo",
+    173,
+    300,
+  ],
+  Array [
+    "lineTo",
+    174,
+    300,
+  ],
+  Array [
+    "lineTo",
+    175,
+    300,
+  ],
+  Array [
+    "lineTo",
+    176,
+    300,
+  ],
+  Array [
+    "lineTo",
+    177,
+    300,
+  ],
+  Array [
+    "lineTo",
+    178,
+    300,
+  ],
+  Array [
+    "lineTo",
+    179,
+    300,
+  ],
+  Array [
+    "lineTo",
+    180,
+    300,
+  ],
+  Array [
+    "lineTo",
+    181,
+    300,
+  ],
+  Array [
+    "lineTo",
+    182,
+    300,
+  ],
+  Array [
+    "lineTo",
+    183,
+    300,
+  ],
+  Array [
+    "lineTo",
+    184,
+    300,
+  ],
+  Array [
+    "lineTo",
+    185,
+    300,
+  ],
+  Array [
+    "lineTo",
+    186,
+    300,
+  ],
+  Array [
+    "lineTo",
+    187,
+    300,
+  ],
+  Array [
+    "lineTo",
+    188,
+    300,
+  ],
+  Array [
+    "lineTo",
+    189,
+    300,
+  ],
+  Array [
+    "lineTo",
+    190,
+    300,
+  ],
+  Array [
+    "lineTo",
+    191,
+    300,
+  ],
+  Array [
+    "lineTo",
+    192,
+    300,
+  ],
+  Array [
+    "lineTo",
+    193,
+    300,
+  ],
+  Array [
+    "lineTo",
+    194,
+    300,
+  ],
+  Array [
+    "lineTo",
+    195,
+    300,
+  ],
+  Array [
+    "lineTo",
+    196,
+    300,
+  ],
+  Array [
+    "lineTo",
+    195,
+    298.47619039937854,
+  ],
+  Array [
+    "lineTo",
+    194,
+    293.71428564190865,
+  ],
+  Array [
+    "lineTo",
+    193,
+    283.9999996125698,
+  ],
+  Array [
+    "lineTo",
+    192,
+    267.6190450787544,
+  ],
+  Array [
+    "lineTo",
+    191,
+    242.8571417927742,
+  ],
+  Array [
+    "lineTo",
+    190,
+    211.04761362075806,
+  ],
+  Array [
+    "lineTo",
+    189,
+    173.90475869178772,
+  ],
+  Array [
+    "lineTo",
+    188,
+    134.6666693687439,
+  ],
+  Array [
+    "lineTo",
+    187,
+    96.76190614700317,
+  ],
+  Array [
+    "lineTo",
+    186,
+    63.61904740333557,
+  ],
+  Array [
+    "lineTo",
+    185,
+    37.14285492897034,
+  ],
+  Array [
+    "lineTo",
+    184,
+    19.04761791229248,
+  ],
+  Array [
+    "lineTo",
+    183,
+    7.999992370605469,
+  ],
+  Array [
+    "lineTo",
+    182,
+    2.2857069969177246,
+  ],
+  Array [
+    "lineTo",
+    181,
+    0.19047260284423828,
+  ],
+  Array [
+    "lineTo",
+    180,
+    0,
+  ],
+  Array [
+    "lineTo",
+    179,
+    0,
+  ],
+  Array [
+    "lineTo",
+    178,
+    0,
+  ],
+  Array [
+    "lineTo",
+    177,
+    0,
+  ],
+  Array [
+    "lineTo",
+    176,
+    0,
+  ],
+  Array [
+    "lineTo",
+    175,
+    0,
+  ],
+  Array [
+    "lineTo",
+    174,
+    0,
+  ],
+  Array [
+    "lineTo",
+    173,
+    0,
+  ],
+  Array [
+    "lineTo",
+    172,
+    0,
+  ],
+  Array [
+    "lineTo",
+    171,
+    0,
+  ],
+  Array [
+    "lineTo",
+    170,
+    0,
+  ],
+  Array [
+    "lineTo",
+    169,
+    0,
+  ],
+  Array [
+    "lineTo",
+    168,
+    0,
+  ],
+  Array [
+    "lineTo",
+    167,
+    0,
+  ],
+  Array [
+    "lineTo",
+    166,
+    0,
+  ],
+  Array [
+    "lineTo",
+    165,
+    0,
+  ],
+  Array [
+    "lineTo",
+    164,
+    0,
+  ],
+  Array [
+    "lineTo",
+    163,
+    0,
+  ],
+  Array [
+    "lineTo",
+    162,
+    0,
+  ],
+  Array [
+    "lineTo",
+    161,
+    0,
+  ],
+  Array [
+    "lineTo",
+    160,
+    0,
+  ],
+  Array [
+    "lineTo",
+    159,
+    0,
+  ],
+  Array [
+    "lineTo",
+    158,
+    0,
+  ],
+  Array [
+    "lineTo",
+    157,
+    0,
+  ],
+  Array [
+    "lineTo",
+    156,
+    0,
+  ],
+  Array [
+    "lineTo",
+    155,
+    0,
+  ],
+  Array [
+    "lineTo",
+    154,
+    0,
+  ],
+  Array [
+    "lineTo",
+    153,
+    0,
+  ],
+  Array [
+    "lineTo",
+    152,
+    0,
+  ],
+  Array [
+    "lineTo",
+    151,
+    0,
+  ],
+  Array [
+    "lineTo",
+    150,
+    0,
+  ],
+  Array [
+    "lineTo",
+    149,
+    0,
+  ],
+  Array [
+    "lineTo",
+    148,
+    0,
+  ],
+  Array [
+    "lineTo",
+    147,
+    0,
+  ],
+  Array [
+    "lineTo",
+    146,
+    0,
+  ],
+  Array [
+    "lineTo",
+    145,
+    0,
+  ],
+  Array [
+    "lineTo",
+    144,
+    0,
+  ],
+  Array [
+    "lineTo",
+    143,
+    0,
+  ],
+  Array [
+    "lineTo",
+    142,
+    0,
+  ],
+  Array [
+    "lineTo",
+    141,
+    0,
+  ],
+  Array [
+    "lineTo",
+    140,
+    0,
+  ],
+  Array [
+    "lineTo",
+    139,
+    0,
+  ],
+  Array [
+    "lineTo",
+    138,
+    0,
+  ],
+  Array [
+    "lineTo",
+    137,
+    0,
+  ],
+  Array [
+    "lineTo",
+    136,
+    0,
+  ],
+  Array [
+    "lineTo",
+    135,
+    0,
+  ],
+  Array [
+    "lineTo",
+    134,
+    0,
+  ],
+  Array [
+    "lineTo",
+    133,
+    0,
+  ],
+  Array [
+    "lineTo",
+    132,
+    0,
+  ],
+  Array [
+    "lineTo",
+    131,
+    0,
+  ],
+  Array [
+    "lineTo",
+    130,
+    0,
+  ],
+  Array [
+    "lineTo",
+    129,
+    0,
+  ],
+  Array [
+    "lineTo",
+    128,
+    0,
+  ],
+  Array [
+    "lineTo",
+    127,
+    0,
+  ],
+  Array [
+    "lineTo",
+    126,
+    0,
+  ],
+  Array [
+    "lineTo",
+    125,
+    0,
+  ],
+  Array [
+    "lineTo",
+    124,
+    0,
+  ],
+  Array [
+    "lineTo",
+    123,
+    0,
+  ],
+  Array [
+    "lineTo",
+    122,
+    0,
+  ],
+  Array [
+    "lineTo",
+    121,
+    0,
+  ],
+  Array [
+    "lineTo",
+    120,
+    0,
+  ],
+  Array [
+    "lineTo",
+    119,
+    0,
+  ],
+  Array [
+    "lineTo",
+    118,
+    0,
+  ],
+  Array [
+    "lineTo",
+    117,
+    0,
+  ],
+  Array [
+    "lineTo",
+    116,
+    0,
+  ],
+  Array [
+    "lineTo",
+    115,
+    0,
+  ],
+  Array [
+    "lineTo",
+    114,
+    0,
+  ],
+  Array [
+    "lineTo",
+    113,
+    0,
+  ],
+  Array [
+    "lineTo",
+    112,
+    0,
+  ],
+  Array [
+    "lineTo",
+    111,
+    0,
+  ],
+  Array [
+    "lineTo",
+    110,
+    0,
+  ],
+  Array [
+    "lineTo",
+    109,
+    0,
+  ],
+  Array [
+    "lineTo",
+    108,
+    0,
+  ],
+  Array [
+    "lineTo",
+    107,
+    0,
+  ],
+  Array [
+    "lineTo",
+    106,
+    0,
+  ],
+  Array [
+    "lineTo",
+    105,
+    0,
+  ],
+  Array [
+    "lineTo",
+    104,
+    0,
+  ],
+  Array [
+    "lineTo",
+    103,
+    0,
+  ],
+  Array [
+    "lineTo",
+    102,
+    0,
+  ],
+  Array [
+    "lineTo",
+    101,
+    0,
+  ],
+  Array [
+    "lineTo",
+    100,
+    0,
+  ],
+  Array [
+    "lineTo",
+    99,
+    0,
+  ],
+  Array [
+    "lineTo",
+    98,
+    0,
+  ],
+  Array [
+    "lineTo",
+    97,
+    0,
+  ],
+  Array [
+    "lineTo",
+    96,
+    0,
+  ],
+  Array [
+    "lineTo",
+    95,
+    0,
+  ],
+  Array [
+    "lineTo",
+    94,
+    0,
+  ],
+  Array [
+    "lineTo",
+    93,
+    0,
+  ],
+  Array [
+    "lineTo",
+    92,
+    0,
+  ],
+  Array [
+    "lineTo",
+    91,
+    0,
+  ],
+  Array [
+    "lineTo",
+    90,
+    0,
+  ],
+  Array [
+    "lineTo",
+    89,
+    0,
+  ],
+  Array [
+    "lineTo",
+    88,
+    0,
+  ],
+  Array [
+    "lineTo",
+    87,
+    0,
+  ],
+  Array [
+    "lineTo",
+    86,
+    0,
+  ],
+  Array [
+    "lineTo",
+    85,
+    0,
+  ],
+  Array [
+    "lineTo",
+    84,
+    0,
+  ],
+  Array [
+    "lineTo",
+    83,
+    0,
+  ],
+  Array [
+    "lineTo",
+    82,
+    0,
+  ],
+  Array [
+    "lineTo",
+    81,
+    0,
+  ],
+  Array [
+    "lineTo",
+    80,
+    0,
+  ],
+  Array [
+    "lineTo",
+    79,
+    0,
+  ],
+  Array [
+    "lineTo",
+    78,
+    0,
+  ],
+  Array [
+    "lineTo",
+    77,
+    0,
+  ],
+  Array [
+    "lineTo",
+    76,
+    0,
+  ],
+  Array [
+    "lineTo",
     75,
-    22.22222222222222,
-    225,
+    0,
+  ],
+  Array [
+    "lineTo",
+    74,
+    0,
+  ],
+  Array [
+    "lineTo",
+    73,
+    0,
+  ],
+  Array [
+    "lineTo",
+    72,
+    0,
+  ],
+  Array [
+    "lineTo",
+    71,
+    0,
+  ],
+  Array [
+    "lineTo",
+    70,
+    0,
+  ],
+  Array [
+    "lineTo",
+    69,
+    0,
+  ],
+  Array [
+    "lineTo",
+    68,
+    0,
+  ],
+  Array [
+    "lineTo",
+    67,
+    0,
+  ],
+  Array [
+    "lineTo",
+    66,
+    0,
+  ],
+  Array [
+    "lineTo",
+    65,
+    0,
+  ],
+  Array [
+    "lineTo",
+    64,
+    0,
+  ],
+  Array [
+    "lineTo",
+    63,
+    0,
+  ],
+  Array [
+    "lineTo",
+    62,
+    0,
+  ],
+  Array [
+    "lineTo",
+    61,
+    0,
+  ],
+  Array [
+    "lineTo",
+    60,
+    0,
+  ],
+  Array [
+    "lineTo",
+    59,
+    0,
+  ],
+  Array [
+    "lineTo",
+    58,
+    0,
+  ],
+  Array [
+    "lineTo",
+    57,
+    0,
+  ],
+  Array [
+    "lineTo",
+    56,
+    0,
+  ],
+  Array [
+    "lineTo",
+    55,
+    0,
+  ],
+  Array [
+    "lineTo",
+    54,
+    0,
+  ],
+  Array [
+    "lineTo",
+    53,
+    0,
+  ],
+  Array [
+    "lineTo",
+    52,
+    0,
+  ],
+  Array [
+    "lineTo",
+    51,
+    0,
+  ],
+  Array [
+    "lineTo",
+    50,
+    0,
+  ],
+  Array [
+    "lineTo",
+    49,
+    0,
+  ],
+  Array [
+    "lineTo",
+    48,
+    0,
+  ],
+  Array [
+    "lineTo",
+    47,
+    0,
+  ],
+  Array [
+    "lineTo",
+    46,
+    0,
+  ],
+  Array [
+    "lineTo",
+    45,
+    0,
+  ],
+  Array [
+    "lineTo",
+    44,
+    0,
+  ],
+  Array [
+    "lineTo",
+    43,
+    0,
+  ],
+  Array [
+    "lineTo",
+    42,
+    0,
+  ],
+  Array [
+    "lineTo",
+    41,
+    0,
+  ],
+  Array [
+    "lineTo",
+    40,
+    0,
+  ],
+  Array [
+    "lineTo",
+    39,
+    0,
+  ],
+  Array [
+    "lineTo",
+    38,
+    0,
+  ],
+  Array [
+    "lineTo",
+    37,
+    0,
+  ],
+  Array [
+    "lineTo",
+    36,
+    0,
+  ],
+  Array [
+    "lineTo",
+    35,
+    0,
+  ],
+  Array [
+    "lineTo",
+    34,
+    0,
+  ],
+  Array [
+    "lineTo",
+    33,
+    0,
+  ],
+  Array [
+    "lineTo",
+    32,
+    0,
+  ],
+  Array [
+    "lineTo",
+    31,
+    0,
+  ],
+  Array [
+    "lineTo",
+    30,
+    0,
+  ],
+  Array [
+    "lineTo",
+    29,
+    0,
+  ],
+  Array [
+    "lineTo",
+    28,
+    0,
+  ],
+  Array [
+    "lineTo",
+    27,
+    0,
+  ],
+  Array [
+    "lineTo",
+    26,
+    0,
+  ],
+  Array [
+    "lineTo",
+    25,
+    0,
+  ],
+  Array [
+    "lineTo",
+    24,
+    0,
+  ],
+  Array [
+    "lineTo",
+    23,
+    0,
+  ],
+  Array [
+    "lineTo",
+    22,
+    0,
+  ],
+  Array [
+    "lineTo",
+    21,
+    0,
+  ],
+  Array [
+    "lineTo",
+    20,
+    0,
+  ],
+  Array [
+    "lineTo",
+    19,
+    0,
+  ],
+  Array [
+    "lineTo",
+    18,
+    0,
+  ],
+  Array [
+    "lineTo",
+    17,
+    0,
+  ],
+  Array [
+    "lineTo",
+    16,
+    0,
+  ],
+  Array [
+    "lineTo",
+    15,
+    0,
+  ],
+  Array [
+    "lineTo",
+    14,
+    0,
+  ],
+  Array [
+    "lineTo",
+    13,
+    0,
+  ],
+  Array [
+    "lineTo",
+    12,
+    0,
+  ],
+  Array [
+    "lineTo",
+    11,
+    0,
+  ],
+  Array [
+    "lineTo",
+    10,
+    0,
+  ],
+  Array [
+    "lineTo",
+    9,
+    0,
+  ],
+  Array [
+    "lineTo",
+    8,
+    0,
+  ],
+  Array [
+    "lineTo",
+    7,
+    0,
+  ],
+  Array [
+    "lineTo",
+    6,
+    1.7142891883850098,
+  ],
+  Array [
+    "lineTo",
+    5,
+    6.8571388721466064,
+  ],
+  Array [
+    "lineTo",
+    4,
+    17.142856121063232,
+  ],
+  Array [
+    "lineTo",
+    3,
+    39.42856192588806,
+  ],
+  Array [
+    "lineTo",
+    2,
+    73.71429204940796,
+  ],
+  Array [
+    "lineTo",
+    1,
+    131.99999928474426,
+  ],
+  Array [
+    "lineTo",
+    0,
+    186.85713708400726,
+  ],
+  Array [
+    "closePath",
+  ],
+  Array [
+    "fill",
   ],
   Array [
     "set fillStyle",
-    "#003eaa",
+    "#d7d7db60",
   ],
   Array [
     "set fillStyle",
-    "#c5e1fe",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc00",
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df60",
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df",
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df60",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "set globalCompositeOperation",
+    "lighter",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db60",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db",
+  ],
+  Array [
+    "beginPath",
+  ],
+  Array [
+    "moveTo",
+    70,
+    300,
+  ],
+  Array [
+    "lineTo",
+    71,
+    300,
+  ],
+  Array [
+    "lineTo",
+    72,
+    300,
+  ],
+  Array [
+    "lineTo",
+    73,
+    300,
+  ],
+  Array [
+    "lineTo",
+    74,
+    300,
+  ],
+  Array [
+    "lineTo",
+    75,
+    300,
+  ],
+  Array [
+    "lineTo",
+    76,
+    300,
+  ],
+  Array [
+    "lineTo",
+    77,
+    300,
+  ],
+  Array [
+    "lineTo",
+    78,
+    300,
+  ],
+  Array [
+    "lineTo",
+    79,
+    300,
+  ],
+  Array [
+    "lineTo",
+    80,
+    300,
+  ],
+  Array [
+    "lineTo",
+    81,
+    300,
+  ],
+  Array [
+    "lineTo",
+    82,
+    300,
+  ],
+  Array [
+    "lineTo",
+    83,
+    300,
+  ],
+  Array [
+    "lineTo",
+    84,
+    300,
+  ],
+  Array [
+    "lineTo",
+    85,
+    300,
+  ],
+  Array [
+    "lineTo",
+    86,
+    300,
+  ],
+  Array [
+    "lineTo",
+    87,
+    300,
+  ],
+  Array [
+    "lineTo",
+    88,
+    300,
+  ],
+  Array [
+    "lineTo",
+    89,
+    300,
+  ],
+  Array [
+    "lineTo",
+    90,
+    300,
+  ],
+  Array [
+    "lineTo",
+    91,
+    300,
+  ],
+  Array [
+    "lineTo",
+    92,
+    300,
+  ],
+  Array [
+    "lineTo",
+    93,
+    300,
+  ],
+  Array [
+    "lineTo",
+    94,
+    300,
+  ],
+  Array [
+    "lineTo",
+    95,
+    300,
+  ],
+  Array [
+    "lineTo",
+    96,
+    300,
+  ],
+  Array [
+    "lineTo",
+    97,
+    300,
+  ],
+  Array [
+    "lineTo",
+    98,
+    300,
+  ],
+  Array [
+    "lineTo",
+    99,
+    300,
+  ],
+  Array [
+    "lineTo",
+    100,
+    300,
+  ],
+  Array [
+    "lineTo",
+    101,
+    300,
+  ],
+  Array [
+    "lineTo",
+    102,
+    300,
+  ],
+  Array [
+    "lineTo",
+    103,
+    300,
+  ],
+  Array [
+    "lineTo",
+    104,
+    300,
+  ],
+  Array [
+    "lineTo",
+    105,
+    300,
+  ],
+  Array [
+    "lineTo",
+    106,
+    300,
+  ],
+  Array [
+    "lineTo",
+    107,
+    300,
+  ],
+  Array [
+    "lineTo",
+    108,
+    300,
+  ],
+  Array [
+    "lineTo",
+    109,
+    300,
+  ],
+  Array [
+    "lineTo",
+    110,
+    300,
+  ],
+  Array [
+    "lineTo",
+    111,
+    300,
+  ],
+  Array [
+    "lineTo",
+    112,
+    300,
+  ],
+  Array [
+    "lineTo",
+    113,
+    300,
+  ],
+  Array [
+    "lineTo",
+    114,
+    300,
+  ],
+  Array [
+    "lineTo",
+    115,
+    300,
+  ],
+  Array [
+    "lineTo",
+    116,
+    300,
+  ],
+  Array [
+    "lineTo",
+    117,
+    300,
+  ],
+  Array [
+    "lineTo",
+    118,
+    300,
+  ],
+  Array [
+    "lineTo",
+    119,
+    300,
+  ],
+  Array [
+    "lineTo",
+    120,
+    300,
+  ],
+  Array [
+    "lineTo",
+    121,
+    300,
+  ],
+  Array [
+    "lineTo",
+    122,
+    300,
+  ],
+  Array [
+    "lineTo",
+    123,
+    300,
+  ],
+  Array [
+    "lineTo",
+    124,
+    300,
+  ],
+  Array [
+    "lineTo",
+    125,
+    300,
+  ],
+  Array [
+    "lineTo",
+    126,
+    300,
+  ],
+  Array [
+    "lineTo",
+    127,
+    300,
+  ],
+  Array [
+    "lineTo",
+    128,
+    300,
+  ],
+  Array [
+    "lineTo",
+    129,
+    300,
+  ],
+  Array [
+    "lineTo",
+    130,
+    300,
+  ],
+  Array [
+    "lineTo",
+    131,
+    300,
+  ],
+  Array [
+    "lineTo",
+    132,
+    300,
+  ],
+  Array [
+    "lineTo",
+    133,
+    300,
+  ],
+  Array [
+    "lineTo",
+    134,
+    300,
+  ],
+  Array [
+    "lineTo",
+    135,
+    300,
+  ],
+  Array [
+    "lineTo",
+    136,
+    300,
+  ],
+  Array [
+    "lineTo",
+    137,
+    300,
+  ],
+  Array [
+    "lineTo",
+    138,
+    300,
+  ],
+  Array [
+    "lineTo",
+    139,
+    300,
+  ],
+  Array [
+    "lineTo",
+    140,
+    300,
+  ],
+  Array [
+    "lineTo",
+    141,
+    300,
+  ],
+  Array [
+    "lineTo",
+    142,
+    300,
+  ],
+  Array [
+    "lineTo",
+    143,
+    300,
+  ],
+  Array [
+    "lineTo",
+    144,
+    300,
+  ],
+  Array [
+    "lineTo",
+    145,
+    300,
+  ],
+  Array [
+    "lineTo",
+    146,
+    300,
+  ],
+  Array [
+    "lineTo",
+    147,
+    300,
+  ],
+  Array [
+    "lineTo",
+    148,
+    300,
+  ],
+  Array [
+    "lineTo",
+    149,
+    300,
+  ],
+  Array [
+    "lineTo",
+    150,
+    300,
+  ],
+  Array [
+    "lineTo",
+    151,
+    300,
+  ],
+  Array [
+    "lineTo",
+    152,
+    300,
+  ],
+  Array [
+    "lineTo",
+    151,
+    299.23809519968927,
+  ],
+  Array [
+    "lineTo",
+    150,
+    295.99999990314245,
+  ],
+  Array [
+    "lineTo",
+    149,
+    288.5714281350374,
+  ],
+  Array [
+    "lineTo",
+    148,
+    275.2380944788456,
+  ],
+  Array [
+    "lineTo",
+    147,
+    254.2857125401497,
+  ],
+  Array [
+    "lineTo",
+    146,
+    225.52380859851837,
+  ],
+  Array [
+    "lineTo",
+    145,
+    190.66666066646576,
+  ],
+  Array [
+    "lineTo",
+    144,
+    152.1904706954956,
+  ],
+  Array [
+    "lineTo",
+    143,
+    113.5237991809845,
+  ],
+  Array [
+    "lineTo",
+    142,
+    78.09523344039917,
+  ],
+  Array [
+    "lineTo",
+    141,
+    48.571425676345825,
+  ],
+  Array [
+    "lineTo",
+    140,
+    26.666665077209473,
+  ],
+  Array [
+    "lineTo",
+    139,
+    12.57142424583435,
+  ],
+  Array [
+    "lineTo",
+    138,
+    4.571431875228882,
+  ],
+  Array [
+    "lineTo",
+    137,
+    0.952380895614624,
+  ],
+  Array [
+    "lineTo",
+    136,
+    0,
+  ],
+  Array [
+    "lineTo",
+    135,
+    0,
+  ],
+  Array [
+    "lineTo",
+    134,
+    0,
+  ],
+  Array [
+    "lineTo",
+    133,
+    0,
+  ],
+  Array [
+    "lineTo",
+    132,
+    0,
+  ],
+  Array [
+    "lineTo",
+    131,
+    0,
+  ],
+  Array [
+    "lineTo",
+    130,
+    0,
+  ],
+  Array [
+    "lineTo",
+    129,
+    0,
+  ],
+  Array [
+    "lineTo",
+    128,
+    0,
+  ],
+  Array [
+    "lineTo",
+    127,
+    0,
+  ],
+  Array [
+    "lineTo",
+    126,
+    0,
+  ],
+  Array [
+    "lineTo",
+    125,
+    0,
+  ],
+  Array [
+    "lineTo",
+    124,
+    0,
+  ],
+  Array [
+    "lineTo",
+    123,
+    0,
+  ],
+  Array [
+    "lineTo",
+    122,
+    0,
+  ],
+  Array [
+    "lineTo",
+    121,
+    0,
+  ],
+  Array [
+    "lineTo",
+    120,
+    0,
+  ],
+  Array [
+    "lineTo",
+    119,
+    0,
+  ],
+  Array [
+    "lineTo",
+    118,
+    0,
+  ],
+  Array [
+    "lineTo",
+    117,
+    0,
+  ],
+  Array [
+    "lineTo",
+    116,
+    0,
+  ],
+  Array [
+    "lineTo",
+    115,
+    0,
+  ],
+  Array [
+    "lineTo",
+    114,
+    0,
+  ],
+  Array [
+    "lineTo",
+    113,
+    0,
+  ],
+  Array [
+    "lineTo",
+    112,
+    0,
+  ],
+  Array [
+    "lineTo",
+    111,
+    0,
+  ],
+  Array [
+    "lineTo",
+    110,
+    0,
+  ],
+  Array [
+    "lineTo",
+    109,
+    0,
+  ],
+  Array [
+    "lineTo",
+    108,
+    0,
+  ],
+  Array [
+    "lineTo",
+    107,
+    0,
+  ],
+  Array [
+    "lineTo",
+    106,
+    0,
+  ],
+  Array [
+    "lineTo",
+    105,
+    0,
+  ],
+  Array [
+    "lineTo",
+    104,
+    0,
+  ],
+  Array [
+    "lineTo",
+    103,
+    0,
+  ],
+  Array [
+    "lineTo",
+    102,
+    0,
+  ],
+  Array [
+    "lineTo",
+    101,
+    0,
+  ],
+  Array [
+    "lineTo",
+    100,
+    0,
+  ],
+  Array [
+    "lineTo",
+    99,
+    0,
+  ],
+  Array [
+    "lineTo",
+    98,
+    0,
+  ],
+  Array [
+    "lineTo",
+    97,
+    0,
+  ],
+  Array [
+    "lineTo",
+    96,
+    0,
+  ],
+  Array [
+    "lineTo",
+    95,
+    0,
+  ],
+  Array [
+    "lineTo",
+    94,
+    0,
+  ],
+  Array [
+    "lineTo",
+    93,
+    0,
+  ],
+  Array [
+    "lineTo",
+    92,
+    0,
+  ],
+  Array [
+    "lineTo",
+    91,
+    0,
+  ],
+  Array [
+    "lineTo",
+    90,
+    0,
+  ],
+  Array [
+    "lineTo",
+    89,
+    0,
+  ],
+  Array [
+    "lineTo",
+    88,
+    0,
+  ],
+  Array [
+    "lineTo",
+    87,
+    0,
+  ],
+  Array [
+    "lineTo",
+    86,
+    0,
+  ],
+  Array [
+    "lineTo",
+    85,
+    0,
+  ],
+  Array [
+    "lineTo",
+    84,
+    1.3333261013031006,
+  ],
+  Array [
+    "lineTo",
+    83,
+    5.714285373687744,
+  ],
+  Array [
+    "lineTo",
+    82,
+    14.857149124145508,
+  ],
+  Array [
+    "lineTo",
+    81,
+    30.47618865966797,
+  ],
+  Array [
+    "lineTo",
+    80,
+    54.28571105003357,
+  ],
+  Array [
+    "lineTo",
+    79,
+    85.33333539962769,
+  ],
+  Array [
+    "lineTo",
+    78,
+    121.90475463867188,
+  ],
+  Array [
+    "lineTo",
+    77,
+    160.95238029956818,
+  ],
+  Array [
+    "lineTo",
+    76,
+    199.04761612415314,
+  ],
+  Array [
+    "lineTo",
+    75,
+    232.76190161705017,
+  ],
+  Array [
+    "lineTo",
+    74,
+    259.99999791383743,
+  ],
+  Array [
+    "lineTo",
+    73,
+    279.0476180613041,
+  ],
+  Array [
+    "lineTo",
+    72,
+    290.8571429550648,
+  ],
+  Array [
+    "lineTo",
+    71,
+    297.14285703375936,
+  ],
+  Array [
+    "lineTo",
+    70,
+    299.61904759984463,
+  ],
+  Array [
+    "closePath",
+  ],
+  Array [
+    "fill",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db60",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc00",
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df60",
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df",
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df60",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "set globalCompositeOperation",
+    "lighter",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db60",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db",
+  ],
+  Array [
+    "beginPath",
+  ],
+  Array [
+    "moveTo",
+    70,
+    300,
+  ],
+  Array [
+    "lineTo",
+    71,
+    300,
+  ],
+  Array [
+    "lineTo",
+    72,
+    300,
+  ],
+  Array [
+    "lineTo",
+    73,
+    300,
+  ],
+  Array [
+    "lineTo",
+    74,
+    300,
+  ],
+  Array [
+    "lineTo",
+    75,
+    300,
+  ],
+  Array [
+    "lineTo",
+    76,
+    300,
+  ],
+  Array [
+    "lineTo",
+    77,
+    300,
+  ],
+  Array [
+    "lineTo",
+    78,
+    300,
+  ],
+  Array [
+    "lineTo",
+    79,
+    300,
+  ],
+  Array [
+    "lineTo",
+    80,
+    300,
+  ],
+  Array [
+    "lineTo",
+    81,
+    300,
+  ],
+  Array [
+    "lineTo",
+    82,
+    300,
+  ],
+  Array [
+    "lineTo",
+    83,
+    300,
+  ],
+  Array [
+    "lineTo",
+    84,
+    300,
+  ],
+  Array [
+    "lineTo",
+    85,
+    300,
+  ],
+  Array [
+    "lineTo",
+    86,
+    300,
+  ],
+  Array [
+    "lineTo",
+    87,
+    300,
+  ],
+  Array [
+    "lineTo",
+    88,
+    300,
+  ],
+  Array [
+    "lineTo",
+    89,
+    300,
+  ],
+  Array [
+    "lineTo",
+    90,
+    300,
+  ],
+  Array [
+    "lineTo",
+    91,
+    300,
+  ],
+  Array [
+    "lineTo",
+    92,
+    300,
+  ],
+  Array [
+    "lineTo",
+    93,
+    300,
+  ],
+  Array [
+    "lineTo",
+    94,
+    300,
+  ],
+  Array [
+    "lineTo",
+    95,
+    300,
+  ],
+  Array [
+    "lineTo",
+    96,
+    300,
+  ],
+  Array [
+    "lineTo",
+    97,
+    300,
+  ],
+  Array [
+    "lineTo",
+    98,
+    300,
+  ],
+  Array [
+    "lineTo",
+    99,
+    300,
+  ],
+  Array [
+    "lineTo",
+    100,
+    300,
+  ],
+  Array [
+    "lineTo",
+    101,
+    300,
+  ],
+  Array [
+    "lineTo",
+    102,
+    300,
+  ],
+  Array [
+    "lineTo",
+    103,
+    300,
+  ],
+  Array [
+    "lineTo",
+    104,
+    300,
+  ],
+  Array [
+    "lineTo",
+    105,
+    300,
+  ],
+  Array [
+    "lineTo",
+    106,
+    300,
+  ],
+  Array [
+    "lineTo",
+    107,
+    300,
+  ],
+  Array [
+    "lineTo",
+    108,
+    300,
+  ],
+  Array [
+    "lineTo",
+    109,
+    300,
+  ],
+  Array [
+    "lineTo",
+    110,
+    300,
+  ],
+  Array [
+    "lineTo",
+    111,
+    300,
+  ],
+  Array [
+    "lineTo",
+    112,
+    300,
+  ],
+  Array [
+    "lineTo",
+    113,
+    300,
+  ],
+  Array [
+    "lineTo",
+    114,
+    300,
+  ],
+  Array [
+    "lineTo",
+    115,
+    300,
+  ],
+  Array [
+    "lineTo",
+    116,
+    300,
+  ],
+  Array [
+    "lineTo",
+    117,
+    300,
+  ],
+  Array [
+    "lineTo",
+    118,
+    300,
+  ],
+  Array [
+    "lineTo",
+    119,
+    300,
+  ],
+  Array [
+    "lineTo",
+    120,
+    300,
+  ],
+  Array [
+    "lineTo",
+    121,
+    300,
+  ],
+  Array [
+    "lineTo",
+    122,
+    300,
+  ],
+  Array [
+    "lineTo",
+    123,
+    300,
+  ],
+  Array [
+    "lineTo",
+    124,
+    300,
+  ],
+  Array [
+    "lineTo",
+    125,
+    300,
+  ],
+  Array [
+    "lineTo",
+    126,
+    300,
+  ],
+  Array [
+    "lineTo",
+    127,
+    300,
+  ],
+  Array [
+    "lineTo",
+    128,
+    300,
+  ],
+  Array [
+    "lineTo",
+    129,
+    300,
+  ],
+  Array [
+    "lineTo",
+    130,
+    300,
+  ],
+  Array [
+    "lineTo",
+    131,
+    300,
+  ],
+  Array [
+    "lineTo",
+    132,
+    300,
+  ],
+  Array [
+    "lineTo",
+    133,
+    300,
+  ],
+  Array [
+    "lineTo",
+    134,
+    300,
+  ],
+  Array [
+    "lineTo",
+    135,
+    300,
+  ],
+  Array [
+    "lineTo",
+    136,
+    300,
+  ],
+  Array [
+    "lineTo",
+    137,
+    300,
+  ],
+  Array [
+    "lineTo",
+    138,
+    300,
+  ],
+  Array [
+    "lineTo",
+    139,
+    300,
+  ],
+  Array [
+    "lineTo",
+    140,
+    300,
+  ],
+  Array [
+    "lineTo",
+    141,
+    300,
+  ],
+  Array [
+    "lineTo",
+    142,
+    300,
+  ],
+  Array [
+    "lineTo",
+    143,
+    300,
+  ],
+  Array [
+    "lineTo",
+    144,
+    300,
+  ],
+  Array [
+    "lineTo",
+    145,
+    300,
+  ],
+  Array [
+    "lineTo",
+    146,
+    300,
+  ],
+  Array [
+    "lineTo",
+    147,
+    300,
+  ],
+  Array [
+    "lineTo",
+    148,
+    300,
+  ],
+  Array [
+    "lineTo",
+    149,
+    300,
+  ],
+  Array [
+    "lineTo",
+    150,
+    300,
+  ],
+  Array [
+    "lineTo",
+    151,
+    300,
+  ],
+  Array [
+    "lineTo",
+    152,
+    300,
+  ],
+  Array [
+    "lineTo",
+    151,
+    299.23809519968927,
+  ],
+  Array [
+    "lineTo",
+    150,
+    295.99999990314245,
+  ],
+  Array [
+    "lineTo",
+    149,
+    288.5714281350374,
+  ],
+  Array [
+    "lineTo",
+    148,
+    275.2380944788456,
+  ],
+  Array [
+    "lineTo",
+    147,
+    254.2857125401497,
+  ],
+  Array [
+    "lineTo",
+    146,
+    225.52380859851837,
+  ],
+  Array [
+    "lineTo",
+    145,
+    190.66666066646576,
+  ],
+  Array [
+    "lineTo",
+    144,
+    152.1904706954956,
+  ],
+  Array [
+    "lineTo",
+    143,
+    113.5237991809845,
+  ],
+  Array [
+    "lineTo",
+    142,
+    78.09523344039917,
+  ],
+  Array [
+    "lineTo",
+    141,
+    48.571425676345825,
+  ],
+  Array [
+    "lineTo",
+    140,
+    26.666665077209473,
+  ],
+  Array [
+    "lineTo",
+    139,
+    12.57142424583435,
+  ],
+  Array [
+    "lineTo",
+    138,
+    4.571431875228882,
+  ],
+  Array [
+    "lineTo",
+    137,
+    0.952380895614624,
+  ],
+  Array [
+    "lineTo",
+    136,
+    0,
+  ],
+  Array [
+    "lineTo",
+    135,
+    0,
+  ],
+  Array [
+    "lineTo",
+    134,
+    0,
+  ],
+  Array [
+    "lineTo",
+    133,
+    0,
+  ],
+  Array [
+    "lineTo",
+    132,
+    0,
+  ],
+  Array [
+    "lineTo",
+    131,
+    0,
+  ],
+  Array [
+    "lineTo",
+    130,
+    0,
+  ],
+  Array [
+    "lineTo",
+    129,
+    0,
+  ],
+  Array [
+    "lineTo",
+    128,
+    0,
+  ],
+  Array [
+    "lineTo",
+    127,
+    0,
+  ],
+  Array [
+    "lineTo",
+    126,
+    0,
+  ],
+  Array [
+    "lineTo",
+    125,
+    0,
+  ],
+  Array [
+    "lineTo",
+    124,
+    0,
+  ],
+  Array [
+    "lineTo",
+    123,
+    0,
+  ],
+  Array [
+    "lineTo",
+    122,
+    0,
+  ],
+  Array [
+    "lineTo",
+    121,
+    0,
+  ],
+  Array [
+    "lineTo",
+    120,
+    0,
+  ],
+  Array [
+    "lineTo",
+    119,
+    0,
+  ],
+  Array [
+    "lineTo",
+    118,
+    0,
+  ],
+  Array [
+    "lineTo",
+    117,
+    0,
+  ],
+  Array [
+    "lineTo",
+    116,
+    0,
+  ],
+  Array [
+    "lineTo",
+    115,
+    0,
+  ],
+  Array [
+    "lineTo",
+    114,
+    0,
+  ],
+  Array [
+    "lineTo",
+    113,
+    0,
+  ],
+  Array [
+    "lineTo",
+    112,
+    0,
+  ],
+  Array [
+    "lineTo",
+    111,
+    0,
+  ],
+  Array [
+    "lineTo",
+    110,
+    0,
+  ],
+  Array [
+    "lineTo",
+    109,
+    0,
+  ],
+  Array [
+    "lineTo",
+    108,
+    0,
+  ],
+  Array [
+    "lineTo",
+    107,
+    0,
+  ],
+  Array [
+    "lineTo",
+    106,
+    0,
+  ],
+  Array [
+    "lineTo",
+    105,
+    0,
+  ],
+  Array [
+    "lineTo",
+    104,
+    0,
+  ],
+  Array [
+    "lineTo",
+    103,
+    0,
+  ],
+  Array [
+    "lineTo",
+    102,
+    0,
+  ],
+  Array [
+    "lineTo",
+    101,
+    0,
+  ],
+  Array [
+    "lineTo",
+    100,
+    0,
+  ],
+  Array [
+    "lineTo",
+    99,
+    0,
+  ],
+  Array [
+    "lineTo",
+    98,
+    0,
+  ],
+  Array [
+    "lineTo",
+    97,
+    0,
+  ],
+  Array [
+    "lineTo",
+    96,
+    0,
+  ],
+  Array [
+    "lineTo",
+    95,
+    0,
+  ],
+  Array [
+    "lineTo",
+    94,
+    0,
+  ],
+  Array [
+    "lineTo",
+    93,
+    0,
+  ],
+  Array [
+    "lineTo",
+    92,
+    0,
+  ],
+  Array [
+    "lineTo",
+    91,
+    0,
+  ],
+  Array [
+    "lineTo",
+    90,
+    0,
+  ],
+  Array [
+    "lineTo",
+    89,
+    0,
+  ],
+  Array [
+    "lineTo",
+    88,
+    0,
+  ],
+  Array [
+    "lineTo",
+    87,
+    0,
+  ],
+  Array [
+    "lineTo",
+    86,
+    0,
+  ],
+  Array [
+    "lineTo",
+    85,
+    0,
+  ],
+  Array [
+    "lineTo",
+    84,
+    1.3333261013031006,
+  ],
+  Array [
+    "lineTo",
+    83,
+    5.714285373687744,
+  ],
+  Array [
+    "lineTo",
+    82,
+    14.857149124145508,
+  ],
+  Array [
+    "lineTo",
+    81,
+    30.47618865966797,
+  ],
+  Array [
+    "lineTo",
+    80,
+    54.28571105003357,
+  ],
+  Array [
+    "lineTo",
+    79,
+    85.33333539962769,
+  ],
+  Array [
+    "lineTo",
+    78,
+    121.90475463867188,
+  ],
+  Array [
+    "lineTo",
+    77,
+    160.95238029956818,
+  ],
+  Array [
+    "lineTo",
+    76,
+    199.04761612415314,
+  ],
+  Array [
+    "lineTo",
+    75,
+    232.76190161705017,
+  ],
+  Array [
+    "lineTo",
+    74,
+    259.99999791383743,
+  ],
+  Array [
+    "lineTo",
+    73,
+    279.0476180613041,
+  ],
+  Array [
+    "lineTo",
+    72,
+    290.8571429550648,
+  ],
+  Array [
+    "lineTo",
+    71,
+    297.14285703375936,
+  ],
+  Array [
+    "lineTo",
+    70,
+    299.61904759984463,
+  ],
+  Array [
+    "closePath",
+  ],
+  Array [
+    "fill",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db60",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc00",
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df60",
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df",
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df60",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
   ],
   Array [
     "clearRect",

--- a/src/test/components/__snapshots__/TrackThread.test.js.snap
+++ b/src/test/components/__snapshots__/TrackThread.test.js.snap
@@ -16,10 +16,10 @@ exports[`timeline/TrackThread matches the snapshot 1`] = `
     />
   </div>
   <div
-    className="timelineStackGraph"
+    className="threadStackGraph"
   >
     <canvas
-      className="timelineStackGraphCanvas"
+      className="threadStackGraphCanvas threadStackGraphCanvas"
       onMouseUp={[Function]}
     />
   </div>

--- a/src/test/fixtures/mocks/canvas-context.js
+++ b/src/test/fixtures/mocks/canvas-context.js
@@ -41,6 +41,7 @@ export default function mockCanvasContext() {
       createLinearGradient: spyLog('createLinearGradient', () => ({
         addColorStop: spyLog('addColorStop'),
       })),
+      createPattern: spyLog('createPattern', () => ({})),
       __flushDrawLog: (): Array<any> => {
         const oldLog = log.slice();
         log.splice(0, log.length);

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -81,6 +81,7 @@ type ProfileAction =
       +type: 'CHANGE_SELECTED_CALL_NODE',
       +threadIndex: ThreadIndex,
       +selectedCallNodePath: CallNodePath,
+      +optionalExpandedToCallNodePath: ?CallNodePath,
     |}
   | {|
       +type: 'FOCUS_CALL_TREE',

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -35,6 +35,7 @@ export type DataSource =
   | 'local'
   | 'public'
   | 'from-url';
+export type TimelineType = 'stack' | 'category';
 export type PreviewSelection =
   | {| +hasSelection: false, +isModifying: false |}
   | {|
@@ -249,6 +250,10 @@ type UrlStateAction =
       +type: 'POP_TRANSFORMS_FROM_STACK',
       +threadIndex: ThreadIndex,
       +firstPoppedFilterIndex: number,
+    |}
+  | {|
+      +type: 'CHANGE_TIMELINE_TYPE',
+      +timelineType: TimelineType,
     |}
   | {|
       +type: 'CHANGE_IMPLEMENTATION_FILTER',

--- a/src/types/reducers.js
+++ b/src/types/reducers.js
@@ -11,6 +11,7 @@ import type {
   ImplementationFilter,
   RequestedLib,
   TrackReference,
+  TimelineType,
 } from './actions';
 import type { TabSlug } from '../app-logic/tabs-handling';
 import type { Milliseconds, StartEndRange } from './units';
@@ -152,6 +153,7 @@ export type UrlState = {|
     callTreeSearchString: string,
     markersSearchString: string,
     transforms: TransformStacksPerThread,
+    timelineType: TimelineType,
     legacyThreadOrder: ThreadIndex[] | null,
     legacyHiddenThreads: ThreadIndex[] | null,
   |},

--- a/src/types/store.js
+++ b/src/types/store.js
@@ -7,18 +7,56 @@ import type { Store as ReduxStore } from 'redux'; // eslint-disable-line import/
 import type { Action as ActionsRef } from './actions';
 import type { State as StateRef } from './reducers';
 
+/**
+ * This file contains type definitions for the Redux store. Unlike the definitions
+ * that are provided by the libdef, the store will be opinionated by this project's
+ * specific union of Actions and the store's specific State type definition.
+ */
+
 // Re-export these here so they are easily available from wherever and avoids
 // circular dependencies.
 export type Action = ActionsRef;
 export type State = StateRef;
 
-// R = Result of a thunk action
-type ThunkDispatch = <R>(action: ThunkAction<R>) => R;
+type ThunkDispatch = <Returns>(action: ThunkAction<Returns>) => Returns;
 type PlainDispatch = (action: Action) => Action;
 export type GetState = () => State;
-export type ThunkAction<R> = (dispatch: Dispatch, GetState) => R;
-// The `dispatch` function can accept either a plain action or a thunk action.
-// This is similar to a type `(action: Action | ThunkAction) => any` except this
-// allows to type the return value as well.
+
+/**
+ * A thunk action
+ */
+export type ThunkAction<Returns> = (dispatch: Dispatch, GetState) => Returns;
+
+/**
+ * The `dispatch` function can accept either a plain action or a thunk action.
+ * This is similar to a type `(action: Action | ThunkAction) => any` except this
+ * allows to type the return value as well.
+ */
 export type Dispatch = PlainDispatch & ThunkDispatch;
+
+/**
+ * Export a store that is opinionated about our State definition, and the union
+ * of all Actions, as well as specific Dispatch behavior.
+ */
 export type Store = ReduxStore<State, Action, Dispatch>;
+
+/**
+ * This type definition takes a ThunkAction, and strips out the function
+ * that accepts the (Dispatch, GetState). This is effectively what wrapping
+ * the action in the connect function does.
+ *
+ * For instance:
+ *   (...Args) => (Dispatch, GetState) => Returns
+ *
+ * Gets transformed into:
+ *   (...Args) => Returns
+ */
+export type ConnectedThunk<Fn> = $Call<
+  <Args, Returns>(
+    // Take as input a ThunkAction.
+    (...Args) => (Dispatch, GetState) => Returns
+    // Return the wrapped action.
+  ) => (...Args) => Returns,
+  // Apply this to the function:
+  Fn
+>;

--- a/src/types/units.js
+++ b/src/types/units.js
@@ -16,7 +16,8 @@ export type CssPixels = number;
 
 /**
  * The size of the pixels actually present on the device, particularly used on canvas
- * sizing.
+ * sizing. For instance on a device with a devicePixelRatio of 2, the DevicePixels
+ * will be  twice as large as CssPixels.
  */
 export type DevicePixels = number;
 


### PR DESCRIPTION
@mstange This is now ready for review.

This PR is work split off from #1072 it combines the commits of:

bead04b67 Fix thread stack graph highlighting.
9fdb49e21 Make clicking in the graph work correctly:
6b541b073 Rename things.
932a00d72 Define a total order of call nodes.
529e5b174 Use striped patterns for samples that were filtered out.
a462be8b7 Reduce opacity for non-selected samples in the thread activity graph some more.
3e061be24 Use small fills for non-empty shapes.
90cb948e1 Make clicking the SelectedThreadActivityGraph work again.
4abd5e40b Render to canvas during React render and not via rAF.
b0351155e Use Viewport to zoom / pan the selected thread activity graph.
39f2bed62 Take the y position of the click into account to select a sample of the clicked category.
47413e656 Use the filtered thread to calculate the new selected call node.
ba1c90c60 onStackClick -> onSampleClick
06a6455d2 Fix tests.
9158e8f94 Use #RRGGBBAA syntax to make photon colors transparent
64c47a649 Fix unused variable lints.
6d4661c28 Fix formatting.
ac3abfcbf Add the thread activity graph and the thread stack graph for the selected thread to the call tree tab.
dffcf0058 Add ThreadActivityGraph component and use it in place of ThreadStackGraph.

I would like to (as much as possible) follow-up with work that is non-breaking. My currently planned follow-ups are:

 * Getting really good test coverage.
 * I think making the timeline resizable #67 is even more important now.
 * Make tweaks to the UX and colors.