### PR TITLE
Fix some minor issues in the documentation

### DIFF
--- a/docs-user/guide-filtering-call-trees.md
+++ b/docs-user/guide-filtering-call-trees.md
@@ -42,7 +42,7 @@ The following graphic demonstrates how it can be useful to filter to only JavaSc
 
 Before the implementation filter, the call tree contains both C++ JavaScript internals, as well as the JavaScript stacks. This interleaving could be useful when diagnosing how the JS engine is optimizing code, but for normal JS performance profiling this could be confusing to find hot JS functions. When the native stacks are removed, the call tree that is generated is much more sensible for representing the execution of JavaScript code.
 
-The implementation filter will modify the shape of stacks, and generate a completely new call tree. If the any of the filtered stacks in a sample are empty (for instance filtering on JavaScript when there are only C++ stacks), then those samples with empty stacks will be dropped from the analysis.
+The implementation filter will modify the shape of stacks, and generate a completely new call tree. If any of the filtered stacks in a sample are empty (for instance filtering on JavaScript when there are only C++ stacks), then those samples with empty stacks will be dropped from the analysis.
 
 ## Invert call stack
 

--- a/docs-user/guide-profiler-fundamentals.md
+++ b/docs-user/guide-profiler-fundamentals.md
@@ -12,7 +12,7 @@ There are two ways to get more samples to provide more statistical significance.
 
 ![A picture of the dropdown in the Gecko Profiler Addon with the interval adjustment highlighted.](images/interval.jpg)
 
-For example the sampling rate could be increased from 1ms to 0.1ms to collect 10 times more samples. This makes it easy to run the profiled program fewer times, but comes with a trade-off. When the profiler is collecting more samples, the profiler needs to do more work to collect these samples, and thus there is more overhead from the profiler. This can skew the results by measuring more of the overhead of profiling, compared to the actual program that is being run.
+For example the sampling rate could be increased by changing the interval from 1ms to 0.1ms to collect 10 times more samples. This makes it easy to run the profiled program fewer times, but comes with a trade-off. When the profiler is collecting more samples, the profiler needs to do more work to collect these samples, and thus there is more overhead from the profiler. This can skew the results by measuring more of the overhead of profiling, compared to the actual program that is being run.
 
 The other way to increase the number of samples is to run the code more often, and not increase the sampling rate. For instance to profile a mouse click event, one click event would not be sampled much with a frequency of 1ms. However, performing the click event multiple times over the course of a minute would increase the amount of samples collected, without introducing additional overhead from the profiler.
 

--- a/docs-user/guide-stack-samples-and-call-trees.md
+++ b/docs-user/guide-stack-samples-and-call-trees.md
@@ -28,7 +28,7 @@ This image shows that the profiler sampled `B` at the beginning and end of the p
 
 ![This graphic demonstrates the modified call tree. It is a chart of the stacks A, B, C, and doWork, each connected by an arrow going from the root A to the leaf doWork. A has a running time of 5ms, and a self time of 0ms. B has a running time of 5ms, and a self time of 2ms. C has a running time of 3ms, and a self time of 0ms. doWork has a running time of 3ms, and a self time of 3ms.](./images/simple-call-tree-self-time.svg)
 
-The call node with the function `B` continues to have the running time of 5ms, but also has a self time of 2ms. Function `C` has a reduced running time of `3ms` and finally do work was only observed `3ms` for both the running and self time.
+The call node with the function `B` continues to have the running time of 5ms, but also has a self time of 2ms. Function `C` has a reduced running time of `3ms` and finally `doWork` was only observed `3ms` for both the running and self time.
 
 In summary, self time is where work was actually happening when observed by the profiler.
 


### PR DESCRIPTION
- Remove unnecessary `the`
- Clarify that the sampling interval is not the rate
- Put function name `doWork` in backticks