### PR TITLE
Add a groups pretenured count to GCMinor marker tooltips

### DIFF
--- a/src/components/shared/MarkerTooltipContents.js
+++ b/src/components/shared/MarkerTooltipContents.js
@@ -480,6 +480,14 @@ function getMarkerDetails(
                         formatMicroseconds
                       )
                     : null}
+                  {nursery.groups_pretenured
+                    ? _markerDetail(
+                        'gcpretenured',
+                        'Number of groups to pretenure',
+                        nursery.groups_pretenured,
+                        x => formatNumber(x, 2, 0)
+                      )
+                    : null}
                   {_makePhaseTimesArray(nursery.phase_times)
                     /*
                      * Nursery collection should usually be very quick.  1ms

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -214,6 +214,9 @@ export type GCMinorCompletedData = {
 
   chunk_alloc_us?: Microseconds,
 
+  // Added in https://bugzilla.mozilla.org/show_bug.cgi?id=1507379
+  groups_pretenured?: number,
+
   phase_times: PhaseTimes<Microseconds>,
 };
 


### PR DESCRIPTION
This was added in https://bugzilla.mozilla.org/show_bug.cgi?id=1507379