### PR TITLE
ThreadActivityGraph tests

### DIFF
--- a/src/test/components/ThreadActivityGraph.test.js
+++ b/src/test/components/ThreadActivityGraph.test.js
@@ -1,0 +1,188 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import type { Viewport } from '../../components/shared/chart/Viewport';
+import type { Profile, IndexIntoSamplesTable } from '../../types/profile';
+import type { CssPixels } from '../../types/units';
+
+import * as React from 'react';
+import { Provider } from 'react-redux';
+import { mount } from 'enzyme';
+
+import SelectedThreadActivityGraph from '../../components/shared/thread/SelectedActivityGraph';
+import { selectedThreadSelectors } from '../../reducers/profile-view';
+import mockCanvasContext from '../fixtures/mocks/canvas-context';
+import mockRaf from '../fixtures/mocks/request-animation-frame';
+import { storeWithProfile } from '../fixtures/stores';
+import { getBoundingBox, getMouseEvent } from '../fixtures/utils';
+
+import { getProfileFromTextSamples } from '../fixtures/profiles/make-profile';
+
+// The following constants determine the size of the drawn graph.
+const SAMPLE_COUNT = 8;
+const PIXELS_PER_SAMPLE = 10;
+const GRAPH_WIDTH = PIXELS_PER_SAMPLE * SAMPLE_COUNT;
+const GRAPH_HEIGHT = 10;
+function getSamplesPixelPosition(
+  sampleIndex: IndexIntoSamplesTable
+): CssPixels {
+  // Compute the pixel position of the center of a given sample.
+  return sampleIndex * PIXELS_PER_SAMPLE + PIXELS_PER_SAMPLE * 0.5;
+}
+
+/**
+ * This test is asserting behavior of the ThreadStackGraph component. It does this
+ * by using the SelectedThreadActivityGraph component, which is a connected version
+ * that is used in the CallTree.
+ */
+describe('SelectedThreadActivityGraph', function() {
+  function getSamplesProfile() {
+    return getProfileFromTextSamples(`
+      A[cat:DOM]  A[cat:DOM]       A[cat:DOM]    A[cat:DOM]    A[cat:DOM]    A[cat:DOM]   A[cat:DOM]    A[cat:DOM]
+      B           B                B             B             B             B            B             B
+      C           C                H[cat:Other]  H[cat:Other]  H[cat:Other]  H[cat:Other] H[cat:Other]  C
+      D           F[cat:Graphics]  I             I             I             I            I             F[cat:Graphics]
+      E           G                                                                                     G
+    `).profile;
+  }
+
+  function setup(profile: Profile = getSamplesProfile()) {
+    const store = storeWithProfile(profile);
+    const { getState, dispatch } = store;
+    const threadIndex = 0;
+    const flushRafCalls = mockRaf();
+    const ctx = mockCanvasContext();
+
+    jest
+      .spyOn(HTMLCanvasElement.prototype, 'getContext')
+      .mockImplementation(() => ctx);
+
+    jest
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(() => getBoundingBox(GRAPH_WIDTH, GRAPH_HEIGHT));
+
+    const viewport: Viewport = {
+      containerWidth: GRAPH_WIDTH,
+      containerHeight: GRAPH_HEIGHT,
+      viewportLeft: 0,
+      viewportRight: 1,
+      viewportTop: 0,
+      viewportBottom: GRAPH_HEIGHT,
+      isDragging: false,
+      moveViewport: (_x: CssPixels, _y: CssPixels) => {},
+      isSizeSet: true,
+    };
+
+    const view = mount(
+      <Provider store={store}>
+        <SelectedThreadActivityGraph viewport={viewport} />
+      </Provider>
+    );
+
+    // WithSize uses requestAnimationFrame
+    flushRafCalls();
+    view.update();
+
+    const activityGraphCanvas = view.find('.threadActivityGraphCanvas').first();
+    const stackGraphCanvas = view.find('.threadStackGraphCanvas').first();
+    const thread = profile.threads[0];
+
+    // Perform a click on the activity graph.
+    function clickActivityGraph(
+      index: IndexIntoSamplesTable,
+      graphHeightPercentage: number
+    ) {
+      return activityGraphCanvas.simulate(
+        'mouseup',
+        getMouseEvent({
+          pageX: getSamplesPixelPosition(index),
+          pageY: GRAPH_HEIGHT * graphHeightPercentage,
+        })
+      );
+    }
+
+    // This function gets the selected call node path as a list of function names.
+    function getCallNodePath() {
+      return selectedThreadSelectors
+        .getSelectedCallNodePath(getState())
+        .map(funcIndex =>
+          thread.stringTable.getString(thread.funcTable.name[funcIndex])
+        );
+    }
+
+    return {
+      dispatch,
+      getState,
+      profile,
+      thread,
+      store,
+      view,
+      threadIndex,
+      activityGraphCanvas,
+      stackGraphCanvas,
+      clickActivityGraph,
+      getCallNodePath,
+      ctx,
+    };
+  }
+
+  it('matches the component snapshot', () => {
+    const { view } = setup();
+    expect(view).toMatchSnapshot();
+  });
+
+  it('matches the 2d canvas draw snapshot', () => {
+    const { ctx } = setup();
+    expect(ctx.__flushDrawLog()).toMatchSnapshot();
+  });
+
+  it('has the correct selectors into useful parts of the component for the samples profile', function() {
+    const { activityGraphCanvas, stackGraphCanvas } = setup();
+    expect(activityGraphCanvas.exists()).toBe(true);
+    expect(stackGraphCanvas.exists()).toBe(true);
+  });
+
+  /**
+   * The ThreadActivityGraph is not a connected component. It's easiest to test it
+   * as once it's connected to the Redux store in the SelectedActivityGraph.
+   */
+  describe('ThreadActivityGraph', function() {
+    it('can click a a best ancestor call node', function() {
+      const { clickActivityGraph, getCallNodePath } = setup();
+
+      // The full call node at this sample is:
+      //  A -> B -> C -> F -> G
+      // However, the best ancestor call node is:
+      //  A -> B -> C -> F
+      // As this is the most common ancestor with the same category.
+      clickActivityGraph(1, 0.2);
+      expect(getCallNodePath()).toEqual(['A', 'B', 'C', 'F']);
+
+      // The full call node at this sample is:
+      //  A -> B -> H -> I
+      // However, the best ancestor call node is:
+      //  A -> B -> H
+      // As this is the most common ancestor with the same category.
+      clickActivityGraph(1, 0.8);
+      expect(getCallNodePath()).toEqual(['A', 'B', 'H']);
+    });
+  });
+
+  /**
+   * For completeness, test that the ThreadStackGraph is clickable, as it is using
+   * a different method than the ThreadActivityGraph to select a call node.
+   */
+  describe('ThreadStackGraph', function() {
+    it('can click a stack', function() {
+      const { stackGraphCanvas, getCallNodePath } = setup();
+      stackGraphCanvas.simulate(
+        'mouseup',
+        getMouseEvent({ pageX: getSamplesPixelPosition(1) })
+      );
+      expect(getCallNodePath()).toEqual(['A', 'B', 'C', 'F', 'G']);
+    });
+  });
+});

