### PR TITLE
Remove the vsync field from VsyncTimestampPayload

### DIFF
--- a/src/profile-logic/processed-profile-versioning.js
+++ b/src/profile-logic/processed-profile-versioning.js
@@ -742,6 +742,9 @@ const _upgraders = {
     // The type field on some markers were missing. Renamed category field of
     // VsyncTimestamp and LayerTranslation marker payloads to type and added
     // a type field to Screenshot marker payload.
+    // In addition to that, we removed the `vsync` field from VsyncTimestamp
+    // since we don't use that field and have a timestamp for them already.
+    // Old profiles might still have this property.
     for (const thread of profile.threads) {
       const { stringArray, markers } = thread;
       const stringTable = new UniqueStringArray(stringArray);

--- a/src/test/fixtures/profiles/gecko-profile.js
+++ b/src/test/fixtures/profiles/gecko-profile.js
@@ -197,7 +197,7 @@ function _createGeckoThread(): GeckoThread {
           },
         ],
         // This marker is filtered out
-        [4, 2, { type: 'VsyncTimestamp', vsync: 0 }],
+        [4, 2, { type: 'VsyncTimestamp' }],
         [
           5, // Reflow
           3,

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -350,7 +350,6 @@ type StyleMarkerPayload_Shared = {
 
 type VsyncTimestampPayload = {|
   type: 'VsyncTimestamp',
-  vsync: 0,
 |};
 
 export type ScreenshotPayload = {|


### PR DESCRIPTION
We don't need to create an upgrader for that since this won't affect the old profiles. It will continue to recognize these markers even if there are vsync field.
Actually, It looks like it wasn't recognizing the `VsyncTimestampPayload` type before because of the `vsync: 0` line. In real world, vsync field was a timestamp and it can't be zero.

We are removing the vsync field in [Bug 1349607](https://bugzilla.mozilla.org/show_bug.cgi?id=1349607)