### PR TITLE
Add debounce to WithSize resize handler (Fixes #1090)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "escape-string-regexp": "^1.0.5",
     "gecko-profiler-demangle": "^0.1.0",
     "jszip": "^3.1.5",
+    "lodash.debounce": "^4.0.8",
     "memoize-immutable": "^3.0.0",
     "mixedtuplemap": "^1.0.0",
     "photon-colors": "2.0.1",

--- a/src/components/shared/WithSize.js
+++ b/src/components/shared/WithSize.js
@@ -45,9 +45,16 @@ export function withSize<
       if (!container) {
         throw new Error('Unable to find the DOMNode');
       }
-      this._resizeListener = debounce(() => {
+      const debouncedUpdateWidth = debounce(() => {
         this._updateWidth(container);
       }, 400);
+      this._resizeListener = () => {
+        if (document.hidden) {
+          debouncedUpdateWidth();
+        } else {
+          this._updateWidth(container);
+        }
+      };
       window.addEventListener('resize', this._resizeListener);
 
       // Wrapping the first update in a requestAnimationFrame to defer the

--- a/src/components/shared/WithSize.js
+++ b/src/components/shared/WithSize.js
@@ -5,6 +5,7 @@
 
 import * as React from 'react';
 import { findDOMNode } from 'react-dom';
+import debounce from 'lodash.debounce';
 import type { CssPixels } from '../../types/units';
 
 type State = {|
@@ -44,9 +45,9 @@ export function withSize<
       if (!container) {
         throw new Error('Unable to find the DOMNode');
       }
-      this._resizeListener = () => {
+      this._resizeListener = debounce(() => {
         this._updateWidth(container);
-      };
+      }, 400);
       window.addEventListener('resize', this._resizeListener);
 
       // Wrapping the first update in a requestAnimationFrame to defer the
@@ -64,6 +65,8 @@ export function withSize<
       }
       const { width, height } = container.getBoundingClientRect();
       this.setState({ width, height });
+      const style = 'color: green; font-weight: bold;';
+      console.log(`[updateWidth]  %c"${width}, ${height}"`, style);
     }
 
     render() {

--- a/src/types/libdef/npm-custom/lodash.debounce_vx.x.x.js
+++ b/src/types/libdef/npm-custom/lodash.debounce_vx.x.x.js
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+// This definition was adapted from lodash-es definition in
+// https://github.com/flow-typed/flow-typed/blob/master/definitions/npm/lodash-es_v4.x.x/flow_v0.63.x-/lodash-es_v4.x.x.js
+
+declare type $$lodash$$DebounceOptions = {
+  leading?: boolean,
+  maxWait?: number,
+  trailing?: boolean,
+};
+
+declare module 'lodash.debounce' {
+  declare export default function debounce<F: Function>(
+    func: F,
+    wait?: number,
+    options?: $$lodash$$DebounceOptions
+  ): F;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6071,6 +6071,7 @@ lodash.cond@^4.3.0:
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+  integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
@@ -10246,7 +10247,8 @@ worker-farm@^1.5.2:
   version "0.1.2"
   resolved "https://codeload.github.com/jasonLaster/workerjs/tar.gz/8c7df3e465b1d096d5134c648287d4a6f9c3e4ea"
   dependencies:
-    babel-register "^6.18.0"
+    "@babel/core" "^7.0.0"
+    "@babel/register" "^7.0.0"
 
 wrap-ansi@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
As I understand, `debounce` delays invoking function until resizing has finished, so I wait 400ms instead 1-2 seconds for smooth resizing.