### PR TITLE
Position screenshot overlays using transform

### DIFF
--- a/src/components/timeline/TrackScreenshots.css
+++ b/src/components/timeline/TrackScreenshots.css
@@ -32,11 +32,14 @@
   position: absolute;
   pointer-events: none;
   z-index: 4; /* Ensure this is higher than any other timeline element. */
+
+  /* The left edge of the element will be absolutely positioned at the mouse
+   * position. So we want to move the element so that its center is actually
+   * at the mouse position. */
+  transform: translate(-50%);
 }
 
 .timelineTrackScreenshotHoverImg {
-  position: relative;
-  left: -50%;
   border-radius: 5px;
   padding: 0.5px;
   border: 0.5px solid rgba(0,0,0,.2);


### PR DESCRIPTION
This positions the screenshot overlay's center at the mouse position using
transforms instead of relative positioning, so that its container
doesn't move past the windows's edge, and there's no scrollbar
appearing.

Fixes #1427 

[Example profile](https://deploy-preview-1430--perf-html.netlify.com/public/404ff08ee5f412f355264601f12e5feff0ebaee6/network-chart/?globalTrackOrder=6-1-2-3-4-0-5&hiddenGlobalTracks=1-2-3-4&localTrackOrderByPid=15249-1-0~15254-0~&range=10.0984_14.1128&thread=0&v=3)

Please compare with the other solution in https://github.com/devtools-html/perf.html/pull/1431