### PR TITLE
Document and update the ProfileMeta type

### DIFF
--- a/src/types/gecko-profile.js
+++ b/src/types/gecko-profile.js
@@ -172,7 +172,7 @@ export type GeckoProfileMeta = {|
   platform: string,
   processType: number,
   product: string,
-  stackwalk: number,
+  stackwalk: 0 | 1,
   toolkit: string,
   version: number,
   // The appBuildID, sourceURL, physicalCPUs and logicalCPUs properties landed


### PR DESCRIPTION
Resolves #1317.

The primary reason for this PR is to make more of the `ProfileMeta` fields optional for #1317, but while I was there I updated the documentation.

@canaltinova I'm marking you for review, since this is updating what we're documenting from the platform side of things. I went through and read the Gecko source to ensure that we have an accurate definition.

The definition update made me touch a few test fixtures, but other than that there were no user-facing code was touched.