### PR TITLE
Fixes #883 Adjust tooltip space to avoid information truncation

### DIFF
--- a/src/components/shared/Tooltip.js
+++ b/src/components/shared/Tooltip.js
@@ -89,12 +89,14 @@ export default class Tooltip extends React.PureComponent<Props, State> {
     let offsetY = 0;
     if (interiorElement) {
       if (
-        mouseY + interiorElement.offsetHeight + MOUSE_OFFSET >
-        window.innerHeight
+        interiorElement.offsetHeight + MOUSE_OFFSET <
+        window.innerHeight - mouseY
       ) {
+        offsetY = 0;
+      } else if (interiorElement.offsetHeight + MOUSE_OFFSET < mouseY) {
         offsetY = interiorElement.offsetHeight + MOUSE_OFFSET;
       } else {
-        offsetY = -MOUSE_OFFSET;
+        offsetY = mouseY;
       }
     }
 


### PR DESCRIPTION
Previously, long tooltips were flipped upwards and so
sometimes, it goes beyond the window's top edge.
This makes it difficult to view the information.
This fix will make sure that, the tooltip header always
stays within the window.

Resolves: #883