### PR TITLE
Display the function name in breadcrumbs 

### DIFF
--- a/src/profile-logic/transforms.js
+++ b/src/profile-logic/transforms.js
@@ -38,8 +38,6 @@ import type {
   TransformStack,
 } from '../types/transforms';
 
-
-
 /**
  * This file contains the functions and logic for working with and applying transforms
  * to profile data.
@@ -1426,4 +1424,3 @@ export function funcHasRecursiveCall(
   }
   return false;
 }
-

--- a/src/profile-logic/transforms.js
+++ b/src/profile-logic/transforms.js
@@ -14,6 +14,7 @@ import {
 import { timeCode } from '../utils/time-code';
 import { assertExhaustiveCheck, convertToTransformType } from '../utils/flow';
 import { CallTree } from '../profile-logic/call-tree';
+import { getFunctionName } from './function-info';
 
 import type {
   Thread,
@@ -36,6 +37,8 @@ import type {
   TransformType,
   TransformStack,
 } from '../types/transforms';
+
+
 
 /**
  * This file contains the functions and logic for working with and applying transforms
@@ -327,7 +330,7 @@ export function getTransformLabels(
         throw assertExhaustiveCheck(transform);
     }
     const nameIndex = funcTable.name[funcIndex];
-    const funcName = stringTable.getString(nameIndex);
+    const funcName = getFunctionName(stringTable.getString(nameIndex));
 
     switch (transform.type) {
       case 'focus-subtree':
@@ -1423,3 +1426,4 @@ export function funcHasRecursiveCall(
   }
   return false;
 }
+


### PR DESCRIPTION
This is fix for issue #407 . The function name is now displaying properly .