### PR TITLE
Properly handle the lifecycle events of the service worker

### DIFF
--- a/res/css/photon-components.css
+++ b/res/css/photon-components.css
@@ -4,6 +4,7 @@
   border: none;
   margin: 0;
   padding: 0;
+  font: inherit;
 
   /* photon styles */
   background-color: var(--grey-90-a10);

--- a/res/img/svg/close-icon.svg
+++ b/res/img/svg/close-icon.svg
@@ -1,0 +1,4 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M5.293 6.707a1 1 0 1 1 1.414-1.414L12 10.586l5.293-5.293a1 1 0 1 1 1.414 1.414L13.414 12l5.293 5.293a1 1 0 0 1-1.414 1.414L12 13.414l-5.293 5.293a1 1 0 0 1-1.414-1.414L10.586 12 5.293 6.707z" fill="#0C0C0D" fill-opacity=".8"></path></svg>

--- a/res/img/svg/info-icon.svg
+++ b/res/img/svg/info-icon.svg
@@ -1,0 +1,4 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 20a8 8 0 1 0 0-16 8 8 0 0 0 0 16zm0 2c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10zm1-14a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm-1 3a1 1 0 0 0-1 1v4a1 1 0 1 0 2 0v-4a1 1 0 0 0-1-1z" fill="#0C0C0D" fill-opacity=".8"></path></svg>

--- a/src/components/app/Root.js
+++ b/src/components/app/Root.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
-import React, { PureComponent } from 'react';
+import React, { Fragment, PureComponent } from 'react';
 import { Provider } from 'react-redux';
 import explicitConnect from '../../utils/connect';
 
@@ -23,6 +23,7 @@ import {
   getProfileUrl,
 } from '../../reducers/url-state';
 import UrlManager from './UrlManager';
+import ServiceWorkerManager from './ServiceWorkerManager';
 import FooterLinks from './FooterLinks';
 
 import type { Store } from '../../types/store';
@@ -156,7 +157,7 @@ class ProfileViewWhenReadyImpl extends PureComponent<ProfileViewProps> {
     );
   }
 
-  render() {
+  renderAppropriateComponents() {
     const { view, dataSource, hasZipFile } = this.props;
     const phase = view.phase;
     if (dataSource === 'none') {
@@ -211,6 +212,15 @@ class ProfileViewWhenReadyImpl extends PureComponent<ProfileViewProps> {
           <Home specialMessage="The URL you came in on was not recognized." />
         );
     }
+  }
+
+  render() {
+    return (
+      <Fragment>
+        <ServiceWorkerManager />
+        {this.renderAppropriateComponents()}
+      </Fragment>
+    );
   }
 }
 

