### PR TITLE
Hide the network tab if no network requests exist

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -41,13 +41,6 @@ export function setProfileSharingStatus(
   };
 }
 
-export function changeTabOrder(tabOrder: number[]): Action {
-  return {
-    type: 'CHANGE_TAB_ORDER',
-    tabOrder,
-  };
-}
-
 export function urlSetupDone(): ThunkAction<void> {
   return (dispatch, getState) => {
     dispatch({ type: 'URL_SETUP_DONE' });

--- a/src/app-logic/tabs-handling.js
+++ b/src/app-logic/tabs-handling.js
@@ -31,6 +31,11 @@ export const tabSlugs: $ReadOnlyArray<TabSlug> =
   Object.getOwnPropertyNames(tabsWithTitle);
 
 /**
+ * It can be useful to have a list of the tab indexes to operate upon.
+ */
+export const tabIndexes: $ReadOnlyArray<number> = tabSlugs.map((_, i) => i);
+
+/**
  * This array contains the same data as tabsWithTitle above, but in an ordered
  * array so that we can use it directly in some of our components.
  */
@@ -40,11 +45,3 @@ export const tabsWithTitleArray: $ReadOnlyArray<TabWithTitle> = tabSlugs.map(
     title: tabsWithTitle[tabSlug],
   })
 );
-
-/**
- * This function returns the initial order of the tabs.
- * This is simply the sequence of all array indices in ascending order.
- */
-export function getInitialTabOrder(): number[] {
-  return Array.from({ length: tabSlugs.length }, (_, i) => i);
-}

--- a/src/app-logic/tabs-handling.js
+++ b/src/app-logic/tabs-handling.js
@@ -31,11 +31,6 @@ export const tabSlugs: $ReadOnlyArray<TabSlug> =
   Object.getOwnPropertyNames(tabsWithTitle);
 
 /**
- * It can be useful to have a list of the tab indexes to operate upon.
- */
-export const tabIndexes: $ReadOnlyArray<number> = tabSlugs.map((_, i) => i);
-
-/**
  * This array contains the same data as tabsWithTitle above, but in an ordered
  * array so that we can use it directly in some of our components.
  */

--- a/src/components/app/Details.js
+++ b/src/components/app/Details.js
@@ -17,14 +17,9 @@ import NetworkChart from '../network-chart/';
 import FlameGraph from '../flame-graph/';
 import selectSidebar from '../sidebar';
 
-import {
-  changeSelectedTab,
-  changeTabOrder,
-  changeSidebarOpenState,
-} from '../../actions/app';
-import { getTabOrder } from '../../reducers/profile-view';
+import { changeSelectedTab, changeSidebarOpenState } from '../../actions/app';
 import { getSelectedTab } from '../../reducers/url-state';
-import { getIsSidebarOpen } from '../../reducers/app';
+import { getIsSidebarOpen, getVisibleTabs } from '../../reducers/app';
 import CallNodeContextMenu from '../shared/CallNodeContextMenu';
 import MarkerTableContextMenu from '../marker-table/ContextMenu';
 import TimelineTrackContextMenu from '../timeline/TrackContextMenu';
@@ -41,14 +36,13 @@ import '../../../res/css/photon-components.css';
 import './Details.css';
 
 type StateProps = {|
-  +tabOrder: number[],
+  +visibleTabs: $ReadOnlyArray<number>,
   +selectedTab: TabSlug,
   +isSidebarOpen: boolean,
 |};
 
 type DispatchProps = {|
   +changeSelectedTab: typeof changeSelectedTab,
-  +changeTabOrder: typeof changeTabOrder,
   +changeSidebarOpenState: typeof changeSidebarOpenState,
 |};
 
