### PR TITLE
Handle 'tracing' markers of type TRACING_EVENT (no interval property) as zero-duration tracing markers.

### DIFF
--- a/src/profile-logic/marker-data.js
+++ b/src/profile-logic/marker-data.js
@@ -206,7 +206,7 @@ export function getTracingMarkers(
         data: null,
       };
       tracingMarkers.push(marker);
-    } else if (data.type === 'tracing') {
+    } else if (data.type === 'tracing' && data.interval) {
       // Tracing markers are created from two distinct markers that are created at
       // the start and end of whatever code that is running that we care about.
       // This is implemented by AutoProfilerTracing in Gecko.

--- a/src/test/fixtures/profiles/gecko-profile.js
+++ b/src/test/fixtures/profiles/gecko-profile.js
@@ -380,6 +380,14 @@ function _createGeckoThread(): GeckoThread {
             type: 'tracing',
           },
         ],
+        [
+          12, // ArbitraryName
+          21,
+          {
+            category: 'ArbitraryCategory',
+            type: 'tracing',
+          },
+        ],
       ],
     },
     stringTable: [
@@ -395,6 +403,7 @@ function _createGeckoThread(): GeckoThread {
       'MinorGC',
       'Rasterize',
       'UserTiming',
+      'ArbitraryName',
     ],
   };
 }

--- a/src/test/unit/marker-data.test.js
+++ b/src/test/unit/marker-data.test.js
@@ -12,8 +12,8 @@ describe('getTracingMarkers', function() {
   const thread = profile.threads[0];
   const tracingMarkers = getTracingMarkers(thread.markers, thread.stringTable);
 
-  it('creates 10 tracing markers given the test data', function() {
-    expect(tracingMarkers.length).toEqual(10);
+  it('creates 11 tracing markers given the test data', function() {
+    expect(tracingMarkers.length).toEqual(11);
   });
   it('creates a tracing marker even if there is no start or end time', function() {
     expect(tracingMarkers[1]).toMatchObject({
@@ -32,7 +32,7 @@ describe('getTracingMarkers', function() {
     });
   });
   it('should fold the two reflow markers into one tracing marker', function() {
-    expect(tracingMarkers.length).toEqual(10);
+    expect(tracingMarkers.length).toEqual(11);
     expect(tracingMarkers[2]).toMatchObject({
       start: 3,
       dur: 5,
@@ -100,6 +100,15 @@ describe('getTracingMarkers', function() {
       dur: 1,
       name: 'Reflow',
       title: null,
+    });
+  });
+  it('should handle arbitrary event tracing markers correctly', function() {
+    expect(tracingMarkers[10]).toMatchObject({
+      start: 21,
+      dur: 0,
+      name: 'ArbitraryName',
+      title: null,
+      data: { category: 'ArbitraryCategory', type: 'tracing' },
     });
   });
 });

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -44,6 +44,11 @@ export type PaintProfilerMarkerTracing = {
   interval: 'start' | 'end',
 };
 
+export type ArbitraryEventTracing = {|
+  +type: 'tracing',
+  +category: string,
+|};
+
 export type PhaseTimes<Unit> = { [phase: string]: Unit };
 
 type GCSliceData_Shared = {
@@ -430,4 +435,5 @@ export type MarkerPayload_Gecko =
   | FrameConstructionMarkerPayload
   | DummyForTestsMarkerPayload
   | VsyncTimestampPayload
+  | ArbitraryEventTracing
   | null;


### PR DESCRIPTION
Example profile: https://perfht.ml/2EeZBr0

GeckoProfiler.h exposes a way of adding point-of-time markers (no duration) that have both a name and a category, using `PROFILER_TRACING("Category", "Name", TRACING_EVENT)`. This way of adding markers is mostly unused, but if it *is* used, perf.html doesn't display the markers.
The change in this PR makes us display them.