--- a/src/components/app/ServiceWorkerManager.css
+++ b/src/components/app/ServiceWorkerManager.css
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 .serviceworker-ready-notice-wrapper {
   position: fixed;
   top: 0;

--- a/src/components/app/ServiceWorkerManager.css
+++ b/src/components/app/ServiceWorkerManager.css
@@ -1,0 +1,48 @@
+.serviceworker-ready-notice-wrapper {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+
+  z-index: 4;
+
+  display: flex;
+}
+.serviceworker-ready-notice {
+  margin: 0 auto;
+  padding: 0 4px;
+
+  display: flex;
+  align-items: center;
+
+  background: var(--grey-20);
+  color: var(--grey-90);
+  border-radius: 0 0 4px 4px;
+  box-shadow: 0 0 0 0.5px rgba(0, 0, 0, 0.1), 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.serviceworker-ready-notice-close-button {
+  flex: none;
+
+  padding: 4px;
+  width: 16px;
+  height: 16px;
+  margin-left: 8px;
+
+  border-radius: 4px;
+  background-image: url(../../../res/img/svg/close-icon.svg);
+  background-repeat: no-repeat;
+  background-position: center center;
+  background-size: 16px 16px;
+}
+
+.serviceworker-ready-notice-action-button {
+  margin-left: 8px;
+}
+
+.serviceworker-ready-notice p {
+  flex: auto;
+  padding: .5em .5em .5em 24px;
+  margin: 0;
+  background: url(../../../res/img/svg/info-icon.svg) no-repeat left center / 16px 16px;
+}

--- a/src/components/app/ServiceWorkerManager.js
+++ b/src/components/app/ServiceWorkerManager.js
@@ -27,13 +27,13 @@ type Props = ConnectedProps<{||}, StateProps, {||}>;
 type InstallStatus = 'pending' | 'ready' | 'idle';
 type State = {|
   installStatus: InstallStatus,
-  closeNotice: boolean,
+  isNoticeDisplayed: boolean,
 |};
 
 class ServiceWorkerManager extends PureComponent<Props, State> {
   state = {
     installStatus: 'idle',
-    closeNotice: true,
+    isNoticeDisplayed: false,
   };
 
   _installServiceWorker() {
@@ -61,7 +61,7 @@ class ServiceWorkerManager extends PureComponent<Props, State> {
         console.log(
           '[ServiceWorker] The new version of the application has been enabled.'
         );
-        this.setState({ installStatus: 'ready', closeNotice: false });
+        this.setState({ installStatus: 'ready', isNoticeDisplayed: true });
       },
       onUpdateFailed: () => {
         console.log(
@@ -95,14 +95,18 @@ class ServiceWorkerManager extends PureComponent<Props, State> {
   }
 
   _onCloseNotice = () => {
-    this.setState({ closeNotice: true });
+    this.setState({ isNoticeDisplayed: false });
   };
 
   render() {
     const { dataSource } = this.props;
-    const { installStatus, closeNotice } = this.state;
+    const { installStatus, isNoticeDisplayed } = this.state;
 
-    if (dataSource !== 'none' && dataSource !== 'public') {
+    if (
+      dataSource !== 'none' &&
+      dataSource !== 'public' &&
+      dataSource !== 'from-url'
+    ) {
       return null;
     }
 
@@ -110,7 +114,7 @@ class ServiceWorkerManager extends PureComponent<Props, State> {
       return null;
     }
 
-    if (closeNotice) {
+    if (!isNoticeDisplayed) {
       return null;
     }
 

--- a/src/components/app/ServiceWorkerManager.js
+++ b/src/components/app/ServiceWorkerManager.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
-import { PureComponent } from 'react';
+import React, { PureComponent } from 'react';
 import explicitConnect from '../../utils/connect';
 
 import { getDataSource } from '../../reducers/url-state';
@@ -85,7 +85,25 @@ class ServiceWorkerManager extends PureComponent<Props, State> {
   }
 
   render() {
-    return null;
+    const { dataSource } = this.props;
+    const { installStatus } = this.state;
+
+    if (dataSource !== 'none' && dataSource === 'public') {
+      return null;
+    }
+
+    if (installStatus !== 'ready') {
+      return null;
+    }
+
+    return (
+      <div className="serviceworker-ready-notice">
+        An update is ready, if you want to use it now you can
+        <a href="javascript:location.reload()">
+          click here to reload the page
+        </a>.
+      </div>
+    );
   }
 }
 

--- a/src/components/app/ServiceWorkerManager.js
+++ b/src/components/app/ServiceWorkerManager.js
@@ -1,0 +1,99 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+
+import { PureComponent } from 'react';
+import explicitConnect from '../../utils/connect';
+
+import { getDataSource } from '../../reducers/url-state';
+import { getView } from '../../reducers/app';
+
+import type {
+  ExplicitConnectOptions,
+  ConnectedProps,
+} from '../../utils/connect';
+import type { DataSource } from '../../types/actions';
+import type { Phase } from '../../types/reducers';
+
+type StateProps = {|
+  +dataSource: DataSource,
+  +phase: Phase,
+|};
+type Props = ConnectedProps<{||}, StateProps, {||}>;
+
+type InstallStatus = 'pending' | 'ready' | 'idle';
+type State = {|
+  installStatus: InstallStatus,
+|};
+
+class ServiceWorkerManager extends PureComponent<Props, State> {
+  state = { installStatus: 'idle' };
+
+  _installServiceWorker() {
+    // We use '@mstange/offline-plugin/runtime' here instead of
+    // 'offline-plugin/runtime' because the fork contains the fix from
+    // https://github.com/NekR/offline-plugin/pull/410
+    const runtime = require('@mstange/offline-plugin/runtime');
+    runtime.install({
+      onInstalled: () => {
+        console.log('[ServiceWorker] App is ready for offline usage!');
+      },
+      onUpdating: () => {
+        console.log(
+          '[ServiceWorker] An update has been found and the browser is downloading the new assets.'
+        );
+      },
+      onUpdateReady: () => {
+        console.log(
+          '[ServiceWorker] We have downloaded the new assets and we are ready to go.'
+        );
+        runtime.applyUpdate();
+        this.setState({ installStatus: 'pending' });
+      },
+      onUpdated: () => {
+        console.log(
+          '[ServiceWorker] The new version of the service worker has been enabled.'
+        );
+        this.setState({ installStatus: 'ready' });
+      },
+      onUpdateFailed: () => {
+        console.log(
+          '[ServiceWorker] We failed to update the service worker for an unknown reason.'
+        );
+      },
+    });
+  }
+
+  componentWillMount() {
+    if (process.env.NODE_ENV === 'production') {
+      this._installServiceWorker();
+    }
+  }
+
+  componentDidUpdate() {
+    const { phase } = this.props;
+    const { installStatus } = this.state;
+
+    if (phase !== 'FATAL_ERROR') {
+      return;
+    }
+
+    if (installStatus === 'ready') {
+      window.location.reload();
+    }
+  }
+
+  render() {
+    return null;
+  }
+}
+
+const options: ExplicitConnectOptions<{||}, StateProps, {||}> = {
+  mapStateToProps: state => ({
+    phase: getView(state).phase,
+    dataSource: getDataSource(state),
+  }),
+  component: ServiceWorkerManager,
+};
+export default explicitConnect(options);

--- a/src/components/app/ServiceWorkerManager.js
+++ b/src/components/app/ServiceWorkerManager.js
@@ -16,6 +16,8 @@ import type {
 import type { DataSource } from '../../types/actions';
 import type { Phase } from '../../types/reducers';
 
+import './ServiceWorkerManager.css';
+
 type StateProps = {|
   +dataSource: DataSource,
   +phase: Phase,
@@ -25,10 +27,14 @@ type Props = ConnectedProps<{||}, StateProps, {||}>;
 type InstallStatus = 'pending' | 'ready' | 'idle';
 type State = {|
   installStatus: InstallStatus,
+  closeNotice: boolean,
 |};
 
 class ServiceWorkerManager extends PureComponent<Props, State> {
-  state = { installStatus: 'idle' };
+  state = {
+    installStatus: 'idle',
+    closeNotice: true,
+  };
 
   _installServiceWorker() {
     // We use '@mstange/offline-plugin/runtime' here instead of
@@ -53,13 +59,13 @@ class ServiceWorkerManager extends PureComponent<Props, State> {
       },
       onUpdated: () => {
         console.log(
-          '[ServiceWorker] The new version of the service worker has been enabled.'
+          '[ServiceWorker] The new version of the application has been enabled.'
         );
-        this.setState({ installStatus: 'ready' });
+        this.setState({ installStatus: 'ready', closeNotice: false });
       },
       onUpdateFailed: () => {
         console.log(
-          '[ServiceWorker] We failed to update the service worker for an unknown reason.'
+          '[ServiceWorker] We failed to update the application for an unknown reason.'
         );
       },
     });
@@ -80,15 +86,23 @@ class ServiceWorkerManager extends PureComponent<Props, State> {
     }
 
     if (installStatus === 'ready') {
-      window.location.reload();
+      this.reloadPage();
     }
   }
 
+  reloadPage() {
+    window.location.reload();
+  }
+
+  _onCloseNotice = () => {
+    this.setState({ closeNotice: true });
+  };
+
   render() {
     const { dataSource } = this.props;
-    const { installStatus } = this.state;
+    const { installStatus, closeNotice } = this.state;
 
-    if (dataSource !== 'none' && dataSource === 'public') {
+    if (dataSource !== 'none' && dataSource !== 'public') {
       return null;
     }
 
@@ -96,12 +110,33 @@ class ServiceWorkerManager extends PureComponent<Props, State> {
       return null;
     }
 
+    if (closeNotice) {
+      return null;
+    }
+
     return (
-      <div className="serviceworker-ready-notice">
-        An update is ready, if you want to use it now you can
-        <a href="javascript:location.reload()">
-          click here to reload the page
-        </a>.
+      <div className="serviceworker-ready-notice-wrapper">
+        {/* We use the wrapper to horizontally center the notice */}
+        <div className="serviceworker-ready-notice">
+          <p>
+            A new version of the application has been downloaded and is ready to
+            use.
+          </p>
+          <button
+            className="photon-button serviceworker-ready-notice-action-button"
+            type="button"
+            onClick={this.reloadPage}
+          >
+            Reload the application
+          </button>
+          <button
+            aria-label="Hide the reload notice"
+            title="Hide the reload notice"
+            className="photon-button photon-button-ghost serviceworker-ready-notice-close-button"
+            type="button"
+            onClick={this._onCloseNotice}
+          />
+        </div>
       </div>
     );
   }

--- a/src/index.js
+++ b/src/index.js
@@ -26,18 +26,6 @@ if (process.env.NODE_ENV === 'development') {
   window.ga = () => {};
 }
 
-if (process.env.NODE_ENV === 'production') {
-  // We use '@mstange/offline-plugin/runtime' here instead of
-  // 'offline-plugin/runtime' because the fork contains the fix from
-  // https://github.com/NekR/offline-plugin/pull/410
-  const runtime = require('@mstange/offline-plugin/runtime');
-  runtime.install({
-    onUpdateReady: () => {
-      runtime.applyUpdate();
-    },
-  });
-}
-
 window.geckoProfilerPromise = new Promise(function(resolve) {
   window.connectToGeckoProfiler = resolve;
 });

--- a/src/test/components/ServiceWorkerManager.test.js
+++ b/src/test/components/ServiceWorkerManager.test.js
@@ -1,0 +1,157 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+//
+import React from 'react';
+import { Provider } from 'react-redux';
+import { render, fireEvent, cleanup } from 'react-testing-library';
+import serviceWorkerRuntime from '@mstange/offline-plugin/runtime';
+
+import ServiceWorkerManager from '../../components/app/ServiceWorkerManager';
+import { stateFromLocation } from '../../app-logic/url-handling';
+import { updateUrlState } from '../../actions/app';
+import { fatalError } from '../../actions/receive-profile';
+
+import { blankStore } from '../fixtures/stores';
+
+// Mock the offline plugin library.
+jest.mock('@mstange/offline-plugin/runtime', () => ({
+  install: jest.fn(),
+  applyUpdate: jest.fn(),
+}));
+
+describe('app/ServiceWorkerManager', () => {
+  afterEach(cleanup);
+  afterEach(() => {
+    process.env.NODE_ENV = 'development';
+  });
+
+  function setup() {
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(window.location, 'reload').mockImplementation(() => {});
+
+    function navigateToStoreLoadingPage() {
+      const newUrlState = stateFromLocation({
+        pathname: '/public/ThisIsAFakeHash/calltree',
+        search: '',
+        hash: '',
+      });
+      store.dispatch(updateUrlState(newUrlState));
+    }
+
+    function navigateToAddonLoadingPage() {
+      const newUrlState = stateFromLocation({
+        pathname: '/from-addon/',
+        search: '',
+        hash: '',
+      });
+      store.dispatch(updateUrlState(newUrlState));
+    }
+
+    const store = blankStore();
+
+    const renderResult = render(
+      <Provider store={store}>
+        <ServiceWorkerManager />
+      </Provider>
+    );
+
+    return {
+      ...renderResult,
+      navigateToStoreLoadingPage,
+      navigateToAddonLoadingPage,
+      dispatch: store.dispatch,
+    };
+  }
+
+  it('does not register a service worker in the development environment', () => {
+    setup();
+    expect(serviceWorkerRuntime.install).not.toHaveBeenCalled();
+  });
+
+  it('calls the appropriate functions to update the service worker', () => {
+    process.env.NODE_ENV = 'production';
+
+    setup();
+    expect(serviceWorkerRuntime.install).toHaveBeenCalled();
+
+    const installOptions = serviceWorkerRuntime.install.mock.calls[0][0];
+    installOptions.onUpdating();
+    expect(serviceWorkerRuntime.applyUpdate).not.toHaveBeenCalled();
+    installOptions.onUpdateReady();
+    expect(serviceWorkerRuntime.applyUpdate).toHaveBeenCalled();
+    installOptions.onUpdated();
+    installOptions.onInstalled();
+    expect(console.log).toHaveBeenCalledTimes(4);
+  });
+
+  it('shows a notice when the SW is updated, and the user can close it', () => {
+    process.env.NODE_ENV = 'production';
+
+    const { container, getByLabelText, getByText } = setup();
+
+    const installOptions = serviceWorkerRuntime.install.mock.calls[0][0];
+    installOptions.onUpdated();
+    expect(console.log).toHaveBeenCalled();
+    expect(container.firstChild).toMatchSnapshot();
+
+    const closeButton = getByLabelText(/hide/i);
+    fireEvent.click(closeButton);
+    expect(container.firstChild).toBe(null);
+
+    // Getting a new update should display the notice again
+    installOptions.onUpdated();
+    const reloadButton = getByText(/reload/i);
+    fireEvent.click(reloadButton);
+    expect(window.location.reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a notice with the `public` datasource too', () => {
+    process.env.NODE_ENV = 'production';
+
+    const { navigateToStoreLoadingPage, container } = setup();
+    navigateToStoreLoadingPage();
+
+    const installOptions = serviceWorkerRuntime.install.mock.calls[0][0];
+    installOptions.onUpdated();
+    expect(container.firstChild).not.toBe(null);
+  });
+
+  it('does not show a notice with the `from-addon` datasource', () => {
+    process.env.NODE_ENV = 'production';
+
+    const { navigateToAddonLoadingPage, container } = setup();
+    navigateToAddonLoadingPage();
+
+    const installOptions = serviceWorkerRuntime.install.mock.calls[0][0];
+    installOptions.onUpdated();
+    expect(container.firstChild).toBe(null);
+  });
+
+  describe('automatic reloading', () => {
+    it('reloads the application automatically if there is an error and there is a pending version', () => {
+      process.env.NODE_ENV = 'production';
+
+      const { dispatch } = setup();
+      const installOptions = serviceWorkerRuntime.install.mock.calls[0][0];
+
+      dispatch(fatalError(new Error('Error while loading profile')));
+      expect(window.location.reload).not.toHaveBeenCalled();
+      installOptions.onUpdated();
+      expect(window.location.reload).toHaveBeenCalled();
+    });
+
+    it('reloads the application automatically if there is an error and a new version is notified', () => {
+      process.env.NODE_ENV = 'production';
+
+      const { dispatch } = setup();
+      const installOptions = serviceWorkerRuntime.install.mock.calls[0][0];
+
+      installOptions.onUpdated();
+      expect(window.location.reload).not.toHaveBeenCalled();
+      dispatch(fatalError(new Error('Error while loading profile')));
+      expect(window.location.reload).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/test/components/ServiceWorkerManager.test.js
+++ b/src/test/components/ServiceWorkerManager.test.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
-//
+
 import React from 'react';
 import { Provider } from 'react-redux';
 import { render, fireEvent, cleanup } from 'react-testing-library';

--- a/src/test/components/__snapshots__/Root.test.js.snap
+++ b/src/test/components/__snapshots__/Root.test.js.snap
@@ -1,231 +1,258 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`app/ProfileViewWhenReady renders an home when the user pressed back after an error 1`] = `
-<div
-  className="rootMessageContainer"
->
+<Fragment>
+  <Connect(ServiceWorkerManager) />
   <div
-    className="rootMessage"
+    className="rootMessageContainer"
   >
-    <h1
-      className="rootMessageTitle"
-    >
-      perf.html
-    </h1>
     <div
-      className="rootMessageText"
+      className="rootMessage"
     >
-      Could not download the profile.
-    </div>
-    <div
-      className="rootMessageAdditional"
-    >
-      <p
-        key="0"
+      <h1
+        className="rootMessageTitle"
       >
-        Error: Error while loading profile
-      </p>
-      <p
-        key="1"
+        perf.html
+      </h1>
+      <div
+        className="rootMessageText"
       >
-        The full stack has been written to the Web Console.
-      </p>
-      <a
-        href="/"
+        Could not download the profile.
+      </div>
+      <div
+        className="rootMessageAdditional"
       >
-        Back to home
-      </a>
+        <p
+          key="0"
+        >
+          Error: Error while loading profile
+        </p>
+        <p
+          key="1"
+        >
+          The full stack has been written to the Web Console.
+        </p>
+        <a
+          href="/"
+        >
+          Back to home
+        </a>
+      </div>
     </div>
   </div>
-</div>
+</Fragment>
 `;
 
-exports[`app/ProfileViewWhenReady renders an home when the user pressed back after an error 2`] = `<Connect(Home) />`;
+exports[`app/ProfileViewWhenReady renders an home when the user pressed back after an error 2`] = `
+<Fragment>
+  <Connect(ServiceWorkerManager) />
+  <Connect(Home) />
+</Fragment>
+`;
 
-exports[`app/ProfileViewWhenReady renders an initial home 1`] = `<Connect(Home) />`;
+exports[`app/ProfileViewWhenReady renders an initial home 1`] = `
+<Fragment>
+  <Connect(ServiceWorkerManager) />
+  <Connect(Home) />
+</Fragment>
+`;
 
 exports[`app/ProfileViewWhenReady renders temporary errors 1`] = `
-<div
-  className="rootMessageContainer"
->
+<Fragment>
+  <Connect(ServiceWorkerManager) />
   <div
-    className="rootMessage"
+    className="rootMessageContainer"
   >
-    <h1
-      className="rootMessageTitle"
-    >
-      perf.html
-    </h1>
     <div
-      className="rootMessageText"
+      className="rootMessage"
     >
-      Downloading and processing the profile...
-    </div>
-    <div
-      className="rootMessageAdditional"
-    >
-      <p
-        key="0"
+      <h1
+        className="rootMessageTitle"
       >
-        This is a temporary error, wait a bit more.
-      </p>
-      <p
-        key="1"
+        perf.html
+      </h1>
+      <div
+        className="rootMessageText"
       >
-        Tried 3 times out of 10.
-      </p>
-      <a
-        href="/"
+        Downloading and processing the profile...
+      </div>
+      <div
+        className="rootMessageAdditional"
       >
-        Back to home
-      </a>
-    </div>
-    <div
-      className="loading"
-    >
+        <p
+          key="0"
+        >
+          This is a temporary error, wait a bit more.
+        </p>
+        <p
+          key="1"
+        >
+          Tried 3 times out of 10.
+        </p>
+        <a
+          href="/"
+        >
+          Back to home
+        </a>
+      </div>
       <div
-        className="loading-div loading-div-1 loading-row-1"
-      />
-      <div
-        className="loading-div loading-div-2 loading-row-2"
-      />
-      <div
-        className="loading-div loading-div-3 loading-row-3"
-      />
-      <div
-        className="loading-div loading-div-4 loading-row-3"
-      />
-      <div
-        className="loading-div loading-div-5 loading-row-4"
-      />
-      <div
-        className="loading-div loading-div-6 loading-row-4"
-      />
-      <div
-        className="loading-div loading-div-7 loading-row-4"
-      />
-      <div
-        className="loading-div loading-div-8 loading-row-4"
-      />
-      <div
-        className="loading-div loading-div-9 loading-row-4"
-      />
-      <div
-        className="loading-div loading-div-10 loading-row-4"
-      />
+        className="loading"
+      >
+        <div
+          className="loading-div loading-div-1 loading-row-1"
+        />
+        <div
+          className="loading-div loading-div-2 loading-row-2"
+        />
+        <div
+          className="loading-div loading-div-3 loading-row-3"
+        />
+        <div
+          className="loading-div loading-div-4 loading-row-3"
+        />
+        <div
+          className="loading-div loading-div-5 loading-row-4"
+        />
+        <div
+          className="loading-div loading-div-6 loading-row-4"
+        />
+        <div
+          className="loading-div loading-div-7 loading-row-4"
+        />
+        <div
+          className="loading-div loading-div-8 loading-row-4"
+        />
+        <div
+          className="loading-div loading-div-9 loading-row-4"
+        />
+        <div
+          className="loading-div loading-div-10 loading-row-4"
+        />
+      </div>
     </div>
   </div>
-</div>
+</Fragment>
 `;
 
 exports[`app/ProfileViewWhenReady renders the addon loading page 1`] = `
-<div
-  className="rootMessageContainer"
->
+<Fragment>
+  <Connect(ServiceWorkerManager) />
   <div
-    className="rootMessage"
+    className="rootMessageContainer"
   >
-    <h1
-      className="rootMessageTitle"
-    >
-      perf.html
-    </h1>
     <div
-      className="rootMessageText"
+      className="rootMessage"
     >
-      Grabbing the profile from the Gecko Profiler Addon...
-    </div>
-    <div
-      className="loading"
-    >
+      <h1
+        className="rootMessageTitle"
+      >
+        perf.html
+      </h1>
       <div
-        className="loading-div loading-div-1 loading-row-1"
-      />
+        className="rootMessageText"
+      >
+        Grabbing the profile from the Gecko Profiler Addon...
+      </div>
       <div
-        className="loading-div loading-div-2 loading-row-2"
-      />
-      <div
-        className="loading-div loading-div-3 loading-row-3"
-      />
-      <div
-        className="loading-div loading-div-4 loading-row-3"
-      />
-      <div
-        className="loading-div loading-div-5 loading-row-4"
-      />
-      <div
-        className="loading-div loading-div-6 loading-row-4"
-      />
-      <div
-        className="loading-div loading-div-7 loading-row-4"
-      />
-      <div
-        className="loading-div loading-div-8 loading-row-4"
-      />
-      <div
-        className="loading-div loading-div-9 loading-row-4"
-      />
-      <div
-        className="loading-div loading-div-10 loading-row-4"
-      />
+        className="loading"
+      >
+        <div
+          className="loading-div loading-div-1 loading-row-1"
+        />
+        <div
+          className="loading-div loading-div-2 loading-row-2"
+        />
+        <div
+          className="loading-div loading-div-3 loading-row-3"
+        />
+        <div
+          className="loading-div loading-div-4 loading-row-3"
+        />
+        <div
+          className="loading-div loading-div-5 loading-row-4"
+        />
+        <div
+          className="loading-div loading-div-6 loading-row-4"
+        />
+        <div
+          className="loading-div loading-div-7 loading-row-4"
+        />
+        <div
+          className="loading-div loading-div-8 loading-row-4"
+        />
+        <div
+          className="loading-div loading-div-9 loading-row-4"
+        />
+        <div
+          className="loading-div loading-div-10 loading-row-4"
+        />
+      </div>
     </div>
   </div>
-</div>
+</Fragment>
 `;
 
 exports[`app/ProfileViewWhenReady renders the profile view 1`] = `
-<div
-  className="rootMessageContainer"
->
+<Fragment>
+  <Connect(ServiceWorkerManager) />
   <div
-    className="rootMessage"
+    className="rootMessageContainer"
   >
-    <h1
-      className="rootMessageTitle"
-    >
-      perf.html
-    </h1>
     <div
-      className="rootMessageText"
+      className="rootMessage"
     >
-      Downloading and processing the profile...
-    </div>
-    <div
-      className="loading"
-    >
+      <h1
+        className="rootMessageTitle"
+      >
+        perf.html
+      </h1>
       <div
-        className="loading-div loading-div-1 loading-row-1"
-      />
+        className="rootMessageText"
+      >
+        Downloading and processing the profile...
+      </div>
       <div
-        className="loading-div loading-div-2 loading-row-2"
-      />
-      <div
-        className="loading-div loading-div-3 loading-row-3"
-      />
-      <div
-        className="loading-div loading-div-4 loading-row-3"
-      />
-      <div
-        className="loading-div loading-div-5 loading-row-4"
-      />
-      <div
-        className="loading-div loading-div-6 loading-row-4"
-      />
-      <div
-        className="loading-div loading-div-7 loading-row-4"
-      />
-      <div
-        className="loading-div loading-div-8 loading-row-4"
-      />
-      <div
-        className="loading-div loading-div-9 loading-row-4"
-      />
-      <div
-        className="loading-div loading-div-10 loading-row-4"
-      />
+        className="loading"
+      >
+        <div
+          className="loading-div loading-div-1 loading-row-1"
+        />
+        <div
+          className="loading-div loading-div-2 loading-row-2"
+        />
+        <div
+          className="loading-div loading-div-3 loading-row-3"
+        />
+        <div
+          className="loading-div loading-div-4 loading-row-3"
+        />
+        <div
+          className="loading-div loading-div-5 loading-row-4"
+        />
+        <div
+          className="loading-div loading-div-6 loading-row-4"
+        />
+        <div
+          className="loading-div loading-div-7 loading-row-4"
+        />
+        <div
+          className="loading-div loading-div-8 loading-row-4"
+        />
+        <div
+          className="loading-div loading-div-9 loading-row-4"
+        />
+        <div
+          className="loading-div loading-div-10 loading-row-4"
+        />
+      </div>
     </div>
   </div>
-</div>
+</Fragment>
 `;
 
-exports[`app/ProfileViewWhenReady renders the profile view 2`] = `<Connect(ProfileViewer) />`;
+exports[`app/ProfileViewWhenReady renders the profile view 2`] = `
+<Fragment>
+  <Connect(ServiceWorkerManager) />
+  <Connect(ProfileViewer) />
+</Fragment>
+`;

--- a/src/test/components/__snapshots__/ServiceWorkerManager.test.js.snap
+++ b/src/test/components/__snapshots__/ServiceWorkerManager.test.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`app/ServiceWorkerManager shows a notice when the SW is updated, and the user can close it 1`] = `
+<div
+  class="serviceworker-ready-notice-wrapper"
+>
+  <div
+    class="serviceworker-ready-notice"
+  >
+    <p>
+      A new version of the application has been downloaded and is ready to use.
+    </p>
+    <button
+      class="photon-button serviceworker-ready-notice-action-button"
+      type="button"
+    >
+      Reload the application
+    </button>
+    <button
+      aria-label="Hide the reload notice"
+      class="photon-button photon-button-ghost serviceworker-ready-notice-close-button"
+      title="Hide the reload notice"
+      type="button"
+    />
+  </div>
+</div>
+`;

--- a/src/types/reducers.js
+++ b/src/types/reducers.js
@@ -78,6 +78,8 @@ export type AppViewState =
       +additionalData?: {| +attempt: Attempt | null, +message: string |},
     |};
 
+export type Phase = $PropertyType<AppViewState, 'phase'>;
+
 /**
  * This represents the finite state machine for loading zip files. The phase represents
  * where the state is now.


### PR DESCRIPTION
With this PR we now automatically reload if there's an error _and_ there's a SW update.

I also added this notice:
![image](https://user-images.githubusercontent.com/454175/48917130-87ba6180-ee85-11e8-9633-1bd4554ee613.png)

The notice appears only when we can reload the page without losing any data: if the datasource is `none` (this is the home) or `public` (I've been quite conservative here, maybe we could add `from-url`).