@@ -70,7 +64,7 @@ class ProfileViewer extends PureComponent<Props> {
   };
 
   render() {
-    const { tabOrder, selectedTab, isSidebarOpen, changeTabOrder } = this.props;
+    const { visibleTabs, selectedTab, isSidebarOpen } = this.props;
     const hasSidebar = selectSidebar(selectedTab) !== null;
     const extraButton = hasSidebar && (
       <button
@@ -94,9 +88,8 @@ class ProfileViewer extends PureComponent<Props> {
         <TabBar
           tabs={tabsWithTitleArray}
           selectedTabName={selectedTab}
-          tabOrder={tabOrder}
+          visibleTabs={visibleTabs}
           onSelectTab={this._onSelectTab}
-          onChangeTabOrder={changeTabOrder}
           extraElements={extraButton}
         />
         {
@@ -119,13 +112,12 @@ class ProfileViewer extends PureComponent<Props> {
 
 const options: ExplicitConnectOptions<{||}, StateProps, DispatchProps> = {
   mapStateToProps: state => ({
-    tabOrder: getTabOrder(state),
+    visibleTabs: getVisibleTabs(state),
     selectedTab: getSelectedTab(state),
     isSidebarOpen: getIsSidebarOpen(state),
   }),
   mapDispatchToProps: {
     changeSelectedTab,
-    changeTabOrder,
     changeSidebarOpenState,
   },
   component: ProfileViewer,

--- a/src/components/app/Details.js
+++ b/src/components/app/Details.js
@@ -24,7 +24,6 @@ import CallNodeContextMenu from '../shared/CallNodeContextMenu';
 import MarkerTableContextMenu from '../marker-table/ContextMenu';
 import TimelineTrackContextMenu from '../timeline/TrackContextMenu';
 import { toValidTabSlug } from '../../utils/flow';
-import { tabsWithTitleArray } from '../../app-logic/tabs-handling';
 
 import type {
   ExplicitConnectOptions,
@@ -36,7 +35,7 @@ import '../../../res/css/photon-components.css';
 import './Details.css';
 
 type StateProps = {|
-  +visibleTabs: $ReadOnlyArray<number>,
+  +visibleTabs: $ReadOnlyArray<TabSlug>,
   +selectedTab: TabSlug,
   +isSidebarOpen: boolean,
 |};
@@ -86,8 +85,7 @@ class ProfileViewer extends PureComponent<Props> {
     return (
       <div className="Details">
         <TabBar
-          tabs={tabsWithTitleArray}
-          selectedTabName={selectedTab}
+          selectedTabSlug={selectedTab}
           visibleTabs={visibleTabs}
           onSelectTab={this._onSelectTab}
           extraElements={extraButton}

--- a/src/components/app/TabBar.js
+++ b/src/components/app/TabBar.js
@@ -7,13 +7,12 @@
 import * as React from 'react';
 import classNames from 'classnames';
 
-import type { TabWithTitle } from '../../app-logic/tabs-handling';
+import { tabsWithTitle, type TabSlug } from '../../app-logic/tabs-handling';
 
 type Props = {|
   +className?: string,
-  +tabs: $ReadOnlyArray<TabWithTitle>,
-  +selectedTabName: string,
-  +visibleTabs: $ReadOnlyArray<number>,
+  +selectedTabSlug: string,
+  +visibleTabs: $ReadOnlyArray<TabSlug>,
   +onSelectTab: string => void,
   +extraElements?: React.Node,
 |};
@@ -29,30 +28,26 @@ class TabBar extends React.PureComponent<Props> {
   render() {
     const {
       className,
-      tabs,
-      selectedTabName,
+      selectedTabSlug,
       visibleTabs,
       extraElements,
     } = this.props;
     return (
       <div className={classNames('tabBarContainer', className)}>
         <ol className="tabBarTabWrapper">
-          {visibleTabs.map(tabIndex => {
-            const { name, title } = tabs[tabIndex];
-            return (
-              <li
-                className={classNames({
-                  tabBarTab: true,
-                  selected: name === selectedTabName,
-                })}
-                key={name}
-                data-name={name}
-                onMouseDown={this._mouseDownListener}
-              >
-                {title}
-              </li>
-            );
-          })}
+          {visibleTabs.map(tabSlug => (
+            <li
+              className={classNames({
+                tabBarTab: true,
+                selected: tabSlug === selectedTabSlug,
+              })}
+              key={tabSlug}
+              data-name={tabSlug}
+              onMouseDown={this._mouseDownListener}
+            >
+              {tabsWithTitle[tabSlug]}
+            </li>
+          ))}
         </ol>
         {extraElements}
       </div>

--- a/src/components/app/TabBar.js
+++ b/src/components/app/TabBar.js
@@ -6,18 +6,15 @@
 
 import * as React from 'react';
 import classNames from 'classnames';
-import Reorderable from '../shared/Reorderable';
 
-import type { Action } from '../../types/actions';
 import type { TabWithTitle } from '../../app-logic/tabs-handling';
 
 type Props = {|
   +className?: string,
   +tabs: $ReadOnlyArray<TabWithTitle>,
   +selectedTabName: string,
-  +tabOrder: number[],
+  +visibleTabs: $ReadOnlyArray<number>,
   +onSelectTab: string => void,
-  +onChangeTabOrder: (number[]) => Action,
   +extraElements?: React.Node,
 |};
 
@@ -34,33 +31,29 @@ class TabBar extends React.PureComponent<Props> {
       className,
       tabs,
       selectedTabName,
-      tabOrder,
-      onChangeTabOrder,
+      visibleTabs,
       extraElements,
     } = this.props;
     return (
       <div className={classNames('tabBarContainer', className)}>
-        <Reorderable
-          tagName="ol"
-          className="tabBarTabWrapper"
-          grippyClassName="grippy"
-          order={tabOrder}
-          orient="horizontal"
-          onChangeOrder={onChangeTabOrder}
-        >
-          {tabs.map(({ name, title }, i) => (
-            <li
-              className={classNames('tabBarTab', 'grippy', {
-                selected: name === selectedTabName,
-              })}
-              key={i}
-              data-name={name}
-              onMouseDown={this._mouseDownListener}
-            >
-              {title}
-            </li>
-          ))}
-        </Reorderable>
+        <ol className="tabBarTabWrapper">
+          {visibleTabs.map(tabIndex => {
+            const { name, title } = tabs[tabIndex];
+            return (
+              <li
+                className={classNames({
+                  tabBarTab: true,
+                  selected: name === selectedTabName,
+                })}
+                key={name}
+                data-name={name}
+                onMouseDown={this._mouseDownListener}
+              >
+                {title}
+              </li>
+            );
+          })}
+        </ol>
         {extraElements}
       </div>
     );

--- a/src/components/network-chart/NetworkChartEmptyReasons.js
+++ b/src/components/network-chart/NetworkChartEmptyReasons.js
@@ -7,6 +7,7 @@ import React, { PureComponent } from 'react';
 
 import EmptyReasons from '../shared/EmptyReasons';
 import { selectedThreadSelectors } from '../../reducers/profile-view';
+import { oneLine } from 'common-tags';
 
 import explicitConnect, {
   type ExplicitConnectOptions,
@@ -17,21 +18,23 @@ import type { State } from '../../types/store';
 
 type StateProps = {|
   +threadName: string,
-  +isNetworkChartEmptyInFullRange: boolean,
 |};
 
 type Props = ConnectedProps<{||}, StateProps, {||}>;
 class MarkerChartEmptyReasons extends PureComponent<Props> {
   render() {
-    const { isNetworkChartEmptyInFullRange, threadName } = this.props;
+    const { threadName } = this.props;
 
     return (
       <EmptyReasons
         threadName={threadName}
         reason={
-          isNetworkChartEmptyInFullRange
-            ? 'This thread has no network information.'
-            : 'All network requests were filtered out by the current selection or search term.'
+          // The network tab is never displayed if there are no markers in the full
+          // range, so never give that as a reason for it being empty.
+          oneLine`
+            All network requests were filtered out by the current selection or search
+            term. Try changing the search term, or zooming out.
+          `
         }
         viewName="network chart"
       />
@@ -42,9 +45,6 @@ class MarkerChartEmptyReasons extends PureComponent<Props> {
 const options: ExplicitConnectOptions<{||}, StateProps, {||}> = {
   mapStateToProps: (state: State) => ({
     threadName: selectedThreadSelectors.getFriendlyThreadName(state),
-    isNetworkChartEmptyInFullRange: selectedThreadSelectors.getIsNetworkChartEmptyInFullRange(
-      state
-    ),
   }),
   component: MarkerChartEmptyReasons,
 };

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -7,7 +7,7 @@ import { combineReducers } from 'redux';
 import { createSelector } from 'reselect';
 
 import { getSelectedTab } from './url-state';
-import { tabSlugs, tabIndexes } from '../app-logic/tabs-handling';
+import { tabSlugs } from '../app-logic/tabs-handling';
 import { selectedThreadSelectors } from './profile-view';
 
 import type { TabSlug } from '../app-logic/tabs-handling';
@@ -176,8 +176,8 @@ export const getLastVisibleThreadTabSlug = (state: State) =>
 
 export const getVisibleTabs = createSelector(
   selectedThreadSelectors.getIsNetworkChartEmptyInFullRange,
-  (isNetworkChartEmpty): $ReadOnlyArray<number> =>
+  (isNetworkChartEmpty): $ReadOnlyArray<TabSlug> =>
     isNetworkChartEmpty
-      ? tabIndexes.filter(tabIndex => tabSlugs[tabIndex] !== 'network-chart')
-      : tabIndexes
+      ? tabSlugs.filter(tabSlug => tabSlug !== 'network-chart')
+      : tabSlugs
 );

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -4,9 +4,11 @@
 
 // @flow
 import { combineReducers } from 'redux';
+import { createSelector } from 'reselect';
 
 import { getSelectedTab } from './url-state';
-import { tabSlugs } from '../app-logic/tabs-handling';
+import { tabSlugs, tabIndexes } from '../app-logic/tabs-handling';
+import { selectedThreadSelectors } from './profile-view';
 
 import type { TabSlug } from '../app-logic/tabs-handling';
 import type { Action } from '../types/store';
@@ -171,3 +173,11 @@ export const getPanelLayoutGeneration = (state: State) =>
   getApp(state).panelLayoutGeneration;
 export const getLastVisibleThreadTabSlug = (state: State) =>
   getApp(state).lastVisibleThreadTabSlug;
+
+export const getVisibleTabs = createSelector(
+  selectedThreadSelectors.getIsNetworkChartEmptyInFullRange,
+  (isNetworkChartEmpty): $ReadOnlyArray<number> =>
+    isNetworkChartEmpty
+      ? tabIndexes.filter(tabIndex => tabSlugs[tabIndex] !== 'network-chart')
+      : tabIndexes
+);

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -22,7 +22,6 @@ import * as MarkerTiming from '../profile-logic/marker-timing';
 import * as CallTree from '../profile-logic/call-tree';
 import { assertExhaustiveCheck, ensureExists } from '../utils/flow';
 import { arePathsEqual, PathSet } from '../utils/path';
-import { getInitialTabOrder } from '../app-logic/tabs-handling';
 
 import type {
   Profile,
@@ -463,15 +462,6 @@ function zeroAt(state: Milliseconds = 0, action: Action) {
   }
 }
 
-function tabOrder(state: number[] = getInitialTabOrder(), action: Action) {
-  switch (action.type) {
-    case 'CHANGE_TAB_ORDER':
-      return action.tabOrder;
-    default:
-      return state;
-  }
-}
-
 function rightClickedTrack(
   // Make the initial value the first global track, which is assumed to exists.
   // This makes the track reference always exist, which in turn makes it so that
@@ -555,7 +545,6 @@ export default wrapReducerInResetter(
       focusCallTreeGeneration,
       rootRange,
       zeroAt,
-      tabOrder,
       rightClickedTrack,
       isCallNodeContextMenuVisible,
       profileSharingStatus,
@@ -593,11 +582,6 @@ export const getFocusCallTreeGeneration = createSelector(
 export const getZeroAt = createSelector(
   getProfileViewOptions,
   viewOptions => viewOptions.zeroAt
-);
-
-export const getTabOrder = createSelector(
-  getProfileViewOptions,
-  viewOptions => viewOptions.tabOrder
 );
 
 export const getCommittedRange = createSelector(
@@ -1069,7 +1053,7 @@ export const selectorsForThread = (
       }
     );
     const getIsNetworkChartEmptyInFullRange = createSelector(
-      getSearchFilteredTracingMarkers,
+      getTracingMarkers,
       markers => markers.filter(MarkerData.isNetworkMarker).length === 0
     );
     const getNetworkChartTracingMarkers = createSelector(

--- a/src/test/components/NetworkChart.test.js
+++ b/src/test/components/NetworkChart.test.js
@@ -80,15 +80,6 @@ describe('NetworkChart', function() {
 });
 
 describe('EmptyReasons', () => {
-  it('shows a reason when a profile has no network markers', () => {
-    const profile = getProfileWithMarkers([]);
-    const { dispatch, networkChart } = setupWithProfile(profile);
-
-    dispatch(changeSelectedTab('network-chart'));
-    networkChart.update();
-    expect(networkChart.find(EmptyReasons)).toMatchSnapshot();
-  });
-
   it("shows a reason when a profile's network markers have been filtered out", () => {
     const profile = getProfileWithMarkers(NETWORK_MARKERS);
     const { dispatch, networkChart } = setupWithProfile(profile);

--- a/src/test/components/__snapshots__/Details.test.js.snap
+++ b/src/test/components/__snapshots__/Details.test.js.snap
@@ -14,42 +14,14 @@ exports[`app/Details renders an initial view with the right panel 1`] = `
       />
     }
     onSelectTab={[Function]}
-    selectedTabName="calltree"
-    tabs={
-      Array [
-        Object {
-          "name": "calltree",
-          "title": "Call Tree",
-        },
-        Object {
-          "name": "flame-graph",
-          "title": "Flame Graph",
-        },
-        Object {
-          "name": "stack-chart",
-          "title": "Stack Chart",
-        },
-        Object {
-          "name": "marker-chart",
-          "title": "Marker Chart",
-        },
-        Object {
-          "name": "marker-table",
-          "title": "Marker Table",
-        },
-        Object {
-          "name": "network-chart",
-          "title": "Network",
-        },
-      ]
-    }
+    selectedTabSlug="calltree"
     visibleTabs={
       Array [
-        0,
-        1,
-        2,
-        3,
-        4,
+        "calltree",
+        "flame-graph",
+        "stack-chart",
+        "marker-chart",
+        "marker-table",
       ]
     }
   />
@@ -74,42 +46,14 @@ exports[`app/Details renders an initial view with the right panel for tab calltr
       />
     }
     onSelectTab={[Function]}
-    selectedTabName="calltree"
-    tabs={
-      Array [
-        Object {
-          "name": "calltree",
-          "title": "Call Tree",
-        },
-        Object {
-          "name": "flame-graph",
-          "title": "Flame Graph",
-        },
-        Object {
-          "name": "stack-chart",
-          "title": "Stack Chart",
-        },
-        Object {
-          "name": "marker-chart",
-          "title": "Marker Chart",
-        },
-        Object {
-          "name": "marker-table",
-          "title": "Marker Table",
-        },
-        Object {
-          "name": "network-chart",
-          "title": "Network",
-        },
-      ]
-    }
+    selectedTabSlug="calltree"
     visibleTabs={
       Array [
-        0,
-        1,
-        2,
-        3,
-        4,
+        "calltree",
+        "flame-graph",
+        "stack-chart",
+        "marker-chart",
+        "marker-table",
       ]
     }
   />
@@ -134,42 +78,14 @@ exports[`app/Details renders an initial view with the right panel for tab flame-
       />
     }
     onSelectTab={[Function]}
-    selectedTabName="flame-graph"
-    tabs={
-      Array [
-        Object {
-          "name": "calltree",
-          "title": "Call Tree",
-        },
-        Object {
-          "name": "flame-graph",
-          "title": "Flame Graph",
-        },
-        Object {
-          "name": "stack-chart",
-          "title": "Stack Chart",
-        },
-        Object {
-          "name": "marker-chart",
-          "title": "Marker Chart",
-        },
-        Object {
-          "name": "marker-table",
-          "title": "Marker Table",
-        },
-        Object {
-          "name": "network-chart",
-          "title": "Network",
-        },
-      ]
-    }
+    selectedTabSlug="flame-graph"
     visibleTabs={
       Array [
-        0,
-        1,
-        2,
-        3,
-        4,
+        "calltree",
+        "flame-graph",
+        "stack-chart",
+        "marker-chart",
+        "marker-table",
       ]
     }
   />
@@ -187,42 +103,14 @@ exports[`app/Details renders an initial view with the right panel for tab marker
   <TabBar
     extraElements={false}
     onSelectTab={[Function]}
-    selectedTabName="marker-chart"
-    tabs={
-      Array [
-        Object {
-          "name": "calltree",
-          "title": "Call Tree",
-        },
-        Object {
-          "name": "flame-graph",
-          "title": "Flame Graph",
-        },
-        Object {
-          "name": "stack-chart",
-          "title": "Stack Chart",
-        },
-        Object {
-          "name": "marker-chart",
-          "title": "Marker Chart",
-        },
-        Object {
-          "name": "marker-table",
-          "title": "Marker Table",
-        },
-        Object {
-          "name": "network-chart",
-          "title": "Network",
-        },
-      ]
-    }
+    selectedTabSlug="marker-chart"
     visibleTabs={
       Array [
-        0,
-        1,
-        2,
-        3,
-        4,
+        "calltree",
+        "flame-graph",
+        "stack-chart",
+        "marker-chart",
+        "marker-table",
       ]
     }
   />
@@ -240,42 +128,14 @@ exports[`app/Details renders an initial view with the right panel for tab marker
   <TabBar
     extraElements={false}
     onSelectTab={[Function]}
-    selectedTabName="marker-table"
-    tabs={
-      Array [
-        Object {
-          "name": "calltree",
-          "title": "Call Tree",
-        },
-        Object {
-          "name": "flame-graph",
-          "title": "Flame Graph",
-        },
-        Object {
-          "name": "stack-chart",
-          "title": "Stack Chart",
-        },
-        Object {
-          "name": "marker-chart",
-          "title": "Marker Chart",
-        },
-        Object {
-          "name": "marker-table",
-          "title": "Marker Table",
-        },
-        Object {
-          "name": "network-chart",
-          "title": "Network",
-        },
-      ]
-    }
+    selectedTabSlug="marker-table"
     visibleTabs={
       Array [
-        0,
-        1,
-        2,
-        3,
-        4,
+        "calltree",
+        "flame-graph",
+        "stack-chart",
+        "marker-chart",
+        "marker-table",
       ]
     }
   />
@@ -293,42 +153,14 @@ exports[`app/Details renders an initial view with the right panel for tab networ
   <TabBar
     extraElements={false}
     onSelectTab={[Function]}
-    selectedTabName="network-chart"
-    tabs={
-      Array [
-        Object {
-          "name": "calltree",
-          "title": "Call Tree",
-        },
-        Object {
-          "name": "flame-graph",
-          "title": "Flame Graph",
-        },
-        Object {
-          "name": "stack-chart",
-          "title": "Stack Chart",
-        },
-        Object {
-          "name": "marker-chart",
-          "title": "Marker Chart",
-        },
-        Object {
-          "name": "marker-table",
-          "title": "Marker Table",
-        },
-        Object {
-          "name": "network-chart",
-          "title": "Network",
-        },
-      ]
-    }
+    selectedTabSlug="network-chart"
     visibleTabs={
       Array [
-        0,
-        1,
-        2,
-        3,
-        4,
+        "calltree",
+        "flame-graph",
+        "stack-chart",
+        "marker-chart",
+        "marker-table",
       ]
     }
   />
@@ -346,42 +178,14 @@ exports[`app/Details renders an initial view with the right panel for tab stack-
   <TabBar
     extraElements={false}
     onSelectTab={[Function]}
-    selectedTabName="stack-chart"
-    tabs={
-      Array [
-        Object {
-          "name": "calltree",
-          "title": "Call Tree",
-        },
-        Object {
-          "name": "flame-graph",
-          "title": "Flame Graph",
-        },
-        Object {
-          "name": "stack-chart",
-          "title": "Stack Chart",
-        },
-        Object {
-          "name": "marker-chart",
-          "title": "Marker Chart",
-        },
-        Object {
-          "name": "marker-table",
-          "title": "Marker Table",
-        },
-        Object {
-          "name": "network-chart",
-          "title": "Network",
-        },
-      ]
-    }
+    selectedTabSlug="stack-chart"
     visibleTabs={
       Array [
-        0,
-        1,
-        2,
-        3,
-        4,
+        "calltree",
+        "flame-graph",
+        "stack-chart",
+        "marker-chart",
+        "marker-table",
       ]
     }
   />
@@ -406,42 +210,14 @@ exports[`app/Details show the correct state for the sidebar open button 1`] = `
       />
     }
     onSelectTab={[Function]}
-    selectedTabName="calltree"
-    tabs={
-      Array [
-        Object {
-          "name": "calltree",
-          "title": "Call Tree",
-        },
-        Object {
-          "name": "flame-graph",
-          "title": "Flame Graph",
-        },
-        Object {
-          "name": "stack-chart",
-          "title": "Stack Chart",
-        },
-        Object {
-          "name": "marker-chart",
-          "title": "Marker Chart",
-        },
-        Object {
-          "name": "marker-table",
-          "title": "Marker Table",
-        },
-        Object {
-          "name": "network-chart",
-          "title": "Network",
-        },
-      ]
-    }
+    selectedTabSlug="calltree"
     visibleTabs={
       Array [
-        0,
-        1,
-        2,
-        3,
-        4,
+        "calltree",
+        "flame-graph",
+        "stack-chart",
+        "marker-chart",
+        "marker-table",
       ]
     }
   />
@@ -466,42 +242,14 @@ exports[`app/Details show the correct state for the sidebar open button 2`] = `
       />
     }
     onSelectTab={[Function]}
-    selectedTabName="calltree"
-    tabs={
-      Array [
-        Object {
-          "name": "calltree",
-          "title": "Call Tree",
-        },
-        Object {
-          "name": "flame-graph",
-          "title": "Flame Graph",
-        },
-        Object {
-          "name": "stack-chart",
-          "title": "Stack Chart",
-        },
-        Object {
-          "name": "marker-chart",
-          "title": "Marker Chart",
-        },
-        Object {
-          "name": "marker-table",
-          "title": "Marker Table",
-        },
-        Object {
-          "name": "network-chart",
-          "title": "Network",
-        },
-      ]
-    }
+    selectedTabSlug="calltree"
     visibleTabs={
       Array [
-        0,
-        1,
-        2,
-        3,
-        4,
+        "calltree",
+        "flame-graph",
+        "stack-chart",
+        "marker-chart",
+        "marker-table",
       ]
     }
   />
@@ -526,42 +274,14 @@ exports[`app/Details show the correct state for the sidebar open button 3`] = `
       />
     }
     onSelectTab={[Function]}
-    selectedTabName="flame-graph"
-    tabs={
-      Array [
-        Object {
-          "name": "calltree",
-          "title": "Call Tree",
-        },
-        Object {
-          "name": "flame-graph",
-          "title": "Flame Graph",
-        },
-        Object {
-          "name": "stack-chart",
-          "title": "Stack Chart",
-        },
-        Object {
-          "name": "marker-chart",
-          "title": "Marker Chart",
-        },
-        Object {
-          "name": "marker-table",
-          "title": "Marker Table",
-        },
-        Object {
-          "name": "network-chart",
-          "title": "Network",
-        },
-      ]
-    }
+    selectedTabSlug="flame-graph"
     visibleTabs={
       Array [
-        0,
-        1,
-        2,
-        3,
-        4,
+        "calltree",
+        "flame-graph",
+        "stack-chart",
+        "marker-chart",
+        "marker-table",
       ]
     }
   />
@@ -586,42 +306,14 @@ exports[`app/Details show the correct state for the sidebar open button 4`] = `
       />
     }
     onSelectTab={[Function]}
-    selectedTabName="calltree"
-    tabs={
-      Array [
-        Object {
-          "name": "calltree",
-          "title": "Call Tree",
-        },
-        Object {
-          "name": "flame-graph",
-          "title": "Flame Graph",
-        },
-        Object {
-          "name": "stack-chart",
-          "title": "Stack Chart",
-        },
-        Object {
-          "name": "marker-chart",
-          "title": "Marker Chart",
-        },
-        Object {
-          "name": "marker-table",
-          "title": "Marker Table",
-        },
-        Object {
-          "name": "network-chart",
-          "title": "Network",
-        },
-      ]
-    }
+    selectedTabSlug="calltree"
     visibleTabs={
       Array [
-        0,
-        1,
-        2,
-        3,
-        4,
+        "calltree",
+        "flame-graph",
+        "stack-chart",
+        "marker-chart",
+        "marker-table",
       ]
     }
   />

--- a/src/test/components/__snapshots__/Details.test.js.snap
+++ b/src/test/components/__snapshots__/Details.test.js.snap
@@ -13,19 +13,8 @@ exports[`app/Details renders an initial view with the right panel 1`] = `
         type="button"
       />
     }
-    onChangeTabOrder={[Function]}
     onSelectTab={[Function]}
     selectedTabName="calltree"
-    tabOrder={
-      Array [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-      ]
-    }
     tabs={
       Array [
         Object {
@@ -52,6 +41,15 @@ exports[`app/Details renders an initial view with the right panel 1`] = `
           "name": "network-chart",
           "title": "Network",
         },
+      ]
+    }
+    visibleTabs={
+      Array [
+        0,
+        1,
+        2,
+        3,
+        4,
       ]
     }
   />
@@ -75,19 +73,8 @@ exports[`app/Details renders an initial view with the right panel for tab calltr
         type="button"
       />
     }
-    onChangeTabOrder={[Function]}
     onSelectTab={[Function]}
     selectedTabName="calltree"
-    tabOrder={
-      Array [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-      ]
-    }
     tabs={
       Array [
         Object {
@@ -114,6 +101,15 @@ exports[`app/Details renders an initial view with the right panel for tab calltr
           "name": "network-chart",
           "title": "Network",
         },
+      ]
+    }
+    visibleTabs={
+      Array [
+        0,
+        1,
+        2,
+        3,
+        4,
       ]
     }
   />
@@ -137,19 +133,8 @@ exports[`app/Details renders an initial view with the right panel for tab flame-
         type="button"
       />
     }
-    onChangeTabOrder={[Function]}
     onSelectTab={[Function]}
     selectedTabName="flame-graph"
-    tabOrder={
-      Array [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-      ]
-    }
     tabs={
       Array [
         Object {
@@ -176,6 +161,15 @@ exports[`app/Details renders an initial view with the right panel for tab flame-
           "name": "network-chart",
           "title": "Network",
         },
+      ]
+    }
+    visibleTabs={
+      Array [
+        0,
+        1,
+        2,
+        3,
+        4,
       ]
     }
   />
@@ -192,19 +186,8 @@ exports[`app/Details renders an initial view with the right panel for tab marker
 >
   <TabBar
     extraElements={false}
-    onChangeTabOrder={[Function]}
     onSelectTab={[Function]}
     selectedTabName="marker-chart"
-    tabOrder={
-      Array [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-      ]
-    }
     tabs={
       Array [
         Object {
@@ -231,6 +214,15 @@ exports[`app/Details renders an initial view with the right panel for tab marker
           "name": "network-chart",
           "title": "Network",
         },
+      ]
+    }
+    visibleTabs={
+      Array [
+        0,
+        1,
+        2,
+        3,
+        4,
       ]
     }
   />
@@ -247,19 +239,8 @@ exports[`app/Details renders an initial view with the right panel for tab marker
 >
   <TabBar
     extraElements={false}
-    onChangeTabOrder={[Function]}
     onSelectTab={[Function]}
     selectedTabName="marker-table"
-    tabOrder={
-      Array [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-      ]
-    }
     tabs={
       Array [
         Object {
@@ -286,6 +267,15 @@ exports[`app/Details renders an initial view with the right panel for tab marker
           "name": "network-chart",
           "title": "Network",
         },
+      ]
+    }
+    visibleTabs={
+      Array [
+        0,
+        1,
+        2,
+        3,
+        4,
       ]
     }
   />
@@ -302,19 +292,8 @@ exports[`app/Details renders an initial view with the right panel for tab networ
 >
   <TabBar
     extraElements={false}
-    onChangeTabOrder={[Function]}
     onSelectTab={[Function]}
     selectedTabName="network-chart"
-    tabOrder={
-      Array [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-      ]
-    }
     tabs={
       Array [
         Object {
@@ -341,6 +320,15 @@ exports[`app/Details renders an initial view with the right panel for tab networ
           "name": "network-chart",
           "title": "Network",
         },
+      ]
+    }
+    visibleTabs={
+      Array [
+        0,
+        1,
+        2,
+        3,
+        4,
       ]
     }
   />
@@ -357,19 +345,8 @@ exports[`app/Details renders an initial view with the right panel for tab stack-
 >
   <TabBar
     extraElements={false}
-    onChangeTabOrder={[Function]}
     onSelectTab={[Function]}
     selectedTabName="stack-chart"
-    tabOrder={
-      Array [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-      ]
-    }
     tabs={
       Array [
         Object {
@@ -396,6 +373,15 @@ exports[`app/Details renders an initial view with the right panel for tab stack-
           "name": "network-chart",
           "title": "Network",
         },
+      ]
+    }
+    visibleTabs={
+      Array [
+        0,
+        1,
+        2,
+        3,
+        4,
       ]
     }
   />
@@ -419,19 +405,8 @@ exports[`app/Details show the correct state for the sidebar open button 1`] = `
         type="button"
       />
     }
-    onChangeTabOrder={[Function]}
     onSelectTab={[Function]}
     selectedTabName="calltree"
-    tabOrder={
-      Array [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-      ]
-    }
     tabs={
       Array [
         Object {
@@ -458,6 +433,15 @@ exports[`app/Details show the correct state for the sidebar open button 1`] = `
           "name": "network-chart",
           "title": "Network",
         },
+      ]
+    }
+    visibleTabs={
+      Array [
+        0,
+        1,
+        2,
+        3,
+        4,
       ]
     }
   />
@@ -481,19 +465,8 @@ exports[`app/Details show the correct state for the sidebar open button 2`] = `
         type="button"
       />
     }
-    onChangeTabOrder={[Function]}
     onSelectTab={[Function]}
     selectedTabName="calltree"
-    tabOrder={
-      Array [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-      ]
-    }
     tabs={
       Array [
         Object {
@@ -520,6 +493,15 @@ exports[`app/Details show the correct state for the sidebar open button 2`] = `
           "name": "network-chart",
           "title": "Network",
         },
+      ]
+    }
+    visibleTabs={
+      Array [
+        0,
+        1,
+        2,
+        3,
+        4,
       ]
     }
   />
@@ -543,19 +525,8 @@ exports[`app/Details show the correct state for the sidebar open button 3`] = `
         type="button"
       />
     }
-    onChangeTabOrder={[Function]}
     onSelectTab={[Function]}
     selectedTabName="flame-graph"
-    tabOrder={
-      Array [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-      ]
-    }
     tabs={
       Array [
         Object {
@@ -582,6 +553,15 @@ exports[`app/Details show the correct state for the sidebar open button 3`] = `
           "name": "network-chart",
           "title": "Network",
         },
+      ]
+    }
+    visibleTabs={
+      Array [
+        0,
+        1,
+        2,
+        3,
+        4,
       ]
     }
   />
@@ -605,19 +585,8 @@ exports[`app/Details show the correct state for the sidebar open button 4`] = `
         type="button"
       />
     }
-    onChangeTabOrder={[Function]}
     onSelectTab={[Function]}
     selectedTabName="calltree"
-    tabOrder={
-      Array [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-      ]
-    }
     tabs={
       Array [
         Object {
@@ -644,6 +613,15 @@ exports[`app/Details show the correct state for the sidebar open button 4`] = `
           "name": "network-chart",
           "title": "Network",
         },
+      ]
+    }
+    visibleTabs={
+      Array [
+        0,
+        1,
+        2,
+        3,
+        4,
       ]
     }
   />

--- a/src/test/components/__snapshots__/NetworkChart.test.js.snap
+++ b/src/test/components/__snapshots__/NetworkChart.test.js.snap
@@ -1,22 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EmptyReasons shows a reason when a profile has no network markers 1`] = `
-<div
-  className="EmptyReasons"
->
-  <h3>
-    The 
-    network chart
-     is empty for “
-    Empty
-    ”
-  </h3>
-  <p>
-    This thread has no network information.
-  </p>
-</div>
-`;
-
 exports[`EmptyReasons shows a reason when a profile's network markers have been filtered out 1`] = `
 <div
   className="EmptyReasons"
@@ -29,7 +12,7 @@ exports[`EmptyReasons shows a reason when a profile's network markers have been 
     ”
   </h3>
   <p>
-    This thread has no network information.
+    All network requests were filtered out by the current selection or search term. Try changing the search term, or zooming out.
   </p>
 </div>
 `;

--- a/src/test/store/app.test.js
+++ b/src/test/store/app.test.js
@@ -4,7 +4,6 @@
 // @flow
 
 import { storeWithSimpleProfile, storeWithProfile } from '../fixtures/stores';
-import * as ProfileViewSelectors from '../../reducers/profile-view';
 import * as UrlStateSelectors from '../../reducers/url-state';
 import * as AppSelectors from '../../reducers/app';
 import createStore from '../../app-logic/create-store';
@@ -56,29 +55,6 @@ describe('app actions', function() {
       expect(UrlStateSelectors.getHash(getState())).toBe('');
       dispatch(AppActions.profilePublished(hash));
       expect(UrlStateSelectors.getHash(getState())).toBe(hash);
-    });
-  });
-
-  describe('changeTabOrder', function() {
-    it('can change the saved tab order', function() {
-      const { dispatch, getState } = storeWithSimpleProfile();
-      expect(ProfileViewSelectors.getTabOrder(getState())).toEqual([
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-      ]);
-      dispatch(AppActions.changeTabOrder([2, 3, 1, 4, 5, 0]));
-      expect(ProfileViewSelectors.getTabOrder(getState())).toEqual([
-        2,
-        3,
-        1,
-        4,
-        5,
-        0,
-      ]);
     });
   });
 

--- a/src/test/store/app.test.js
+++ b/src/test/store/app.test.js
@@ -10,7 +10,6 @@ import createStore from '../../app-logic/create-store';
 import { withAnalyticsMock } from '../fixtures/mocks/analytics';
 import { isolateProcess } from '../../actions/profile-view';
 import { getProfileWithNiceTracks } from '../fixtures/profiles/tracks';
-import { tabSlugs } from '../../app-logic/tabs-handling';
 import {
   getProfileFromTextSamples,
   getProfileWithMarkers,
@@ -65,13 +64,10 @@ describe('app actions', function() {
   });
 
   describe('visibleTabs', function() {
-    function getVisibleTabSlugs(state) {
-      return AppSelectors.getVisibleTabs(state).map(i => tabSlugs[i]);
-    }
     it('hides the network chart when there are no network markers in a thread', function() {
       const { profile } = getProfileFromTextSamples('A');
       const { getState } = storeWithProfile(profile);
-      expect(getVisibleTabSlugs(getState())).toEqual([
+      expect(AppSelectors.getVisibleTabs(getState())).toEqual([
         'calltree',
         'flame-graph',
         'stack-chart',
@@ -82,7 +78,7 @@ describe('app actions', function() {
     it('shows the network chart when network markers are present in the thread', function() {
       const profile = getProfileWithMarkers([getNetworkMarker(10, 0)]);
       const { getState } = storeWithProfile(profile);
-      expect(getVisibleTabSlugs(getState())).toEqual([
+      expect(AppSelectors.getVisibleTabs(getState())).toEqual([
         'calltree',
         'flame-graph',
         'stack-chart',

--- a/src/test/store/app.test.js
+++ b/src/test/store/app.test.js
@@ -10,6 +10,12 @@ import createStore from '../../app-logic/create-store';
 import { withAnalyticsMock } from '../fixtures/mocks/analytics';
 import { isolateProcess } from '../../actions/profile-view';
 import { getProfileWithNiceTracks } from '../fixtures/profiles/tracks';
+import { tabSlugs } from '../../app-logic/tabs-handling';
+import {
+  getProfileFromTextSamples,
+  getProfileWithMarkers,
+  getNetworkMarker,
+} from '../fixtures/profiles/make-profile';
 
 import * as AppActions from '../../actions/app';
 
@@ -55,6 +61,35 @@ describe('app actions', function() {
       expect(UrlStateSelectors.getHash(getState())).toBe('');
       dispatch(AppActions.profilePublished(hash));
       expect(UrlStateSelectors.getHash(getState())).toBe(hash);
+    });
+  });
+
+  describe('visibleTabs', function() {
+    function getVisibleTabSlugs(state) {
+      return AppSelectors.getVisibleTabs(state).map(i => tabSlugs[i]);
+    }
+    it('hides the network chart when there are no network markers in a thread', function() {
+      const { profile } = getProfileFromTextSamples('A');
+      const { getState } = storeWithProfile(profile);
+      expect(getVisibleTabSlugs(getState())).toEqual([
+        'calltree',
+        'flame-graph',
+        'stack-chart',
+        'marker-chart',
+        'marker-table',
+      ]);
+    });
+    it('shows the network chart when network markers are present in the thread', function() {
+      const profile = getProfileWithMarkers([getNetworkMarker(10, 0)]);
+      const { getState } = storeWithProfile(profile);
+      expect(getVisibleTabSlugs(getState())).toEqual([
+        'calltree',
+        'flame-graph',
+        'stack-chart',
+        'marker-chart',
+        'marker-table',
+        'network-chart',
+      ]);
     });
   });
 

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -101,10 +101,6 @@ type ProfileAction =
       +previewSelection: PreviewSelection,
     |}
   | {|
-      +type: 'CHANGE_TAB_ORDER',
-      +tabOrder: number[],
-    |}
-  | {|
       +type: 'CHANGE_SELECTED_ZIP_FILE',
       +selectedZipFileIndex: IndexIntoZipFileTable | null,
     |}

--- a/src/types/reducers.js
+++ b/src/types/reducers.js
@@ -60,7 +60,6 @@ export type ProfileViewState = {|
     focusCallTreeGeneration: number,
     rootRange: StartEndRange,
     zeroAt: Milliseconds,
-    tabOrder: number[],
     rightClickedTrack: TrackReference,
     isCallNodeContextMenuVisible: boolean,
     profileSharingStatus: ProfileSharingStatus,


### PR DESCRIPTION
This patch adds the functionality to hide a network tab if none exists in the thread. This is logic is also needed for the new JS Tracer tab.

It also removes the ability for tabs to be reordered, since it doesn't really make as much since to define a custom tab order when some tabs are hidden.

[Deploy preview](https://deploy-preview-1477--perf-html.netlify.com/public/62a6d6feb3d1d4fe6d0dd48d9ec4e1fb62a73998/calltree/?globalTrackOrder=6-0-2-3-4-5-1&hiddenGlobalTracks=2-3-4-5&localTrackOrderByPid=77399-1-0~79318-0~&range=14.4031_19.4903&thread=1&v=3)