### PR TITLE
Persist the marker search string in the URL

### DIFF
--- a/src/app-logic/url-handling.js
+++ b/src/app-logic/url-handling.js
@@ -174,9 +174,9 @@ export function urlStateToUrlObject(urlState: UrlState): UrlObject {
       break;
     }
     case 'marker-table':
+    case 'marker-chart':
       query.markerSearch = urlState.profileSpecific.markersSearchString;
       break;
-    case 'marker-chart':
     case 'network-chart':
       break;
     default:


### PR DESCRIPTION
I found this issue while testing https://github.com/devtools-html/perf.html/pull/1286.
The fix was straightforward but I added a test to make it easier to add more tests in the future.