### PR TITLE
fix typos and phrase structure in documentation files

### DIFF
--- a/docs-user/bunny-2.md
+++ b/docs-user/bunny-2.md
@@ -26,7 +26,7 @@ worker.addEventListener('message', message => {
 });
 ```
 
-In this example, the iframe draws to the canvas, and once it's done, it posts a message to the worker asking it generate a new list of the draw calls. While this works, it's not harnessing the fact that the worker can run code in parallel. The fix luckily is simple. Swap the order of the `drawRect` and `worker.postMessage` calls.
+In this example, the iframe draws to the canvas, and once it's done, it posts a message to the worker asking it to generate a new list of the draw calls. While this works, it's not harnessing the fact that the worker can run code in parallel. The fix luckily is simple. Swap the order of the `drawRect` and `worker.postMessage` calls.
 
 ```js
 worker.addEventListener('message', message => {
@@ -71,8 +71,8 @@ Here there are a lot more frames being drawn. The end-user will perceive a more 
 
 ## In summary
 
-Code can be optimized to do less work, and this is can be great for being able to have smoother running code, and a longer battery life. Another class of optimizations is better parallelism. Making code non-blocking means that more work can be performed at the same time, and the results can be presented to the user.
+Code can be optimized to do less work, and this can be great for being able to have smoother running code, and a longer battery life. Another class of optimizations is better parallelism. Making code non-blocking means that more work can be performed at the same time and the results can be presented to the user.
 
-The main trade-off with greater parallelism, is that more power can be consumed when threads do not remain idle. In the above example a greater frame-rate was achieved by parallelizing the tasks, but more work was in fact being done by the smoother-running parallel code.
+The main trade-off with greater parallelism is that more power can be consumed when threads do not remain idle. In the above example, a greater frame-rate was achieved by parallelizing the tasks, but more work was in fact being done by the smoother-running parallel code.
 
 This type of optimization has lots of relevance when working on large multi-threaded applications. While synchronous IPC (inter-process communication) can cause code to become blocked while waiting for a response, asynchronous communication can also cause code to be blocked from executing. It's important to profile to verify the assumptions of how tasks will be scheduled in real-world code.

--- a/docs-user/bunny.md
+++ b/docs-user/bunny.md
@@ -1,7 +1,7 @@
 # Case Study
 ## 2D canvas and worker messaging
 
-The following article is a case study in using the profiler to identify performance issues. The fixes made the code run four times faster, and changed the frame rate from from a fairly slow 15fps to a smooth 60fps. The process for this analysis follows a common pattern:
+The following article is a case study in using the profiler to identify performance issues. The fixes made the code run four times faster, and changed the frame rate from a fairly slow 15fps to a smooth 60fps. The process for this analysis follows a common pattern:
 
  * Profile the code
  * Identify slow areas
@@ -14,7 +14,7 @@ The following article is a case study in using the profiler to identify performa
 
 ![A picture of a 3d bunny rabbit model rendered using small squares.](./images/bunny-analysis/bunny.png)
 
-The project is a website that takes user's JavaScript code, and runs it to produce a visualization. The user's code only has access to the function `rect(color, x, y, width, height)`, which draws a rectangle to the screen. For the implementation, the website posts the user's code to a sandboxed iframe. The iframe has a `<canvas>` element that is rendered to via the [`CanvasRenderingContext2D`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D) API. The user's code is evaluated in a WebWorker, and then the results of `rect()` are posted back to the iframe's code.
+The project is a website that takes user's JavaScript code and runs it to produce a visualization. The user's code only has access to the function `rect(color, x, y, width, height)`, which draws a rectangle to the screen. For the implementation, the website posts the user's code to a sandboxed iframe. The iframe has a `<canvas>` element that is rendered to via the [`CanvasRenderingContext2D`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D) API. The user's code is evaluated in a WebWorker, and then the results of `rect()` are posted back to the iframe's code.
 
 In a simplified example, the `worker.js` would run something like:
 
@@ -56,7 +56,7 @@ This would result in user's evaluated code drawing something to the screen, like
 
 Baseline profile: https://perfht.ml/2IxTwqi
 
-This code ended up not scaling well for large sets of rectangles being drawn to the screen. There were lots of stutters, and a slow frame rate. The user impact for fixing this problem would be to have a smoother frame rate, plus the ability to draw many more rectangles to the screen without slowing things down. In order to validate fixes, the following steps were used to reproduce the issue.
+This code ended up not scaling well for large sets of rectangles being drawn to the screen. There were lots of stutters and a slow frame rate. The user's impact for fixing this problem would be to have a smoother frame rate, plus the ability to draw many more rectangles to the screen without slowing things down. In order to validate fixes, the following steps were used to reproduce the issue.
 
  * Load the page with the bunny visualization.
  * Hit Ctrl Shift 1 to turn on the Gecko Profiler.
@@ -87,7 +87,7 @@ The thread list also nicely shows the message passing between the content proces
 
 ### Problems in the content process' main thread
 
-The Flame Graph provides a nice view into a summary of where time is spent. The X axis represents the percentage of time spent with that function in that stack for all visible stacks. In a previous step the idle time was already hidden from the analysis.
+The Flame Graph provides a nice view into a summary of where time is spent. The X axis represents the percentage of time spent with that function in that stack for all visible stacks. In a previous step, the idle time was already hidden from the analysis.
 
 The stacks are rather deep here, so a nice first step is to focus on just the subtree that is interesting. Visually, `nsThread::ProcessNextEvent` is the last function most common to the tree. Right click and focus on that subtree.
 
@@ -152,11 +152,11 @@ The flame chart shows the summary of where time was spent. The overall length of
 
 ![Screenshot of the flame graph of the content process after applying the fix.](./images/bunny-analysis/flame-graph-set-fillstyle.png)
 
-The flame graph can still provide the information for the magnitude of the change. The way to do this is to look at the `(root)` function on the stack. The idle stacks were dropped in the steps to reproduce, so the only remaining samples are once where (presumably) work was being done. `(root)` has a running time of 2107ms before and while it has a running time of 1613ms after. This is a difference of 1.3 times. However, the range selection is a bit fuzzy, so the FPS is probably a better indicator for this analysis, and the actual result that is visible to the end-user. It's always important to optimized for the perceived performance characteristics.
+The flame graph can still provide the information for the magnitude of the change. The way to do this is to look at the `(root)` function on the stack. The idle stacks were dropped in the steps to reproduce, so the only remaining samples are once where (presumably) work was being done. `(root)` has a running time of 2107ms before and while it has a running time of 1613ms after. This is a difference of 1.3 times. However, the range selection is a bit fuzzy, so the FPS is probably a better indicator for this analysis, and the actual result that is visible to the end-user. It's always important to be optimized for the perceived performance characteristics.
 
 ## Fixing structured cloning
 
-The larger chunk of work, and probably harder to optimize is the [structured clone](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm). The definition of this algorithm is available on MDN and states:
+The larger chunk of work, and probably harder to optimize, is the [structured clone](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm). The definition of this algorithm is available on MDN and states:
 
 > The structured clone algorithm is an algorithm defined by the HTML5 specification for copying complex JavaScript objects. It is used internally when transferring data to and from Workers via postMessage() or when storing objects with IndexedDB. It builds up a clone by recursing through the input object while maintaining a map of previously visited references in order to avoid infinitely traversing cycles.
 
@@ -177,7 +177,7 @@ Already the structure is optimized to not have lots of little objects, making it
 
 Perhaps it would be better to send over typed arrays, that better match the data that will be sent over. A typed array is probably much simpler in its internal representation for cloning.
 
-Another thing is that duplicating the strings over and over could get expensive, and unnecessarily bloat the code. It would be better to store a table of strings, and use an array that stores indexes into that table.
+Another thing is that duplicating the strings over and over could get expensive and unnecessarily bloat the code. It would be better to store a table of strings, and use an array that stores indexes into that table.
 
 ## The code
 
@@ -229,7 +229,7 @@ console.log(array.length);
 // > 3
 ```
 
-Finally when posting the message, the code would send over the bare typed arrays.
+Finally, when posting the message, the code would send over the bare typed arrays.
 
 ```js
 self.postMessage({
@@ -243,7 +243,7 @@ self.postMessage({
 })
 ```
 
-This makes the code much more complex, and hard to maintain, but it could be the key to better performance. This is a common trade-off with fast code and simple code. It's important that any additional complexities are backed by an analysis that it actually affects user-perceived performance.
+This makes the code much more complex and hard to maintain, but it could be the key to better performance. This is a common trade-off with fast code and simple code. It's important that any additional complexities are backed by an analysis that it actually affects user-perceived performance.
 
 ### The resulting structured clone profile:
 
@@ -269,7 +269,7 @@ Profiling the code revealed a simple fix to setting `fillStyle`. These code chan
 
 The structured cloning code was a more complicated problem to solve. The solution ended up increasing the complexity of the code, but is justified by the fairly dramatic end-user benefit. The solution was figured out through thinking about the algorithmic complexity of the structured cloning algorithm, and figuring out a way to fit the constraints of the project's data into a faster data structure.
 
-In the analysis, only the functions that were taking the most time were considered for optimization. This helps to prioritize impactful work, and mitigate the dangers of introducing unneeded complexity to the codebase.
+In the analysis, only the functions that were taking the most time were considered for optimization. This helps to prioritize impactful work and mitigate the dangers of introducing unneeded complexity to the codebase.
 
 A good follow-up would be to do more analysis on a variety of different test cases to ensure that these changes didn't regress performance on a different example.
 


### PR DESCRIPTION
Changes performed:
- removed repeated `from`
- removed unnecesarry comma before coordinating conjuction `and`
- `The user's impact for fixing this problem`: added apostrophe to show possession
- `The larger chunk of work, and probably harder to optimize, is the ...`: I have added a comma to isolate the appositive structure from the rest of the sentence 
- `it posts a message to the worker asking it to generate`: infinitive form added
- `The main trade-off with greater parallelism is ...`: removed comma between subject and verb
