### PR TITLE
Update gecko-profiler-demangle to 0.2.0 in order to pick up msvc-demangling.

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "common-tags": "^1.7.2",
     "copy-to-clipboard": "^3.0.8",
     "escape-string-regexp": "^1.0.5",
-    "gecko-profiler-demangle": "^0.1.0",
+    "gecko-profiler-demangle": "^0.2.0",
     "jszip": "^3.1.5",
     "memoize-immutable": "^3.0.0",
     "mixedtuplemap": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4253,9 +4253,10 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
-gecko-profiler-demangle@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/gecko-profiler-demangle/-/gecko-profiler-demangle-0.1.0.tgz#7bc08d43e3572e64a6c09c4ed6680e4bc4ce356e"
+gecko-profiler-demangle@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/gecko-profiler-demangle/-/gecko-profiler-demangle-0.2.0.tgz#d0ebdd40c9dfd402a6c28e05b2c757396683e75d"
+  integrity sha512-dIamdbOrBCNNXHbJaNnAElxqcBBcNoHkekKi/at+z88lu4x2/tVGKPLKiF9El5kFiWNYDjou4ykEL+5+W8CxQw==
 
 get-caller-file@^1.0.1:
   version "1.0.3"


### PR DESCRIPTION
Fixes #1533.