--- a/src/test/components/__snapshots__/ThreadActivityGraph.test.js.snap
+++ b/src/test/components/__snapshots__/ThreadActivityGraph.test.js.snap
@@ -1,0 +1,1845 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SelectedThreadActivityGraph matches the 2d canvas draw snapshot 1`] = `
+Array [
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "createLinearGradient",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "addColorStop",
+    0,
+    "#d7d7db60",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "#d7d7db60",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "#d7d7db60",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "#d7d7db60",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    1,
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {
+      "addColorStop": [MockFunction] {
+        "calls": Array [
+          Array [
+            0,
+            "#d7d7db60",
+          ],
+          Array [
+            0.25,
+            "#d7d7db60",
+          ],
+          Array [
+            0.25,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "#d7d7db60",
+          ],
+          Array [
+            0.75,
+            "#d7d7db60",
+          ],
+          Array [
+            0.75,
+            "transparent",
+          ],
+          Array [
+            1,
+            "transparent",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+        ],
+      },
+    },
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "createLinearGradient",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "addColorStop",
+    0,
+    "#12bc0060",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "#12bc0060",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "#12bc0060",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "#12bc0060",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    1,
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {
+      "addColorStop": [MockFunction] {
+        "calls": Array [
+          Array [
+            0,
+            "#12bc0060",
+          ],
+          Array [
+            0.25,
+            "#12bc0060",
+          ],
+          Array [
+            0.25,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "#12bc0060",
+          ],
+          Array [
+            0.75,
+            "#12bc0060",
+          ],
+          Array [
+            0.75,
+            "transparent",
+          ],
+          Array [
+            1,
+            "transparent",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+        ],
+      },
+    },
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "scale",
+    1,
+    1,
+  ],
+  Array [
+    "createLinearGradient",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "addColorStop",
+    0,
+    "#0060df60",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "#0060df60",
+  ],
+  Array [
+    "addColorStop",
+    0.25,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    0.5,
+    "#0060df60",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "#0060df60",
+  ],
+  Array [
+    "addColorStop",
+    0.75,
+    "transparent",
+  ],
+  Array [
+    "addColorStop",
+    1,
+    "transparent",
+  ],
+  Array [
+    "set fillStyle",
+    Object {
+      "addColorStop": [MockFunction] {
+        "calls": Array [
+          Array [
+            0,
+            "#0060df60",
+          ],
+          Array [
+            0.25,
+            "#0060df60",
+          ],
+          Array [
+            0.25,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "transparent",
+          ],
+          Array [
+            0.5,
+            "#0060df60",
+          ],
+          Array [
+            0.75,
+            "#0060df60",
+          ],
+          Array [
+            0.75,
+            "transparent",
+          ],
+          Array [
+            1,
+            "transparent",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+        ],
+      },
+    },
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    4,
+    4,
+  ],
+  Array [
+    "createPattern",
+    <canvas
+      height="4"
+      width="4"
+    />,
+    "repeat",
+  ],
+  Array [
+    "set globalCompositeOperation",
+    "lighter",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db60",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db",
+  ],
+  Array [
+    "set fillStyle",
+    "#d7d7db60",
+  ],
+  Array [
+    "beginPath",
+  ],
+  Array [
+    "moveTo",
+    8,
+    10,
+  ],
+  Array [
+    "lineTo",
+    9,
+    10,
+  ],
+  Array [
+    "lineTo",
+    10,
+    10,
+  ],
+  Array [
+    "lineTo",
+    11,
+    10,
+  ],
+  Array [
+    "lineTo",
+    12,
+    10,
+  ],
+  Array [
+    "lineTo",
+    13,
+    10,
+  ],
+  Array [
+    "lineTo",
+    14,
+    10,
+  ],
+  Array [
+    "lineTo",
+    15,
+    10,
+  ],
+  Array [
+    "lineTo",
+    16,
+    10,
+  ],
+  Array [
+    "lineTo",
+    17,
+    10,
+  ],
+  Array [
+    "lineTo",
+    18,
+    10,
+  ],
+  Array [
+    "lineTo",
+    19,
+    10,
+  ],
+  Array [
+    "lineTo",
+    20,
+    10,
+  ],
+  Array [
+    "lineTo",
+    21,
+    10,
+  ],
+  Array [
+    "lineTo",
+    22,
+    10,
+  ],
+  Array [
+    "lineTo",
+    23,
+    10,
+  ],
+  Array [
+    "lineTo",
+    24,
+    10,
+  ],
+  Array [
+    "lineTo",
+    25,
+    10,
+  ],
+  Array [
+    "lineTo",
+    26,
+    10,
+  ],
+  Array [
+    "lineTo",
+    27,
+    10,
+  ],
+  Array [
+    "lineTo",
+    28,
+    10,
+  ],
+  Array [
+    "lineTo",
+    29,
+    10,
+  ],
+  Array [
+    "lineTo",
+    30,
+    10,
+  ],
+  Array [
+    "lineTo",
+    31,
+    10,
+  ],
+  Array [
+    "lineTo",
+    32,
+    10,
+  ],
+  Array [
+    "lineTo",
+    33,
+    10,
+  ],
+  Array [
+    "lineTo",
+    34,
+    10,
+  ],
+  Array [
+    "lineTo",
+    35,
+    10,
+  ],
+  Array [
+    "lineTo",
+    36,
+    10,
+  ],
+  Array [
+    "lineTo",
+    37,
+    10,
+  ],
+  Array [
+    "lineTo",
+    38,
+    10,
+  ],
+  Array [
+    "lineTo",
+    39,
+    10,
+  ],
+  Array [
+    "lineTo",
+    40,
+    10,
+  ],
+  Array [
+    "lineTo",
+    41,
+    10,
+  ],
+  Array [
+    "lineTo",
+    42,
+    10,
+  ],
+  Array [
+    "lineTo",
+    43,
+    10,
+  ],
+  Array [
+    "lineTo",
+    44,
+    10,
+  ],
+  Array [
+    "lineTo",
+    45,
+    10,
+  ],
+  Array [
+    "lineTo",
+    46,
+    10,
+  ],
+  Array [
+    "lineTo",
+    47,
+    10,
+  ],
+  Array [
+    "lineTo",
+    48,
+    10,
+  ],
+  Array [
+    "lineTo",
+    49,
+    10,
+  ],
+  Array [
+    "lineTo",
+    50,
+    10,
+  ],
+  Array [
+    "lineTo",
+    51,
+    10,
+  ],
+  Array [
+    "lineTo",
+    52,
+    10,
+  ],
+  Array [
+    "lineTo",
+    53,
+    10,
+  ],
+  Array [
+    "lineTo",
+    54,
+    10,
+  ],
+  Array [
+    "lineTo",
+    55,
+    10,
+  ],
+  Array [
+    "lineTo",
+    56,
+    10,
+  ],
+  Array [
+    "lineTo",
+    57,
+    10,
+  ],
+  Array [
+    "lineTo",
+    58,
+    10,
+  ],
+  Array [
+    "lineTo",
+    59,
+    10,
+  ],
+  Array [
+    "lineTo",
+    60,
+    10,
+  ],
+  Array [
+    "lineTo",
+    61,
+    10,
+  ],
+  Array [
+    "lineTo",
+    62,
+    10,
+  ],
+  Array [
+    "lineTo",
+    63,
+    10,
+  ],
+  Array [
+    "lineTo",
+    64,
+    10,
+  ],
+  Array [
+    "lineTo",
+    65,
+    10,
+  ],
+  Array [
+    "lineTo",
+    66,
+    10,
+  ],
+  Array [
+    "lineTo",
+    67,
+    10,
+  ],
+  Array [
+    "lineTo",
+    68,
+    10,
+  ],
+  Array [
+    "lineTo",
+    69,
+    10,
+  ],
+  Array [
+    "lineTo",
+    70,
+    10,
+  ],
+  Array [
+    "lineTo",
+    71,
+    10,
+  ],
+  Array [
+    "lineTo",
+    72,
+    10,
+  ],
+  Array [
+    "lineTo",
+    71,
+    9.942857138812542,
+  ],
+  Array [
+    "lineTo",
+    70,
+    9.771428555250168,
+  ],
+  Array [
+    "lineTo",
+    69,
+    9.428571425378323,
+  ],
+  Array [
+    "lineTo",
+    68,
+    8.85714277625084,
+  ],
+  Array [
+    "lineTo",
+    67,
+    7.999999970197678,
+  ],
+  Array [
+    "lineTo",
+    66,
+    6.914285719394684,
+  ],
+  Array [
+    "lineTo",
+    65,
+    5.657142698764801,
+  ],
+  Array [
+    "lineTo",
+    64,
+    4.342857003211975,
+  ],
+  Array [
+    "lineTo",
+    63,
+    3.0857139825820923,
+  ],
+  Array [
+    "lineTo",
+    62,
+    1.9999998807907104,
+  ],
+  Array [
+    "lineTo",
+    61,
+    1.1428570747375488,
+  ],
+  Array [
+    "lineTo",
+    60,
+    0.5714285373687744,
+  ],
+  Array [
+    "lineTo",
+    59,
+    0.22857129573822021,
+  ],
+  Array [
+    "lineTo",
+    58,
+    0.05714297294616699,
+  ],
+  Array [
+    "lineTo",
+    57,
+    0,
+  ],
+  Array [
+    "lineTo",
+    56,
+    0,
+  ],
+  Array [
+    "lineTo",
+    55,
+    0,
+  ],
+  Array [
+    "lineTo",
+    54,
+    0,
+  ],
+  Array [
+    "lineTo",
+    53,
+    0,
+  ],
+  Array [
+    "lineTo",
+    52,
+    0,
+  ],
+  Array [
+    "lineTo",
+    51,
+    0,
+  ],
+  Array [
+    "lineTo",
+    50,
+    0,
+  ],
+  Array [
+    "lineTo",
+    49,
+    0,
+  ],
+  Array [
+    "lineTo",
+    48,
+    0,
+  ],
+  Array [
+    "lineTo",
+    47,
+    0,
+  ],
+  Array [
+    "lineTo",
+    46,
+    0,
+  ],
+  Array [
+    "lineTo",
+    45,
+    0,
+  ],
+  Array [
+    "lineTo",
+    44,
+    0,
+  ],
+  Array [
+    "lineTo",
+    43,
+    0,
+  ],
+  Array [
+    "lineTo",
+    42,
+    0,
+  ],
+  Array [
+    "lineTo",
+    41,
+    0,
+  ],
+  Array [
+    "lineTo",
+    40,
+    0,
+  ],
+  Array [
+    "lineTo",
+    39,
+    0,
+  ],
+  Array [
+    "lineTo",
+    38,
+    0,
+  ],
+  Array [
+    "lineTo",
+    37,
+    0,
+  ],
+  Array [
+    "lineTo",
+    36,
+    0,
+  ],
+  Array [
+    "lineTo",
+    35,
+    0,
+  ],
+  Array [
+    "lineTo",
+    34,
+    0,
+  ],
+  Array [
+    "lineTo",
+    33,
+    0,
+  ],
+  Array [
+    "lineTo",
+    32,
+    0,
+  ],
+  Array [
+    "lineTo",
+    31,
+    0,
+  ],
+  Array [
+    "lineTo",
+    30,
+    0,
+  ],
+  Array [
+    "lineTo",
+    29,
+    0,
+  ],
+  Array [
+    "lineTo",
+    28,
+    0,
+  ],
+  Array [
+    "lineTo",
+    27,
+    0,
+  ],
+  Array [
+    "lineTo",
+    26,
+    0,
+  ],
+  Array [
+    "lineTo",
+    25,
+    0,
+  ],
+  Array [
+    "lineTo",
+    24,
+    0,
+  ],
+  Array [
+    "lineTo",
+    23,
+    0,
+  ],
+  Array [
+    "lineTo",
+    22,
+    0,
+  ],
+  Array [
+    "lineTo",
+    21,
+    0.05714297294616699,
+  ],
+  Array [
+    "lineTo",
+    20,
+    0.22857129573822021,
+  ],
+  Array [
+    "lineTo",
+    19,
+    0.5714285373687744,
+  ],
+  Array [
+    "lineTo",
+    18,
+    1.1428570747375488,
+  ],
+  Array [
+    "lineTo",
+    17,
+    1.9999998807907104,
+  ],
+  Array [
+    "lineTo",
+    16,
+    3.0857139825820923,
+  ],
+  Array [
+    "lineTo",
+    15,
+    4.342857003211975,
+  ],
+  Array [
+    "lineTo",
+    14,
+    5.657142698764801,
+  ],
+  Array [
+    "lineTo",
+    13,
+    6.914285719394684,
+  ],
+  Array [
+    "lineTo",
+    12,
+    7.999999970197678,
+  ],
+  Array [
+    "lineTo",
+    11,
+    8.85714277625084,
+  ],
+  Array [
+    "lineTo",
+    10,
+    9.428571425378323,
+  ],
+  Array [
+    "lineTo",
+    9,
+    9.771428555250168,
+  ],
+  Array [
+    "lineTo",
+    8,
+    9.942857138812542,
+  ],
+  Array [
+    "closePath",
+  ],
+  Array [
+    "fill",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc00",
+  ],
+  Array [
+    "set fillStyle",
+    "#12bc0060",
+  ],
+  Array [
+    "beginPath",
+  ],
+  Array [
+    "moveTo",
+    0,
+    10,
+  ],
+  Array [
+    "lineTo",
+    1,
+    10,
+  ],
+  Array [
+    "lineTo",
+    2,
+    10,
+  ],
+  Array [
+    "lineTo",
+    3,
+    10,
+  ],
+  Array [
+    "lineTo",
+    4,
+    10,
+  ],
+  Array [
+    "lineTo",
+    5,
+    10,
+  ],
+  Array [
+    "lineTo",
+    6,
+    10,
+  ],
+  Array [
+    "lineTo",
+    7,
+    10,
+  ],
+  Array [
+    "lineTo",
+    8,
+    9.942857138812542,
+  ],
+  Array [
+    "lineTo",
+    9,
+    9.771428555250168,
+  ],
+  Array [
+    "lineTo",
+    10,
+    9.428571425378323,
+  ],
+  Array [
+    "lineTo",
+    11,
+    8.85714277625084,
+  ],
+  Array [
+    "lineTo",
+    12,
+    7.999999970197678,
+  ],
+  Array [
+    "lineTo",
+    13,
+    6.914285719394684,
+  ],
+  Array [
+    "lineTo",
+    14,
+    5.657142698764801,
+  ],
+  Array [
+    "lineTo",
+    15,
+    4.342857003211975,
+  ],
+  Array [
+    "lineTo",
+    16,
+    3.0857139825820923,
+  ],
+  Array [
+    "lineTo",
+    17,
+    1.9999998807907104,
+  ],
+  Array [
+    "lineTo",
+    18,
+    1.1428570747375488,
+  ],
+  Array [
+    "lineTo",
+    19,
+    0.5714285373687744,
+  ],
+  Array [
+    "lineTo",
+    20,
+    0.22857129573822021,
+  ],
+  Array [
+    "lineTo",
+    21,
+    0.05714297294616699,
+  ],
+  Array [
+    "lineTo",
+    22,
+    0,
+  ],
+  Array [
+    "lineTo",
+    21,
+    0,
+  ],
+  Array [
+    "lineTo",
+    20,
+    0,
+  ],
+  Array [
+    "lineTo",
+    19,
+    0,
+  ],
+  Array [
+    "lineTo",
+    18,
+    0,
+  ],
+  Array [
+    "lineTo",
+    17,
+    0,
+  ],
+  Array [
+    "lineTo",
+    16,
+    0,
+  ],
+  Array [
+    "lineTo",
+    15,
+    0,
+  ],
+  Array [
+    "lineTo",
+    14,
+    0,
+  ],
+  Array [
+    "lineTo",
+    13,
+    0,
+  ],
+  Array [
+    "lineTo",
+    12,
+    0,
+  ],
+  Array [
+    "lineTo",
+    11,
+    0.05714297294616699,
+  ],
+  Array [
+    "lineTo",
+    10,
+    0.22857129573822021,
+  ],
+  Array [
+    "lineTo",
+    9,
+    0.5714285373687744,
+  ],
+  Array [
+    "lineTo",
+    8,
+    1.1428570747375488,
+  ],
+  Array [
+    "lineTo",
+    7,
+    1.9999998807907104,
+  ],
+  Array [
+    "lineTo",
+    6,
+    3.0857139825820923,
+  ],
+  Array [
+    "lineTo",
+    5,
+    4.342857003211975,
+  ],
+  Array [
+    "lineTo",
+    4,
+    5.657142698764801,
+  ],
+  Array [
+    "lineTo",
+    3,
+    6.914285719394684,
+  ],
+  Array [
+    "lineTo",
+    2,
+    7.999999970197678,
+  ],
+  Array [
+    "lineTo",
+    1,
+    8.85714277625084,
+  ],
+  Array [
+    "lineTo",
+    0,
+    9.428571425378323,
+  ],
+  Array [
+    "closePath",
+  ],
+  Array [
+    "fill",
+  ],
+  Array [
+    "beginPath",
+  ],
+  Array [
+    "moveTo",
+    58,
+    0.05714297294616699,
+  ],
+  Array [
+    "lineTo",
+    59,
+    0.22857129573822021,
+  ],
+  Array [
+    "lineTo",
+    60,
+    0.5714285373687744,
+  ],
+  Array [
+    "lineTo",
+    61,
+    1.1428570747375488,
+  ],
+  Array [
+    "lineTo",
+    62,
+    1.9999998807907104,
+  ],
+  Array [
+    "lineTo",
+    63,
+    3.0857139825820923,
+  ],
+  Array [
+    "lineTo",
+    64,
+    4.342857003211975,
+  ],
+  Array [
+    "lineTo",
+    65,
+    5.657142698764801,
+  ],
+  Array [
+    "lineTo",
+    66,
+    6.914285719394684,
+  ],
+  Array [
+    "lineTo",
+    67,
+    7.999999970197678,
+  ],
+  Array [
+    "lineTo",
+    68,
+    8.85714277625084,
+  ],
+  Array [
+    "lineTo",
+    69,
+    9.428571425378323,
+  ],
+  Array [
+    "lineTo",
+    70,
+    9.771428555250168,
+  ],
+  Array [
+    "lineTo",
+    71,
+    9.942857138812542,
+  ],
+  Array [
+    "lineTo",
+    72,
+    10,
+  ],
+  Array [
+    "lineTo",
+    73,
+    10,
+  ],
+  Array [
+    "lineTo",
+    74,
+    10,
+  ],
+  Array [
+    "lineTo",
+    75,
+    10,
+  ],
+  Array [
+    "lineTo",
+    76,
+    10,
+  ],
+  Array [
+    "lineTo",
+    77,
+    10,
+  ],
+  Array [
+    "lineTo",
+    78,
+    10,
+  ],
+  Array [
+    "lineTo",
+    79,
+    10,
+  ],
+  Array [
+    "lineTo",
+    79,
+    9.428571425378323,
+  ],
+  Array [
+    "lineTo",
+    78,
+    8.85714277625084,
+  ],
+  Array [
+    "lineTo",
+    77,
+    7.999999970197678,
+  ],
+  Array [
+    "lineTo",
+    76,
+    6.914285719394684,
+  ],
+  Array [
+    "lineTo",
+    75,
+    5.657142698764801,
+  ],
+  Array [
+    "lineTo",
+    74,
+    4.342857003211975,
+  ],
+  Array [
+    "lineTo",
+    73,
+    3.0857139825820923,
+  ],
+  Array [
+    "lineTo",
+    72,
+    1.9999998807907104,
+  ],
+  Array [
+    "lineTo",
+    71,
+    1.1428570747375488,
+  ],
+  Array [
+    "lineTo",
+    70,
+    0.5714285373687744,
+  ],
+  Array [
+    "lineTo",
+    69,
+    0.22857129573822021,
+  ],
+  Array [
+    "lineTo",
+    68,
+    0.05714297294616699,
+  ],
+  Array [
+    "lineTo",
+    67,
+    0,
+  ],
+  Array [
+    "lineTo",
+    66,
+    0,
+  ],
+  Array [
+    "lineTo",
+    65,
+    0,
+  ],
+  Array [
+    "lineTo",
+    64,
+    0,
+  ],
+  Array [
+    "lineTo",
+    63,
+    0,
+  ],
+  Array [
+    "lineTo",
+    62,
+    0,
+  ],
+  Array [
+    "lineTo",
+    61,
+    0,
+  ],
+  Array [
+    "lineTo",
+    60,
+    0,
+  ],
+  Array [
+    "lineTo",
+    59,
+    0,
+  ],
+  Array [
+    "lineTo",
+    58,
+    0,
+  ],
+  Array [
+    "closePath",
+  ],
+  Array [
+    "fill",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df60",
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df",
+  ],
+  Array [
+    "set fillStyle",
+    "#0060df60",
+  ],
+  Array [
+    "beginPath",
+  ],
+  Array [
+    "moveTo",
+    0,
+    9.428571425378323,
+  ],
+  Array [
+    "lineTo",
+    1,
+    8.85714277625084,
+  ],
+  Array [
+    "lineTo",
+    2,
+    7.999999970197678,
+  ],
+  Array [
+    "lineTo",
+    3,
+    6.914285719394684,
+  ],
+  Array [
+    "lineTo",
+    4,
+    5.657142698764801,
+  ],
+  Array [
+    "lineTo",
+    5,
+    4.342857003211975,
+  ],
+  Array [
+    "lineTo",
+    6,
+    3.0857139825820923,
+  ],
+  Array [
+    "lineTo",
+    7,
+    1.9999998807907104,
+  ],
+  Array [
+    "lineTo",
+    8,
+    1.1428570747375488,
+  ],
+  Array [
+    "lineTo",
+    9,
+    0.5714285373687744,
+  ],
+  Array [
+    "lineTo",
+    10,
+    0.22857129573822021,
+  ],
+  Array [
+    "lineTo",
+    11,
+    0.05714297294616699,
+  ],
+  Array [
+    "lineTo",
+    12,
+    0,
+  ],
+  Array [
+    "lineTo",
+    11,
+    0,
+  ],
+  Array [
+    "lineTo",
+    10,
+    0,
+  ],
+  Array [
+    "lineTo",
+    9,
+    0,
+  ],
+  Array [
+    "lineTo",
+    8,
+    0,
+  ],
+  Array [
+    "lineTo",
+    7,
+    0,
+  ],
+  Array [
+    "lineTo",
+    6,
+    0.05714237689971924,
+  ],
+  Array [
+    "lineTo",
+    5,
+    0.22857129573822021,
+  ],
+  Array [
+    "lineTo",
+    4,
+    0.5714285373687744,
+  ],
+  Array [
+    "lineTo",
+    3,
+    1.3142859935760498,
+  ],
+  Array [
+    "lineTo",
+    2,
+    2.457142472267151,
+  ],
+  Array [
+    "lineTo",
+    1,
+    4.399999976158142,
+  ],
+  Array [
+    "lineTo",
+    0,
+    6.228571236133575,
+  ],
+  Array [
+    "closePath",
+  ],
+  Array [
+    "fill",
+  ],
+  Array [
+    "set fillStyle",
+    Object {},
+  ],
+  Array [
+    "set fillStyle",
+    "#45a1ff",
+  ],
+  Array [
+    "fillRect",
+    0,
+    0,
+    10,
+    10,
+  ],
+  Array [
+    "fillRect",
+    10,
+    0,
+    10,
+    10,
+  ],
+  Array [
+    "fillRect",
+    20,
+    0,
+    10,
+    7.5,
+  ],
+  Array [
+    "fillRect",
+    30,
+    0,
+    10,
+    7.5,
+  ],
+  Array [
+    "fillRect",
+    40,
+    0,
+    10,
+    7.5,
+  ],
+  Array [
+    "fillRect",
+    50,
+    0,
+    10,
+    7.5,
+  ],
+  Array [
+    "fillRect",
+    60,
+    0,
+    10,
+    7.5,
+  ],
+  Array [
+    "fillRect",
+    70,
+    0,
+    10,
+    10,
+  ],
+  Array [
+    "set fillStyle",
+    "#003eaa",
+  ],
+  Array [
+    "set fillStyle",
+    "#c5e1fe",
+  ],
+]
+`;
+
+exports[`SelectedThreadActivityGraph matches the component snapshot 1`] = `
+<div
+  className="chartViewport selectedThreadActivityGraphViewport"
+  onMouseDown={[Function]}
+  onWheel={[Function]}
+>
+  <div>
+    <div
+      className="selectedThreadActivityGraph"
+    >
+      <canvas
+        className="selectedThreadActivityGraphCanvas threadActivityGraphCanvas"
+        onMouseUp={[Function]}
+      />
+    </div>
+    <div
+      className="selectedThreadStackGraph"
+    >
+      <canvas
+        className="selectedThreadStackGraphCanvas threadStackGraphCanvas"
+        onMouseUp={[Function]}
+      />
+    </div>
+  </div>
+  <div
+    className="chartViewportShiftScroll hidden"
+  >
+    Zoom Chart:
+    <kbd
+      className="chartViewportShiftScrollKbd"
+    >
+      Shift
+    </kbd>
+    <kbd
+      className="chartViewportShiftScrollKbd"
+    >
+      Scroll
+    </kbd>
+  </div>
+</div>
+`;


### PR DESCRIPTION
This test adds coverage for the ThreadActivityGraph. There is a decent amount of complexity with this component. I'm finding it a bit difficult to assert the properties of the smoothly drawn graph. So this test relies primarily on a snapshot of both the React component and the draw calls.

In addition, there are some Enzyme-based tests that perform the click on the graph in order to select the Call Node.

@zoepage I pinged you for the review on this, especially since we were chatting recently about Enzyme and snapshot tests.