### PR TITLE
Re-route "from-file" URLs on refresh

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -77,6 +77,6 @@ export function invalidatePanelLayout(): Action {
  * is generated when the window.location is serialized, or the state is pulled out of
  * the history API.
  */
-export function updateUrlState(newUrlState: UrlState): Action {
+export function updateUrlState(newUrlState: UrlState | null): Action {
   return { type: 'UPDATE_URL_STATE', newUrlState };
 }

--- a/src/components/app/UrlManager.js
+++ b/src/components/app/UrlManager.js
@@ -34,23 +34,31 @@ type OwnProps = {|
 type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
 
 class UrlManager extends React.PureComponent<Props> {
-  _updateState() {
+  _updateState(firstRun: boolean) {
     const { updateUrlState, show404 } = this.props;
+    let urlState;
     if (window.history.state) {
-      updateUrlState(window.history.state);
+      urlState = (window.history.state: UrlState);
     } else {
       try {
-        const urlState = stateFromLocation(window.location);
-        updateUrlState(urlState);
+        urlState = stateFromLocation(window.location);
       } catch (e) {
         console.error(e);
         show404(window.location.pathname + window.location.search);
+        return;
       }
     }
+    if (firstRun) {
+      // Validate the initial URL state.
+      if (urlState.dataSource === 'from-file') {
+        urlState = null;
+      }
+    }
+    updateUrlState(urlState);
   }
   componentDidMount() {
-    this._updateState();
-    window.addEventListener('popstate', () => this._updateState());
+    this._updateState(true);
+    window.addEventListener('popstate', () => this._updateState(false));
     this.props.urlSetupDone();
   }
 

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -313,7 +313,9 @@ const wrapReducerInResetter = (
         // A new URL came in because of a browser action, discard the current UrlState
         // and use the new one, which was probably serialized from the URL, or stored
         // in the history API.
-        return action.newUrlState;
+        return action.newUrlState
+          ? action.newUrlState
+          : regularUrlStateReducer(undefined, action);
       case 'RETURN_TO_ZIP_FILE_LIST':
         // Invalidate all information that would be specific to an individual profile.
         return {

--- a/src/reducers/zipped-profiles.js
+++ b/src/reducers/zipped-profiles.js
@@ -34,6 +34,7 @@ function zipFile(
   switch (action.type) {
     case 'UPDATE_URL_STATE': {
       if (
+        action.newUrlState &&
         action.newUrlState.pathInZipFile === null &&
         state.phase === 'VIEW_PROFILE_IN_ZIP_FILE'
       ) {

--- a/src/test/components/UrlManager.test.js
+++ b/src/test/components/UrlManager.test.js
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+import * as React from 'react';
+import { Provider } from 'react-redux';
+import { mount } from 'enzyme';
+
+import { getIsUrlSetupDone } from '../../reducers/app';
+import UrlManager from '../../components/app/UrlManager';
+import { blankStore } from '../fixtures/stores';
+import { getDataSource } from '../../reducers/url-state';
+
+describe('UrlManager', function() {
+  function setup(urlPath: ?string) {
+    if (typeof urlPath === 'string') {
+      // jsdom doesn't allow us to rewrite window.location. Instead, use the
+      // History API to properly set the current location.
+      window.history.pushState(undefined, 'perf.html', urlPath);
+    }
+    const store = blankStore();
+    const { dispatch, getState } = store;
+
+    const createUrlManager = () =>
+      mount(
+        <Provider store={store}>
+          <UrlManager>Contents</UrlManager>
+        </Provider>
+      );
+    return { dispatch, getState, createUrlManager };
+  }
+
+  it('sets up the URL', function() {
+    const { getState, createUrlManager } = setup();
+    expect(getIsUrlSetupDone(getState())).toBe(false);
+    createUrlManager();
+    expect(getIsUrlSetupDone(getState())).toBe(true);
+  });
+
+  it('has no data source by default', function() {
+    const { getState, createUrlManager } = setup();
+    createUrlManager();
+    expect(getDataSource(getState())).toMatch('none');
+  });
+
+  it('sets the data source to from-addon', function() {
+    const { getState, createUrlManager } = setup('/from-addon/');
+    expect(getDataSource(getState())).toMatch('none');
+    createUrlManager();
+    expect(getDataSource(getState())).toMatch('from-addon');
+  });
+
+  it('redirects from-file back to no data source', function() {
+    const { getState, createUrlManager } = setup('/from-file/');
+    expect(getDataSource(getState())).toMatch('none');
+    createUrlManager();
+    expect(getDataSource(getState())).toMatch('none');
+  });
+});

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -221,7 +221,7 @@ type StackChartAction =
 
 type UrlEnhancerAction =
   | {| +type: 'URL_SETUP_DONE' |}
-  | {| +type: 'UPDATE_URL_STATE', +newUrlState: UrlState |};
+  | {| +type: 'UPDATE_URL_STATE', +newUrlState: UrlState | null |};
 
 type UrlStateAction =
   | {| +type: 'WAITING_FOR_PROFILE_FROM_FILE' |}


### PR DESCRIPTION
I was feeling frustrated working on the JS Tracer files, since I was constantly refreshing on a local profile. This caused perf.html to get into an invalid state. This patch makes it so that when a user refreshes, it will take them to the main page.