### PR TITLE
Make preview selections faster by only dispatching on changes

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -13,6 +13,7 @@ import {
   getLocalTracks,
   getLocalTrackFromReference,
   getGlobalTrackFromReference,
+  getPreviewSelection,
 } from '../reducers/profile-view';
 import {
   getImplementationFilter,
@@ -31,6 +32,7 @@ import {
 } from '../profile-logic/profile-data';
 import { ensureExists, assertExhaustiveCheck } from '../utils/flow';
 import { sendAnalytics } from '../utils/analytics';
+import { objectShallowEquals } from '../utils/index';
 
 import type {
   PreviewSelection,
@@ -898,10 +900,17 @@ export function changeInvertCallstack(
 
 export function updatePreviewSelection(
   previewSelection: PreviewSelection
-): Action {
-  return {
-    type: 'UPDATE_PREVIEW_SELECTION',
-    previewSelection,
+): ThunkAction<void> {
+  return (dispatch, getState) => {
+    const currentPreviewSelection = getPreviewSelection(getState());
+    if (!objectShallowEquals(currentPreviewSelection, previewSelection)) {
+      // Only dispatch if the selection changes. This function can fire in a tight loop,
+      // and this check saves a dispatch.
+      dispatch({
+        type: 'UPDATE_PREVIEW_SELECTION',
+        previewSelection,
+      });
+    }
   };
 }
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -24,3 +24,25 @@ export class FastFillStyle {
     }
   }
 }
+
+/**
+ * Perform a simple shallow object equality check.
+ */
+export function objectShallowEquals(a: Object, b: Object): boolean {
+  let aLength = 0;
+  let bLength = 0;
+  for (const key in a) {
+    if (a.hasOwnProperty(key)) {
+      aLength++;
+      if (a[key] !== b[key]) {
+        return false;
+      }
+    }
+  }
+  for (const key in b) {
+    if (b.hasOwnProperty(key)) {
+      bLength++;
+    }
+  }
+  return aLength === bLength;
+}


### PR DESCRIPTION
I was running into performance issues on the JS Tracer chart when dispatching many equivalent preview selections. This happens especially when scrolling out to the maximum zoom level. I did not include a test specifically for this behavior change, but we have existing coverage over the action, so to me it didn't seem worth it. I will double check the coverage information once it comes back from CI.