### PR TITLE
[deploy-preview] Show JS entry and exit points in the JS only call tree

### DIFF
--- a/docs-developer/gecko-profile-format.md
+++ b/docs-developer/gecko-profile-format.md
@@ -186,16 +186,19 @@ The source data format is de-duplicated to make it quicker to transfer in the JS
       frameTable: {
         schema: {
           location: 0,
-          implementation: 1,
-          optimizations: 2,
-          line: 3,
-          category: 4
+          relevantForJS: 1,
+          implementation: 2,
+          optimizations: 3,
+          line: 4,
+          column: 5,
+          category: 6
         },
         data: [
           [
             18,    // index into stringTable, points to strings like:
                    // JS: "Startup::XRE_Main"
                    // C++: "0x7fff7d962da1"
+            false, // for label frames, whether this label should be shown in "JS only" stacks
             40,    // for JS frames, an index into the string table, usually "Baseline" or "Ion"
             null,  // JSON info about JIT optimizations.
             1536,  // The line of code

--- a/src/profile-logic/call-tree.js
+++ b/src/profile-logic/call-tree.js
@@ -201,7 +201,6 @@ export class CallTree {
       const categoryIndex = this._callNodeTable.category[callNodeIndex];
       const resourceIndex = this._funcTable.resource[funcIndex];
       const resourceType = this._resourceTable.type[resourceIndex];
-      const isJS = this._funcTable.isJS[funcIndex];
       const libName = this._getOriginAnnotation(funcIndex);
 
       let icon = null;
@@ -225,8 +224,7 @@ export class CallTree {
         totalTimePercent: `${(100 * totalTimeRelative).toFixed(1)}%`,
         name: funcName,
         lib: libName,
-        // Dim platform pseudo-stacks.
-        dim: !isJS && this._jsOnly,
+        dim: false,
         categoryName: this._categories[categoryIndex].name,
         categoryColor: this._categories[categoryIndex].color,
         icon,

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -403,9 +403,10 @@ export function getTimingsForPath(
     timings.value += interval;
 
     // Step 2: find the implementation value for this stack
-    const implementation = funcTable.isJS[funcIndex]
-      ? getJsImplementationForStack(stackIndex, thread)
-      : 'native';
+    const implementation =
+      funcTable.isJS[funcIndex] || funcTable.relevantForJS[funcIndex]
+        ? getJsImplementationForStack(stackIndex, thread)
+        : 'native';
 
     // Step 3: increment the right value in the implementation breakdown
     if (timings.breakdownByImplementation === null) {
@@ -630,7 +631,8 @@ export function filterThreadByImplementation(
     case 'js':
       return _filterThreadByFunc(
         thread,
-        funcIndex => funcTable.isJS[funcIndex],
+        funcIndex =>
+          funcTable.isJS[funcIndex] || funcTable.relevantForJS[funcIndex],
         defaultCategory
       );
     default:

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -744,6 +744,7 @@ export function collapsePlatformStackFrames(thread: Thread): Thread {
       length: funcTable.length,
       name: funcTable.name.slice(),
       resource: funcTable.resource.slice(),
+      relevantForJS: funcTable.relevantForJS.slice(),
       address: funcTable.address.slice(),
       isJS: funcTable.isJS.slice(),
       fileName: funcTable.fileName.slice(),

--- a/src/profile-logic/transforms.js
+++ b/src/profile-logic/transforms.js
@@ -1020,7 +1020,10 @@ const FUNC_MATCHES = {
     return !isProbablyJitCode;
   },
   js: (thread: Thread, funcIndex: IndexIntoFuncTable): boolean => {
-    return thread.funcTable.isJS[funcIndex];
+    return (
+      thread.funcTable.isJS[funcIndex] ||
+      thread.funcTable.relevantForJS[funcIndex]
+    );
   },
 };
 

--- a/src/profile-logic/transforms.js
+++ b/src/profile-logic/transforms.js
@@ -770,6 +770,7 @@ export function collapseResource(
     isJS: funcTable.isJS.slice(),
     name: funcTable.name.slice(),
     resource: funcTable.resource.slice(),
+    relevantForJS: funcTable.relevantForJS.slice(),
     fileName: funcTable.fileName.slice(),
     lineNumber: funcTable.lineNumber.slice(),
     length: funcTable.length,

--- a/src/test/fixtures/profiles/call-nodes.js
+++ b/src/test/fixtures/profiles/call-nodes.js
@@ -49,6 +49,7 @@ export default function getProfile(): Profile {
     address: Array(funcNames.length).fill(''),
     isJS: Array(funcNames.length).fill(false),
     resource: Array(funcNames.length).fill(-1),
+    relevantForJS: Array(funcNames.length).fill(false),
     fileName: Array(funcNames.length).fill(''),
     lineNumber: Array(funcNames.length).fill(null),
     length: funcNames.length,

--- a/src/test/fixtures/profiles/gecko-profile.js
+++ b/src/test/fixtures/profiles/gecko-profile.js
@@ -166,18 +166,19 @@ function _createGeckoThread(): GeckoThread {
     frameTable: {
       schema: {
         location: 0,
-        implementation: 1,
-        optimizations: 2,
-        line: 3,
-        column: 4,
-        category: 5,
+        relevantForJS: 1,
+        implementation: 2,
+        optimizations: 3,
+        line: 4,
+        column: 5,
+        category: 6,
       },
       data: [
-        [0, null, null, null, null], // (root)
-        [1, null, null, null, null], // 0x100000f84
-        [2, null, null, null, null], // 0x100001a45
-        [3, null, null, 4391, 16], // Startup::XRE_Main, line 4391, category 16
-        [7, 6, null, 34, null], // frobnicate, implementation 'baseline', line 34
+        [0, false, null, null, null, null], // (root)
+        [1, false, null, null, null, null], // 0x100000f84
+        [2, false, null, null, null, null], // 0x100001a45
+        [3, false, null, null, 4391, 16], // Startup::XRE_Main, line 4391, category 16
+        [7, false, 6, null, 34, null], // frobnicate, implementation 'baseline', line 34
       ],
     },
     markers: {

--- a/src/test/fixtures/profiles/timings-with-js.js
+++ b/src/test/fixtures/profiles/timings-with-js.js
@@ -61,22 +61,23 @@ function _createGeckoThread(name: string): GeckoThread {
     frameTable: {
       schema: {
         location: 0,
-        implementation: 1,
-        optimizations: 2,
-        line: 3,
-        column: 4,
-        category: 5,
+        relevantForJS: 1,
+        implementation: 2,
+        optimizations: 3,
+        line: 4,
+        column: 5,
+        category: 6,
       },
       data: [
-        [0, null, null, null, null], // 0: (root)
-        [1, null, null, null, null], // 1: 0x100000f84
-        [2, null, null, null, null], // 2: 0x100001a45
-        [3, null, null, 4391, 16], // 3: Startup::XRE_Main, line 4391, category 16
-        [7, 6, null, 1, null], // 4: javascriptOne, implementation 'baseline', line 1
-        [8, 6, null, 2, null], // 5: javascriptTwo, implementation 'baseline', line 2
-        [9, null, null, null, null], // 6: 0x10000f0f0
-        [10, null, null, null, null], // 7: 0x100fefefe
-        [11, null, null, 3, null], // 8: javascriptThree, implementation null, line 3
+        [0, false, null, null, null, null], // 0: (root)
+        [1, false, null, null, null, null], // 1: 0x100000f84
+        [2, false, null, null, null, null], // 2: 0x100001a45
+        [3, false, null, null, 4391, 16], // 3: Startup::XRE_Main, line 4391, category 16
+        [7, false, 6, null, 1, null], // 4: javascriptOne, implementation 'baseline', line 1
+        [8, false, 6, null, 2, null], // 5: javascriptTwo, implementation 'baseline', line 2
+        [9, false, null, null, null, null], // 6: 0x10000f0f0
+        [10, false, null, null, null, null], // 7: 0x100fefefe
+        [11, false, null, null, 3, null], // 8: javascriptThree, implementation null, line 3
       ],
     },
     markers: {

--- a/src/test/unit/process-profile.test.js
+++ b/src/test/unit/process-profile.test.js
@@ -78,6 +78,7 @@ describe('extract functions and resource from location strings', function() {
       frameFuncs,
     ] = extractFuncsAndResourcesFromFrameLocations(
       locationIndexes,
+      locationIndexes.map(() => false),
       stringTable,
       libs,
       extensions

--- a/src/types/gecko-profile.js
+++ b/src/types/gecko-profile.js
@@ -77,11 +77,12 @@ export type GeckoSampleStruct = {
 export type GeckoFrameTable = {
   schema: {
     location: 0,
-    implementation: 1,
-    optimizations: 2,
-    line: 3,
-    column: 4,
-    category: 5,
+    relevantForJS: 1,
+    implementation: 2,
+    optimizations: 3,
+    line: 4,
+    column: 5,
+    category: 6,
   },
   data: Array<
     [
@@ -89,6 +90,8 @@ export type GeckoFrameTable = {
       // JS: "Startup::XRE_Main"
       // C++: "0x7fff7d962da1"
       IndexIntoStringTable,
+      // for label frames, whether this frame should be shown in "JS only" stacks
+      boolean,
       // for JS frames, an index into the string table, usually "Baseline" or "Ion"
       null | IndexIntoStringTable,
       // JSON info about JIT optimizations.
@@ -113,6 +116,7 @@ export type GeckoFrameTable = {
 
 export type GeckoFrameStruct = {
   location: IndexIntoStringTable[],
+  relevantForJS: Array<boolean>,
   implementation: Array<null | IndexIntoStringTable>,
   optimizations: Array<null | Object>,
   line: Array<null | number>,

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -146,6 +146,7 @@ export type FuncTable = {
   length: number,
   name: IndexIntoStringTable[],
   resource: Array<IndexIntoResourceTable | -1>,
+  relevantForJS: Array<boolean>,
   fileName: Array<IndexIntoStringTable | null>,
   lineNumber: Array<number | null>,
 };


### PR DESCRIPTION
Fixes #1392.

[Deploy preview link](https://deploy-preview-1393--perf-html.netlify.com/public/7907c99d76a627d02bef47ba74f51f9f9084a237/calltree/?globalTrackOrder=0-1-2-3-4-5&hiddenGlobalTracks=1-2-3-4&hiddenLocalTracksByPid=28442-0~32772-0~28441-0~28443-0~28445-0-1-2-3-4&implementation=js&invertCallstack&localTrackOrderByPid=28439-1-0~28442-0~32772-0~28441-0~28443-0~28445-5-0-1-2-3-4~&react_perf&thread=10&v=3)