### PR TITLE
Add 'pages' array to processed profile format and remove the URLs while sharing without URLs

### DIFF
--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -906,8 +906,17 @@ export function serializeProfile(
   includeNetworkUrls: boolean = true
 ): string {
   // stringTable -> stringArray
+  let urlCounter = 0;
   const newProfile = Object.assign({}, profile, {
     meta: { ...profile.meta, networkURLsRemoved: !includeNetworkUrls },
+    pages:
+      includeNetworkUrls === false
+        ? profile.pages.map(page =>
+            Object.assign({}, page, {
+              url: 'Page #' + urlCounter++,
+            })
+          )
+        : profile.pages,
     threads: profile.threads.map(thread => {
       const stringArray = thread.stringTable.serializeToArray();
       const newThread = Object.assign({}, thread);

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -859,6 +859,12 @@ export function processProfile(
     );
   }
 
+  let pages = [...(geckoProfile.pages || [])];
+
+  for (const subprocessProfile of geckoProfile.processes) {
+    pages = pages.concat(subprocessProfile.pages);
+  }
+
   const meta = {
     interval: geckoProfile.meta.interval,
     startTime: geckoProfile.meta.startTime,
@@ -885,6 +891,7 @@ export function processProfile(
 
   const result = {
     meta,
+    pages,
     threads,
   };
   return result;

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -862,7 +862,7 @@ export function processProfile(
   let pages = [...(geckoProfile.pages || [])];
 
   for (const subprocessProfile of geckoProfile.processes) {
-    pages = pages.concat(subprocessProfile.pages);
+    pages = pages.concat(subprocessProfile.pages || []);
   }
 
   const meta = {
@@ -910,7 +910,7 @@ export function serializeProfile(
   const newProfile = Object.assign({}, profile, {
     meta: { ...profile.meta, networkURLsRemoved: !includeNetworkUrls },
     pages:
-      includeNetworkUrls === false
+      includeNetworkUrls === false && profile.pages
         ? profile.pages.map(page =>
             Object.assign({}, page, {
               url: 'Page #' + urlCounter++,

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -1425,6 +1425,7 @@ export function getEmptyProfile(): Profile {
       physicalCPUs: 0,
       logicalCPUs: 0,
     },
+    pages: [],
     threads: [],
   };
 }

--- a/src/test/fixtures/profiles/gecko-profile.js
+++ b/src/test/fixtures/profiles/gecko-profile.js
@@ -102,6 +102,7 @@ export default function createGeckoProfile(): GeckoProfile {
     meta: contentProcessMeta,
     pausedRanges: [],
     libs: [contentProcessBinary].concat(extraBinaries), // libs are stringified in the Gecko profile
+    pages: [],
     threads: [
       {
         ..._createGeckoThread(),
@@ -115,6 +116,7 @@ export default function createGeckoProfile(): GeckoProfile {
   return {
     meta: parentProcessMeta,
     libs: [parentProcessBinary].concat(extraBinaries),
+    pages: [],
     pausedRanges: [],
     threads: [
       {

--- a/src/test/fixtures/profiles/timings-with-js.js
+++ b/src/test/fixtures/profiles/timings-with-js.js
@@ -11,6 +11,7 @@ export default function createGeckoProfile(): GeckoProfile {
   return {
     meta: geckoProfile.meta,
     libs: geckoProfile.libs,
+    pages: geckoProfile.pages,
     pausedRanges: [],
     threads: [
       _createGeckoThread('GeckoMain'),

--- a/src/test/store/__snapshots__/profile-view.test.js.snap
+++ b/src/test/store/__snapshots__/profile-view.test.js.snap
@@ -60,6 +60,7 @@ Object {
     "toolkit": "",
     "version": 14,
   },
+  "pages": Array [],
   "threads": Array [
     Object {
       "frameTable": Object {

--- a/src/test/unit/__snapshots__/profile-conversion.test.js.snap
+++ b/src/test/unit/__snapshots__/profile-conversion.test.js.snap
@@ -60,6 +60,7 @@ Object {
     "toolkit": "",
     "version": 14,
   },
+  "pages": Array [],
   "threads": Array [
     Object {
       "frameTable": Object {
@@ -5619,6 +5620,7 @@ Object {
     "toolkit": undefined,
     "version": 14,
   },
+  "pages": Array [],
   "threads": Array [
     Object {
       "frameTable": Object {

--- a/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
+++ b/src/test/unit/__snapshots__/profile-upgrading.test.js.snap
@@ -61,6 +61,7 @@ Object {
     "toolkit": undefined,
     "version": 14,
   },
+  "pages": Array [],
   "threads": Array [
     Object {
       "frameTable": Object {

--- a/src/types/gecko-profile.js
+++ b/src/types/gecko-profile.js
@@ -8,6 +8,7 @@ import type {
   IndexIntoStringTable,
   PausedRange,
   CategoryList,
+  PageList,
 } from './profile';
 import type { MarkerPayload_Gecko } from './markers';
 import type { Milliseconds } from './units';
@@ -192,6 +193,7 @@ export type GeckoProfileMeta = {|
 export type GeckoProfile = {|
   meta: GeckoProfileMeta,
   libs: Lib[],
+  pages: PageList,
   threads: GeckoThread[],
   pausedRanges: PausedRange[],
   tasktracer?: Object,

--- a/src/types/gecko-profile.js
+++ b/src/types/gecko-profile.js
@@ -193,7 +193,7 @@ export type GeckoProfileMeta = {|
 export type GeckoProfile = {|
   meta: GeckoProfileMeta,
   libs: Lib[],
-  pages: PageList,
+  pages?: PageList,
   threads: GeckoThread[],
   pausedRanges: PausedRange[],
   tasktracer?: Object,

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -190,6 +190,15 @@ export type Category = {
 
 export type CategoryList = Array<Category>;
 
+export type Page = {
+  docshellId: string,
+  historyId: number,
+  url: string,
+  isSubFrame: boolean,
+};
+
+export type PageList = Array<Page>;
+
 /**
  * Information about a period of time during which no samples were collected.
  */
@@ -327,5 +336,6 @@ export type ProfileMeta = {|
  */
 export type Profile = {
   meta: ProfileMeta,
+  pages: PageList,
   threads: Thread[],
 };

--- a/src/types/profile.js
+++ b/src/types/profile.js
@@ -190,12 +190,12 @@ export type Category = {
 
 export type CategoryList = Array<Category>;
 
-export type Page = {
+export type Page = {|
   docshellId: string,
   historyId: number,
   url: string,
   isSubFrame: boolean,
-};
+|};
 
 export type PageList = Array<Page>;
 
@@ -336,6 +336,6 @@ export type ProfileMeta = {|
  */
 export type Profile = {
   meta: ProfileMeta,
-  pages: PageList,
+  pages?: PageList,
   threads: Thread[],
 };


### PR DESCRIPTION
After [Bug 1417976](https://bugzilla.mozilla.org/show_bug.cgi?id=1417976) we now have `pages` array in gecko profile. Added this array to processed profile format as well and removed the URLs if necessary.