### PR TITLE
Don't display LongTask markers in the marker timeline.

### DIFF
--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -1043,6 +1043,8 @@ export const selectorsForThread = (
           tm =>
             tm.name !== 'GCMajor' &&
             tm.name !== 'BHR-detected hang' &&
+            tm.name !== 'LongTask' &&
+            tm.name !== 'LongIdleTask' &&
             !MarkerData.isNetworkMarker(tm)
         )
     );

--- a/src/test/components/TimelineTracingMarkersOverview.test.js
+++ b/src/test/components/TimelineTracingMarkersOverview.test.js
@@ -56,6 +56,26 @@ describe('TimelineTracingMarkersOverview', function() {
         5,
         { type: 'BHR-detected hang', startTime: 2, endTime: 13 },
       ],
+      [
+        'LongTask',
+        6,
+        {
+          type: 'MainThreadLongTask',
+          category: 'LongTask',
+          startTime: 2,
+          endTime: 6,
+        },
+      ],
+      [
+        'LongIdleTask',
+        8,
+        {
+          type: 'MainThreadLongTask',
+          category: 'LongTask',
+          startTime: 6,
+          endTime: 8,
+        },
+      ],
     ]);
 
     const overview = renderer.create(

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -382,6 +382,13 @@ export type BHRMarkerPayload = {
   endTime: Milliseconds,
 };
 
+export type LongTaskMarkerPayload = {
+  type: 'MainThreadLongTask',
+  category: 'LongTask',
+  startTime: Milliseconds,
+  endTime: Milliseconds,
+};
+
 /*
  * The payload for Frame Construction.
  */
@@ -415,6 +422,7 @@ export type MarkerPayload =
   | GCSliceMarkerPayload
   | StyleMarkerPayload
   | BHRMarkerPayload
+  | LongTaskMarkerPayload
   | VsyncTimestampPayload
   | ScreenshotPayload
   | FrameConstructionMarkerPayload


### PR DESCRIPTION
They cover up other more useful markers and duplicate information from the responsiveness instrumentation.