### PR TITLE
Change 6ms to 5ms in simple-call-tree.svg

### DIFF
--- a/docs-user/images/simple-call-tree.svg
+++ b/docs-user/images/simple-call-tree.svg
@@ -26,16 +26,16 @@
       </g>
     </g>
     <text font-family="Helvetica" font-size="11">
-      <tspan x="128.215" y="88" fill="#000">(Running time: </tspan> <tspan x="202.803" y="88" fill="#0A84FF" font-family="Helvetica-Bold, Helvetica" font-weight="bold">6ms</tspan> <tspan x="224.82" y="88" fill="#000">) (Self time: </tspan> <tspan x="284.106" y="88" fill="#0A84FF" font-family="Helvetica-Bold, Helvetica" font-weight="bold">0ms</tspan> <tspan x="306.122" y="88" fill="#000">)</tspan>
+      <tspan x="128.215" y="88" fill="#000">(Running time: </tspan> <tspan x="202.803" y="88" fill="#0A84FF" font-family="Helvetica-Bold, Helvetica" font-weight="bold">5ms</tspan> <tspan x="224.82" y="88" fill="#000">) (Self time: </tspan> <tspan x="284.106" y="88" fill="#0A84FF" font-family="Helvetica-Bold, Helvetica" font-weight="bold">0ms</tspan> <tspan x="306.122" y="88" fill="#000">)</tspan>
     </text>
     <text font-family="Helvetica" font-size="11">
-      <tspan x="129.215" y="142" fill="#000">(Running time: </tspan> <tspan x="203.803" y="142" fill="#0A84FF" font-family="Helvetica-Bold, Helvetica" font-weight="bold">6ms</tspan> <tspan x="225.82" y="142" fill="#000">) (Self time: </tspan> <tspan x="285.106" y="142" fill="#0A84FF" font-family="Helvetica-Bold, Helvetica" font-weight="bold">0ms</tspan> <tspan x="307.122" y="142" fill="#000">)</tspan>
+      <tspan x="129.215" y="142" fill="#000">(Running time: </tspan> <tspan x="203.803" y="142" fill="#0A84FF" font-family="Helvetica-Bold, Helvetica" font-weight="bold">5ms</tspan> <tspan x="225.82" y="142" fill="#000">) (Self time: </tspan> <tspan x="285.106" y="142" fill="#0A84FF" font-family="Helvetica-Bold, Helvetica" font-weight="bold">0ms</tspan> <tspan x="307.122" y="142" fill="#000">)</tspan>
     </text>
     <text font-family="Helvetica" font-size="11">
-      <tspan x="128.215" y="196" fill="#000">(Running time: </tspan> <tspan x="202.803" y="196" fill="#0A84FF" font-family="Helvetica-Bold, Helvetica" font-weight="bold">6ms</tspan> <tspan x="224.82" y="196" fill="#000">) (Self time: </tspan> <tspan x="284.106" y="196" fill="#0A84FF" font-family="Helvetica-Bold, Helvetica" font-weight="bold">0ms</tspan> <tspan x="306.122" y="196" fill="#000">)</tspan>
+      <tspan x="128.215" y="196" fill="#000">(Running time: </tspan> <tspan x="202.803" y="196" fill="#0A84FF" font-family="Helvetica-Bold, Helvetica" font-weight="bold">5ms</tspan> <tspan x="224.82" y="196" fill="#000">) (Self time: </tspan> <tspan x="284.106" y="196" fill="#0A84FF" font-family="Helvetica-Bold, Helvetica" font-weight="bold">0ms</tspan> <tspan x="306.122" y="196" fill="#000">)</tspan>
     </text>
     <text font-family="Helvetica" font-size="11">
-      <tspan x="147.215" y="249" fill="#000">(Running time: </tspan> <tspan x="221.803" y="249" fill="#0A84FF" font-family="Helvetica-Bold, Helvetica" font-weight="bold">6ms</tspan> <tspan x="243.82" y="249" fill="#000">) (Self time: </tspan> <tspan x="303.106" y="249" fill="#0A84FF" font-family="Helvetica-Bold, Helvetica" font-weight="bold">6ms</tspan> <tspan x="325.122" y="249" fill="#000">)</tspan>
+      <tspan x="147.215" y="249" fill="#000">(Running time: </tspan> <tspan x="221.803" y="249" fill="#0A84FF" font-family="Helvetica-Bold, Helvetica" font-weight="bold">5ms</tspan> <tspan x="243.82" y="249" fill="#000">) (Self time: </tspan> <tspan x="303.106" y="249" fill="#0A84FF" font-family="Helvetica-Bold, Helvetica" font-weight="bold">5ms</tspan> <tspan x="325.122" y="249" fill="#000">)</tspan>
     </text>
   </g>
 </svg>


### PR DESCRIPTION
Since the preceding picture in the docs have five samples with a sampling interval of 1 ms, this SVG should show 5ms instead of 6ms.