### PR TITLE
Remove the ruler line as the timeline is quite busy now

### DIFF
--- a/src/components/timeline/Ruler.css
+++ b/src/components/timeline/Ruler.css
@@ -4,11 +4,12 @@
 
 .timelineRuler {
   height: 20px;
-  overflow: hidden;
-  /* Don't allow this component to steal pointer events, as it can overlay the timeline */
-  pointer-events: none;
 }
 
+/**
+ * Create a border underneath the ruler that spans both the timeline track names on the
+ * left, and the scrollbar area on the right.
+ */
 .timelineRuler::after {
   content: '';
   position: absolute;
@@ -30,16 +31,19 @@
   top: 0;
   left: 0;
   right: 0;
-  bottom: 0;
+  height: 20px;
   -moz-user-select: none;
   user-select: none;
   line-height: 20px;
   font-size: 9px;
   color: #888;
   cursor: default;
-  z-index: 1; /* between .timelineThread background and .timelineThreadDetails */
 }
 
+/**
+ * The notch is a 1px wide span with a gradient. It has a text numeric label that is
+ * then overflows to the left of the line.
+ */
 .timelineRulerNotch {
   display: block;
   position: absolute;


### PR DESCRIPTION
<img width="840" alt="image" src="https://user-images.githubusercontent.com/1588648/48789179-11193a80-ecb2-11e8-9529-af9885ab759b.png">

[Deploy preview](https://deploy-preview-1514--perf-html.netlify.com/public/7d87329a81bd81e5ebd4bc8f404f53c7e553bae1/calltree/?globalTrackOrder=0-1-2-3-4-5&hiddenGlobalTracks=1-2-3-4&localTrackOrderByPid=7620-1-0~7999-0~&range=3.1696_5.4600&thread=1&v=3)
[Current view](https://perf-html.io/public/7d87329a81bd81e5ebd4bc8f404f53c7e553bae1/calltree/?globalTrackOrder=0-1-2-3-4-5&hiddenGlobalTracks=1-2-3-4&localTrackOrderByPid=7620-1-0~7999-0~&range=3.1696_5.4600&thread=1&v=3)