### PR TITLE
 Change the stack chart drawing strategy for small gaps 

### DIFF
--- a/src/components/flame-graph/Canvas.js
+++ b/src/components/flame-graph/Canvas.js
@@ -503,6 +503,7 @@ class FlameGraphCanvas extends React.PureComponent<Props> {
         containerWidth={containerWidth}
         containerHeight={containerHeight}
         isDragging={isDragging}
+        scaleCtxToCssPixels={true}
         onDoubleClickItem={this._noOp}
         getHoveredItemInfo={this._getHoveredStackInfo}
         drawCanvas={this._drawCanvas}

--- a/src/components/marker-chart/Canvas.js
+++ b/src/components/marker-chart/Canvas.js
@@ -384,6 +384,7 @@ class MarkerChartCanvas extends React.PureComponent<Props, State> {
         containerWidth={containerWidth}
         containerHeight={containerHeight}
         isDragging={isDragging}
+        scaleCtxToCssPixels={true}
         onDoubleClickItem={this.onDoubleClickMarker}
         getHoveredItemInfo={this.getHoveredMarkerInfo}
         drawCanvas={this.drawCanvas}

--- a/src/components/stack-chart/Canvas.js
+++ b/src/components/stack-chart/Canvas.js
@@ -67,9 +67,9 @@ type HoveredStackTiming = {|
 
 require('./Canvas.css');
 
-const ROW_CSS_PIXEL_HEIGHT = 16;
-const TEXT_CSS_PIXEL_OFFSET_START = 3;
-const TEXT_CSS_PIXEL_OFFSET_TOP = 11;
+const ROW_CSS_PIXELS_HEIGHT = 16;
+const TEXT_CSS_PIXELS_OFFSET_START = 3;
+const TEXT_CSS_PIXELS_OFFSET_TOP = 11;
 const FONT_SIZE = 10;
 const BORDER_OPACITY = 0.4;
 
@@ -108,14 +108,14 @@ class StackChartCanvas extends React.PureComponent<Props> {
     }
 
     const depth = callNodeTable.depth[selectedCallNodeIndex];
-    const y = depth * ROW_CSS_PIXEL_HEIGHT;
+    const y = depth * ROW_CSS_PIXELS_HEIGHT;
 
     if (y < this.props.viewport.viewportTop) {
       this.props.viewport.moveViewport(0, this.props.viewport.viewportTop - y);
-    } else if (y + ROW_CSS_PIXEL_HEIGHT > this.props.viewport.viewportBottom) {
+    } else if (y + ROW_CSS_PIXELS_HEIGHT > this.props.viewport.viewportBottom) {
       this.props.viewport.moveViewport(
         0,
-        this.props.viewport.viewportBottom - (y + ROW_CSS_PIXEL_HEIGHT)
+        this.props.viewport.viewportBottom - (y + ROW_CSS_PIXELS_HEIGHT)
       );
     }
   };
@@ -177,25 +177,25 @@ class StackChartCanvas extends React.PureComponent<Props> {
 
     const innerContainerWidth =
       containerWidth - TIMELINE_MARGIN_LEFT - TIMELINE_MARGIN_RIGHT;
-    const innerDevicePixelWidth = innerContainerWidth * devicePixelRatio;
+    const innerDevicePixelsWidth = innerContainerWidth * devicePixelRatio;
 
     const pixelAtViewportPosition = (
       viewportPosition: UnitIntervalOfProfileRange
     ): DevicePixels =>
       devicePixelRatio *
-      // The right hand side of this formula is all in device pixels.
+      // The right hand side of this formula is all in CSS pixels.
       (TIMELINE_MARGIN_LEFT +
         (viewportPosition - viewportLeft) *
           innerContainerWidth /
           viewportLength);
 
     // Apply the device pixel ratio to various CssPixel constants.
-    const rowDevicePixelHeight = ROW_CSS_PIXEL_HEIGHT * devicePixelRatio;
+    const rowDevicePixelsHeight = ROW_CSS_PIXELS_HEIGHT * devicePixelRatio;
     const oneCssPixelInDevicePixels = 1 * devicePixelRatio;
-    const textDevicePixelOffsetStart =
-      TEXT_CSS_PIXEL_OFFSET_START * devicePixelRatio;
-    const textDevicePixelOffsetTop =
-      TEXT_CSS_PIXEL_OFFSET_TOP * devicePixelRatio;
+    const textDevicePixelsOffsetStart =
+      TEXT_CSS_PIXELS_OFFSET_START * devicePixelRatio;
+    const textDevicePixelsOffsetTop =
+      TEXT_CSS_PIXELS_OFFSET_TOP * devicePixelRatio;
 
     // Only draw the stack frames that are vertically within view.
     for (let depth = startDepth; depth < endDepth; depth++) {
@@ -213,7 +213,7 @@ class StackChartCanvas extends React.PureComponent<Props> {
        * const endSampleIndex = binarySearch(stackTiming.end, rangeStart + rangeLength * viewportRight);
        */
 
-      const pixelsInViewport = viewportLength * innerDevicePixelWidth;
+      const pixelsInViewport = viewportLength * innerDevicePixelsWidth;
       const timePerPixel = rangeLength / pixelsInViewport;
 
       // Decide which samples to actually draw
@@ -253,7 +253,7 @@ class StackChartCanvas extends React.PureComponent<Props> {
           const floatX = pixelAtViewportPosition(viewportAtStartTime);
           const floatW: DevicePixels =
             (viewportAtEndTime - viewportAtStartTime) *
-              innerDevicePixelWidth /
+              innerDevicePixelsWidth /
               viewportLength -
             1;
 
@@ -269,7 +269,7 @@ class StackChartCanvas extends React.PureComponent<Props> {
             // The left side of the box is before the lastDrawnPixelX value, but the
             // right hand side is within a range to be drawn. Truncate the box a little
             // bit in order to draw it to the screen in the free space.
-            snappedFloatW = floatW - (lastDrawnPixelX - snappedFloatX);
+            snappedFloatW = floatW - (lastDrawnPixelX - floatX);
             snappedFloatX = lastDrawnPixelX;
             skipDraw = false;
           }
@@ -284,11 +284,11 @@ class StackChartCanvas extends React.PureComponent<Props> {
           // off by one errors appear to be creating gaps where there shouldn't be any.
           const intX = Math.floor(snappedFloatX);
           const intY = Math.round(
-            depth * rowDevicePixelHeight - viewportDevicePixelsTop
+            depth * rowDevicePixelsHeight - viewportDevicePixelsTop
           );
           const intW = Math.ceil(Math.max(1, snappedFloatW));
           const intH = Math.round(
-            rowDevicePixelHeight - oneCssPixelInDevicePixels
+            rowDevicePixelsHeight - oneCssPixelInDevicePixels
           );
 
           // Look up information about this stack frame.
@@ -327,7 +327,7 @@ class StackChartCanvas extends React.PureComponent<Props> {
           // the text doesn't snap around when moving. Only the boxes should snap.
           const textX: DevicePixels =
             // Constrain the x coordinate to the leftmost area.
-            Math.max(floatX, 0) + textDevicePixelOffsetStart;
+            Math.max(floatX, 0) + textDevicePixelsOffsetStart;
           const textW: DevicePixels = Math.max(0, floatW - (textX - floatX));
 
           if (textW > textMeasurement.minWidth) {
@@ -336,7 +336,7 @@ class StackChartCanvas extends React.PureComponent<Props> {
               fastFillStyle.set(
                 isHovered || isSelected ? 'HighlightText' : '#000000'
               );
-              ctx.fillText(fittedText, textX, intY + textDevicePixelOffsetTop);
+              ctx.fillText(fittedText, textX, intY + textDevicePixelsOffsetTop);
             }
           }
         }
@@ -463,16 +463,16 @@ class StackChartCanvas extends React.PureComponent<Props> {
       viewport: { viewportLeft, viewportRight, viewportTop, containerWidth },
     } = this.props;
 
-    const innerDevicePixelWidth =
+    const innerDevicePixelsWidth =
       containerWidth - TIMELINE_MARGIN_LEFT - TIMELINE_MARGIN_RIGHT;
     const rangeLength: Milliseconds = rangeEnd - rangeStart;
     const viewportLength: UnitIntervalOfProfileRange =
       viewportRight - viewportLeft;
     const unitIntervalTime: UnitIntervalOfProfileRange =
       viewportLeft +
-      viewportLength * ((x - TIMELINE_MARGIN_LEFT) / innerDevicePixelWidth);
+      viewportLength * ((x - TIMELINE_MARGIN_LEFT) / innerDevicePixelsWidth);
     const time: Milliseconds = rangeStart + unitIntervalTime * rangeLength;
-    const depth = Math.floor((y + viewportTop) / ROW_CSS_PIXEL_HEIGHT);
+    const depth = Math.floor((y + viewportTop) / ROW_CSS_PIXELS_HEIGHT);
     const stackTiming = stackTimingByDepth[depth];
 
     if (!stackTiming) {

--- a/src/test/components/__snapshots__/StackChart.test.js.snap
+++ b/src/test/components/__snapshots__/StackChart.test.js.snap
@@ -150,9 +150,8 @@ exports[`StackChart matches the snapshot 1`] = `
 exports[`StackChart matches the snapshot 2`] = `
 Array [
   Array [
-    "scale",
-    1,
-    1,
+    "set font",
+    "10px sans-serif",
   ],
   Array [
     "measureText",
@@ -181,18 +180,7 @@ Array [
     "fillRect",
     150,
     0,
-    200,
-    15,
-  ],
-  Array [
-    "set fillStyle",
-    "#ffffff",
-  ],
-  Array [
-    "fillRect",
-    150,
-    0,
-    1,
+    199.4,
     15,
   ],
   Array [
@@ -217,18 +205,7 @@ Array [
     "fillRect",
     150,
     16,
-    200,
-    15,
-  ],
-  Array [
-    "set fillStyle",
-    "#ffffff",
-  ],
-  Array [
-    "fillRect",
-    150,
-    16,
-    1,
+    199.4,
     15,
   ],
   Array [
@@ -253,18 +230,7 @@ Array [
     "fillRect",
     150,
     32,
-    133.33333333333331,
-    15,
-  ],
-  Array [
-    "set fillStyle",
-    "#ffffff",
-  ],
-  Array [
-    "fillRect",
-    150,
-    32,
-    1,
+    133.4,
     15,
   ],
   Array [
@@ -287,20 +253,9 @@ Array [
   ],
   Array [
     "fillRect",
-    283.3333333333333,
+    284,
     32,
-    66.66666666666667,
-    15,
-  ],
-  Array [
-    "set fillStyle",
-    "#ffffff",
-  ],
-  Array [
-    "fillRect",
-    283.3333333333333,
-    32,
-    1,
+    65.4,
     15,
   ],
   Array [
@@ -325,18 +280,7 @@ Array [
     "fillRect",
     150,
     48,
-    66.66666666666666,
-    15,
-  ],
-  Array [
-    "set fillStyle",
-    "#ffffff",
-  ],
-  Array [
-    "fillRect",
-    150,
-    48,
-    1,
+    66.4,
     15,
   ],
   Array [
@@ -359,20 +303,9 @@ Array [
   ],
   Array [
     "fillRect",
-    216.66666666666666,
+    217,
     48,
-    66.66666666666666,
-    15,
-  ],
-  Array [
-    "set fillStyle",
-    "#ffffff",
-  ],
-  Array [
-    "fillRect",
-    216.66666666666666,
-    48,
-    1,
+    66.4,
     15,
   ],
   Array [
@@ -395,20 +328,9 @@ Array [
   ],
   Array [
     "fillRect",
-    283.3333333333333,
+    284,
     48,
-    66.66666666666667,
-    15,
-  ],
-  Array [
-    "set fillStyle",
-    "#ffffff",
-  ],
-  Array [
-    "fillRect",
-    283.3333333333333,
-    48,
-    1,
+    65.4,
     15,
   ],
   Array [
@@ -433,18 +355,7 @@ Array [
     "fillRect",
     150,
     64,
-    66.66666666666666,
-    15,
-  ],
-  Array [
-    "set fillStyle",
-    "#ffffff",
-  ],
-  Array [
-    "fillRect",
-    150,
-    64,
-    1,
+    66.4,
     15,
   ],
   Array [
@@ -467,20 +378,9 @@ Array [
   ],
   Array [
     "fillRect",
-    216.66666666666666,
+    217,
     64,
-    66.66666666666666,
-    15,
-  ],
-  Array [
-    "set fillStyle",
-    "#ffffff",
-  ],
-  Array [
-    "fillRect",
-    216.66666666666666,
-    64,
-    1,
+    66.4,
     15,
   ],
   Array [

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -19,8 +19,6 @@ export class FastFillStyle {
 
   set(fillStyle: string) {
     if (fillStyle !== this._previousFillColor) {
-      // This could throw if setCtx wasn't set before calling it. Don't provide an
-      // extra check here since this code is so hot.
       this._ctx.fillStyle = fillStyle;
       this._previousFillColor = fillStyle;
     }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+
+/**
+ * Firefox has issues switching quickly between fill style colors, as the CSS color
+ * is fully parsed each time it is set. As a mitigation, provide a class that only
+ * switches the color when it's really needed.
+ */
+export class FastFillStyle {
+  _ctx: CanvasRenderingContext2D;
+  _previousFillColor: string;
+
+  constructor(ctx: CanvasRenderingContext2D) {
+    this._ctx = ctx;
+    this._previousFillColor = '';
+  }
+
+  set(fillStyle: string) {
+    if (fillStyle !== this._previousFillColor) {
+      // This could throw if setCtx wasn't set before calling it. Don't provide an
+      // extra check here since this code is so hot.
+      this._ctx.fillStyle = fillStyle;
+      this._previousFillColor = fillStyle;
+    }
+  }
+}


### PR DESCRIPTION
This PR changes the strategy for drawing the stack chart to draw small
boxes freely, but to leave 1 pixel gaps between boxes. If there are many
small boxes, it skips them until it finds either the next small box 1
pixel over, or the next box that is larger than 1 pixel.

In addition, it provides a small protection against calls to set
fillStyle which are slow due to the re-parsing of the CSS color.