### PR TITLE
Disable automatic integrity migration in yarn.lock for recent yarn versions

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+unsafe-disable-integrity-migration "true"


### PR DESCRIPTION
Yarn version 1.10 changed how they manage the integrity and introduced a new field `integrity` in yarn.lock. Versions 1.10 and 1.11 make the migration automatically, version 1.12 defaults to false. In this PR I set this option explicitly so that users of these versions of yarn don't migrate `yarn.lock` without thinking.

In the future we'll want to migrate but we'll choose when we'll do it.