### PR TITLE
Update fixtures/profiles/gecko-profile.js to the current format.

### DIFF
--- a/src/test/fixtures/profiles/gecko-profile.js
+++ b/src/test/fixtures/profiles/gecko-profile.js
@@ -12,6 +12,8 @@ import type {
   GeckoMarkerStack,
 } from '../../../types/gecko-profile';
 
+import { CURRENT_VERSION } from '../../../profile-logic/gecko-profile-versioning';
+
 /**
  * export defaults one object that is an example profile, in the Gecko format,
  * i.e. the format that nsIProfiler.getProfileDataAsync outputs.
@@ -80,8 +82,13 @@ export default function createGeckoProfile(): GeckoProfile {
     startTime: 1460221352723.438,
     shutdownTime: 1560221352723,
     toolkit: 'cocoa',
-    version: 5,
-    categories: [],
+    version: CURRENT_VERSION,
+    categories: [
+      {
+        name: 'Other',
+        color: 'grey',
+      },
+    ],
   };
 
   const contentProcessMeta: GeckoProfileMeta = {
@@ -140,8 +147,6 @@ function _createGeckoThread(): GeckoThread {
         responsiveness: 2,
         rss: 3,
         uss: 4,
-        frameNumber: 5,
-        power: 6,
       },
       data: [
         [1, 0, 0, null, null], // (root), 0x100000f84
@@ -176,7 +181,7 @@ function _createGeckoThread(): GeckoThread {
         [0, null, null, null, null], // (root)
         [1, null, null, null, null], // 0x100000f84
         [2, null, null, null, null], // 0x100001a45
-        [3, null, null, 4391, 16], // Startup::XRE_Main, line 4391, category 16
+        [3, null, null, 4391, 0], // Startup::XRE_Main, line 4391, category Other
         [7, 6, null, 34, null], // frobnicate, implementation 'baseline', line 34
       ],
     },
@@ -268,16 +273,28 @@ function _createGeckoThread(): GeckoThread {
         [
           8,
           9,
-          // This doesn't really match the current marker payloads, so coerce
-          // it to any:
-          ({
-            // DOMEvent at time 9ms from 9ms to 10ms
-            startTime: 9,
-            endTime: 10,
+          {
+            // DOMEvent at time 9ms from 9ms to 10ms, this is the start marker
+            type: 'tracing',
+            category: 'DOMEvent',
             timeStamp: 1,
-            type: 'mouseout',
+            interval: 'start',
+            eventType: 'mouseout',
             phase: 3,
-          }: any),
+          },
+        ],
+        [
+          8,
+          10,
+          {
+            // DOMEvent at time 9ms from 9ms to 10ms, this is the end marker
+            type: 'tracing',
+            category: 'DOMEvent',
+            timeStamp: 1,
+            interval: 'end',
+            eventType: 'mouseout',
+            phase: 3,
+          },
         ],
         [
           11, // UserTiming

--- a/src/test/unit/profile-data.test.js
+++ b/src/test/unit/profile-data.test.js
@@ -267,15 +267,6 @@ describe('process-profile', function() {
       expect(thread.stringTable.getString(name0)).toEqual('firefox');
       expect(thread.stringTable.getString(name1)).toEqual('chrome://blargh');
     });
-    it('should preserve pids for threads that have them', function() {
-      expect(profile.threads[0].pid).toEqual(2222);
-    });
-    it('should create a string label for unknown thread pids', function() {
-      const geckoProfile = getGeckoProfile();
-      delete geckoProfile.threads[0].pid;
-      const profileWithNoPids = processProfile(geckoProfile);
-      expect(profileWithNoPids.threads[0].pid).toEqual('Unknown Process 1');
-    });
   });
   describe('DevTools profiles', function() {
     it('should process correctly', function() {


### PR DESCRIPTION
The Gecko profile we created in this function was marked with `version: 5`, but it was using the flow types of the current version. I think it's better if this profile always uses the current version.

I've removed a test for how missing pids are upgraded, because that code doesn't run during profile processing, it runs during profile upgrading, so it is (or should be) tested by the upgrade tests.