### PR TITLE
Improve the CSS for shrinking the top bar area

### DIFF
--- a/res/css/style.css
+++ b/res/css/style.css
@@ -327,9 +327,13 @@ body,
   border-bottom: 1px solid var(--grey-30);
 }
 
+.profileViewerSpacer {
+  flex: 1;
+}
+
 .profileFilterNavigator {
   height: 24px;
-  flex: 1;
+  flex-shrink: 1;
 }
 
 .tabBarContainer {

--- a/src/components/app/MenuButtons.css
+++ b/src/components/app/MenuButtons.css
@@ -179,7 +179,7 @@
   box-sizing: border-box;
 }
 
-.menuButtonsOpenMetaInforButtonLabelOverflow {
+.menuButtonsOpenMetaInfoButtonLabelOverflow {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/components/app/MenuButtons.css
+++ b/src/components/app/MenuButtons.css
@@ -161,6 +161,10 @@
 .menuButtonsOpenMetaInfoButtonBox {
   display: flex;
   padding: 0;
+  /* Let this box shrink down to the size of the three dots and a bit of text. */
+  min-width: 75px;
+  /* Shrink down twice as fast as the range selection labels. */
+  flex-shrink: 2;
 }
 
 .menuButtonsOpenMetaInfoButtonLabel {
@@ -168,7 +172,17 @@
   flex-flow: column nowrap;
   align-items: stretch;
   position: relative;
-  padding: 5px 10px 10px;
+  padding: 5px 10px;
+  /* Let this box shrink down to the size of the three dots. */
+  min-width: 0;
+  /* Make sure the padding doesn't contribute to the height, which is 100% */
+  box-sizing: border-box;
+}
+
+.menuButtonsOpenMetaInforButtonLabelOverflow {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .menuButtonsOpenMetaInfoButtonBox .buttonWithPanelButton,

--- a/src/components/app/MenuButtons.js
+++ b/src/components/app/MenuButtons.js
@@ -4,7 +4,7 @@
 
 // @flow
 
-import React, { PureComponent } from 'react';
+import * as React from 'react';
 import explicitConnect from '../../utils/connect';
 import classNames from 'classnames';
 import {
@@ -190,7 +190,9 @@ function _formatLabel(meta: ProfileMeta): string | null {
   return labelTitle;
 }
 
-class ProfileMetaInfoButton extends PureComponent<ProfileMetaInfoButtonProps> {
+class ProfileMetaInfoButton extends React.PureComponent<
+  ProfileMetaInfoButtonProps
+> {
   render() {
     const { profile } = this.props;
     const meta = profile.meta;
@@ -199,7 +201,9 @@ class ProfileMetaInfoButton extends PureComponent<ProfileMetaInfoButtonProps> {
       return (
         <div className="menuButtonsOpenMetaInfoButtonBox">
           <div className="menuButtonsOpenMetaInfoButtonLabel">
-            {_formatLabel(meta)}
+            <span className="menuButtonsOpenMetaInforButtonLabelOverflow">
+              {_formatLabel(meta)}
+            </span>
           </div>
           <ButtonWithPanel
             className="menuButtonsOpenMetaInfoButtonButton"
@@ -291,7 +295,7 @@ class ProfileMetaInfoButton extends PureComponent<ProfileMetaInfoButtonProps> {
   }
 }
 
-class ProfileSharingCompositeButton extends PureComponent<
+class ProfileSharingCompositeButton extends React.PureComponent<
   ProfileSharingCompositeButtonProps,
   ProfileSharingCompositeButtonState
 > {
@@ -611,7 +615,7 @@ type ProfileDownloadButtonState = {|
   filename: string,
 |};
 
-class ProfileDownloadButton extends PureComponent<
+class ProfileDownloadButton extends React.PureComponent<
   ProfileDownloadButtonProps,
   ProfileDownloadButtonState
 > {
@@ -732,27 +736,30 @@ const MenuButtons = ({
   setProfileSharingStatus,
   predictUrl,
 }: MenuButtonsProps) => (
-  <div className="menuButtons">
+  <>
+    {/* Place the info button outside of the menu buttons to allow it to shrink. */}
     <ProfileMetaInfoButton profile={profile} />
-    <ProfileSharingCompositeButton
-      profile={profile}
-      dataSource={dataSource}
-      symbolicationStatus={symbolicationStatus}
-      onProfilePublished={profilePublished}
-      profileSharingStatus={profileSharingStatus}
-      setProfileSharingStatus={setProfileSharingStatus}
-      predictUrl={predictUrl}
-    />
-    <ProfileDownloadButton profile={profile} rootRange={rootRange} />
-    <a
-      href="/docs/"
-      target="_blank"
-      className="menuButtonsLink"
-      title="Open the documentation in a new window"
-    >
-      Docs…
-    </a>
-  </div>
+    <div className="menuButtons">
+      <ProfileSharingCompositeButton
+        profile={profile}
+        dataSource={dataSource}
+        symbolicationStatus={symbolicationStatus}
+        onProfilePublished={profilePublished}
+        profileSharingStatus={profileSharingStatus}
+        setProfileSharingStatus={setProfileSharingStatus}
+        predictUrl={predictUrl}
+      />
+      <ProfileDownloadButton profile={profile} rootRange={rootRange} />
+      <a
+        href="/docs/"
+        target="_blank"
+        className="menuButtonsLink"
+        title="Open the documentation in a new window"
+      >
+        Docs…
+      </a>
+    </div>
+  </>
 );
 
 const options: ExplicitConnectOptions<

--- a/src/components/app/MenuButtons.js
+++ b/src/components/app/MenuButtons.js
@@ -201,7 +201,7 @@ class ProfileMetaInfoButton extends React.PureComponent<
       return (
         <div className="menuButtonsOpenMetaInfoButtonBox">
           <div className="menuButtonsOpenMetaInfoButtonLabel">
-            <span className="menuButtonsOpenMetaInforButtonLabelOverflow">
+            <span className="menuButtonsOpenMetaInfoButtonLabelOverflow">
               {_formatLabel(meta)}
             </span>
           </div>

--- a/src/components/app/ProfileViewer.js
+++ b/src/components/app/ProfileViewer.js
@@ -51,6 +51,12 @@ class ProfileViewer extends PureComponent<Props> {
             <div className="profileViewerName">{profileName}</div>
           ) : null}
           <ProfileFilterNavigator />
+          {/*
+            * Define a spacer in the middle that will shrink based on the availability
+            * of space in the top bar. It will shrink away before any of the items
+            * with actual content in them do.
+            */}
+          <div className="profileViewerSpacer" />
           <MenuButtons />
         </div>
         <Timeline />

--- a/src/components/shared/FilterNavigatorBar.css
+++ b/src/components/shared/FilterNavigatorBar.css
@@ -27,7 +27,6 @@
   border-right-color: transparent !important;
   padding: 0 6px 0 8px;
   background-clip: padding-box;
-  max-width: 20%;
 }
 
 .filterNavigatorBarRootItem {

--- a/src/components/shared/FilterNavigatorBar.css
+++ b/src/components/shared/FilterNavigatorBar.css
@@ -33,6 +33,7 @@
 .filterNavigatorBarRootItem {
   margin-left: -8px;
   flex-shrink: 0;
+  max-width: 100%;
 }
 
 .filterNavigatorBarItemContent {

--- a/src/test/components/__snapshots__/MenuButtons.test.js.snap
+++ b/src/test/components/__snapshots__/MenuButtons.test.js.snap
@@ -1,16 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`app/MenuButtons renders the MenuButtons buttons 1`] = `
-<div
-  className="menuButtons"
->
+Array [
   <div
     className="menuButtonsOpenMetaInfoButtonBox"
   >
     <div
       className="menuButtonsOpenMetaInfoButtonLabel"
     >
-      Firefox (48.0) Intel Mac OS X 10.11
+      <span
+        className="menuButtonsOpenMetaInfoButtonLabelOverflow"
+      >
+        Firefox (48.0) Intel Mac OS X 10.11
+      </span>
     </div>
     <div
       className="buttonWithPanel menuButtonsOpenMetaInfoButtonButton"
@@ -152,173 +154,322 @@ exports[`app/MenuButtons renders the MenuButtons buttons 1`] = `
         </div>
       </div>
     </div>
-  </div>
+  </div>,
   <div
-    className="menuButtonsCompositeButtonContainer currentButtonIsShareButton"
+    className="menuButtons"
   >
     <div
-      className="buttonWithPanel menuButtonsShareButton"
+      className="menuButtonsCompositeButtonContainer currentButtonIsShareButton"
     >
       <div
-        className="buttonWithPanelButtonWrapper"
-      >
-        <input
-          className="buttonWithPanelButton menuButtonsShareButtonButton"
-          disabled={true}
-          onClick={[Function]}
-          type="button"
-          value="Sharing will be enabled once symbolication is complete"
-        />
-      </div>
-      <div
-        className="arrowPanelAnchor"
+        className="buttonWithPanel menuButtonsShareButton"
       >
         <div
-          className="arrowPanel hasTitle hasButtons menuButtonsPrivacyPanel"
+          className="buttonWithPanelButtonWrapper"
+        >
+          <input
+            className="buttonWithPanelButton menuButtonsShareButtonButton"
+            disabled={true}
+            onClick={[Function]}
+            type="button"
+            value="Sharing will be enabled once symbolication is complete"
+          />
+        </div>
+        <div
+          className="arrowPanelAnchor"
         >
           <div
-            className="arrowPanelArrow"
-          />
-          <h1
-            className="arrowPanelTitle"
+            className="arrowPanel hasTitle hasButtons menuButtonsPrivacyPanel"
           >
-            Upload Profile – Privacy Notice
-          </h1>
-          <div
-            className="arrowPanelContent"
-          >
-            <section
-              className="privacyNotice"
+            <div
+              className="arrowPanelArrow"
+            />
+            <h1
+              className="arrowPanelTitle"
             >
-              <p>
-                You’re about to upload your profile publicly where anyone will be able to access it. To better diagnose performance problems profiles include the following information:
-              </p>
-              <ul>
-                <li>
-                  The URLs of all painted tabs, and running scripts.
-                </li>
-                <li>
-                  The metadata of all your add-ons to identify slow add-ons.
-                </li>
-                <li>
-                  Firefox build and runtime configuration.
-                </li>
-              </ul>
-              <p>
-                To view all the information you can download the full profile to a file and open the json structure with a text editor.
-              </p>
-              <p>
-                By default, the URLs of all network requests will be removed while sharing the profile
+              Upload Profile – Privacy Notice
+            </h1>
+            <div
+              className="arrowPanelContent"
+            >
+              <section
+                className="privacyNotice"
+              >
+                <p>
+                  You’re about to upload your profile publicly where anyone will be able to access it. To better diagnose performance problems profiles include the following information:
+                </p>
+                <ul>
+                  <li>
+                    The URLs of all painted tabs, and running scripts.
+                  </li>
+                  <li>
+                    The metadata of all your add-ons to identify slow add-ons.
+                  </li>
+                  <li>
+                    Firefox build and runtime configuration.
+                  </li>
+                </ul>
+                <p>
+                  To view all the information you can download the full profile to a file and open the json structure with a text editor.
+                </p>
+                <p>
+                  By default, the URLs of all network requests will be removed while sharing the profile
         but keeping the URLs may help to identify the problems. Please select the checkbox
         below to share the URLs of the network requests:
+                </p>
+              </section>
+              <p
+                className="menuButtonsShareNetworkUrlsContainer"
+              >
+                <label>
+                  <input
+                    checked={false}
+                    className="menuButtonsShareNetworkUrlsCheckbox"
+                    disabled={false}
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Share the URLs of all network requests
+                </label>
               </p>
-            </section>
-            <p
-              className="menuButtonsShareNetworkUrlsContainer"
+            </div>
+            <div
+              className="arrowPanelButtons"
             >
-              <label>
-                <input
-                  checked={false}
-                  className="menuButtonsShareNetworkUrlsCheckbox"
-                  disabled={false}
-                  onChange={[Function]}
-                  type="checkbox"
-                />
-                Share the URLs of all network requests
-              </label>
-            </p>
-          </div>
-          <div
-            className="arrowPanelButtons"
-          >
-            <input
-              className="arrowPanelCancelButton"
-              onClick={[Function]}
-              type="button"
-              value="Cancel"
-            />
-            <input
-              className="arrowPanelOkButton"
-              onClick={[Function]}
-              type="button"
-              value="Share"
-            />
+              <input
+                className="arrowPanelCancelButton"
+                onClick={[Function]}
+                type="button"
+                value="Cancel"
+              />
+              <input
+                className="arrowPanelOkButton"
+                onClick={[Function]}
+                type="button"
+                value="Share"
+              />
+            </div>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      className="menuButtonsUploadingButton"
-    >
       <div
-        className="menuButtonsUploadingButtonInner"
+        className="menuButtonsUploadingButton"
       >
-        <progress
-          className="menuButtonsUploadingButtonProgress"
-          value={0}
-        />
         <div
-          className="menuButtonsUploadingButtonLabel"
+          className="menuButtonsUploadingButtonInner"
         >
-          Uploading...
+          <progress
+            className="menuButtonsUploadingButtonProgress"
+            value={0}
+          />
+          <div
+            className="menuButtonsUploadingButtonLabel"
+          >
+            Uploading...
+          </div>
+        </div>
+      </div>
+      <div
+        className="buttonWithPanel menuButtonsPermalinkButton"
+      >
+        <div
+          className="buttonWithPanelButtonWrapper"
+        >
+          <input
+            className="buttonWithPanelButton menuButtonsPermalinkButtonButton"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+            value="Permalink"
+          />
+        </div>
+        <div
+          className="arrowPanelAnchor"
+        >
+          <div
+            className="arrowPanel menuButtonsPermalinkPanel"
+          >
+            <div
+              className="arrowPanelArrow"
+            />
+            <div
+              className="arrowPanelContent"
+            >
+              <input
+                className="menuButtonsPermalinkTextField"
+                readOnly="readOnly"
+                type="text"
+                value="http://localhost/"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="buttonWithPanel menuButtonsUploadErrorButton"
+      >
+        <div
+          className="buttonWithPanelButtonWrapper"
+        >
+          <input
+            className="buttonWithPanelButton menuButtonsUploadErrorButtonButton"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+            value="Upload Error"
+          />
+        </div>
+        <div
+          className="arrowPanelAnchor"
+        >
+          <div
+            className="arrowPanel hasTitle hasButtons menuButtonsUploadErrorPanel"
+          >
+            <div
+              className="arrowPanelArrow"
+            />
+            <h1
+              className="arrowPanelTitle"
+            >
+              Upload Error
+            </h1>
+            <div
+              className="arrowPanelContent"
+            >
+              <p>
+                An error occurred during upload:
+              </p>
+              <pre />
+            </div>
+            <div
+              className="arrowPanelButtons"
+            >
+              <input
+                className="arrowPanelCancelButton"
+                onClick={[Function]}
+                type="button"
+                value="Cancel"
+              />
+              <input
+                className="arrowPanelOkButton"
+                onClick={[Function]}
+                type="button"
+                value="Try Again"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="buttonWithPanel menuButtonsSecondaryShareButton"
+      >
+        <div
+          className="buttonWithPanelButtonWrapper"
+        >
+          <input
+            className="buttonWithPanelButton menuButtonsSecondaryShareButtonButton"
+            disabled={true}
+            onClick={[Function]}
+            type="button"
+            value="Share with URLs"
+          />
+        </div>
+        <div
+          className="arrowPanelAnchor"
+        >
+          <div
+            className="arrowPanel hasTitle hasButtons menuButtonsPrivacyPanel"
+          >
+            <div
+              className="arrowPanelArrow"
+            />
+            <h1
+              className="arrowPanelTitle"
+            >
+              Upload Profile – Privacy Notice
+            </h1>
+            <div
+              className="arrowPanelContent"
+            >
+              <section
+                className="privacyNotice"
+              >
+                <p>
+                  You’re about to upload your profile publicly where anyone will be able to access it. To better diagnose performance problems profiles include the following information:
+                </p>
+                <ul>
+                  <li>
+                    The URLs of all painted tabs, and running scripts.
+                  </li>
+                  <li>
+                    The metadata of all your add-ons to identify slow add-ons.
+                  </li>
+                  <li>
+                    Firefox build and runtime configuration.
+                  </li>
+                </ul>
+                <p>
+                  To view all the information you can download the full profile to a file and open the json structure with a text editor.
+                </p>
+                <p>
+                  By default, the URLs of all network requests will be removed while sharing the profile
+        but keeping the URLs may help to identify the problems. Please select the checkbox
+        below to share the URLs of the network requests:
+                </p>
+              </section>
+              <p
+                className="menuButtonsShareNetworkUrlsContainer"
+              >
+                <label>
+                  <input
+                    checked={false}
+                    className="menuButtonsShareNetworkUrlsCheckbox"
+                    disabled={true}
+                    type="checkbox"
+                  />
+                  Share the URLs of all network requests
+                </label>
+              </p>
+            </div>
+            <div
+              className="arrowPanelButtons"
+            >
+              <input
+                className="arrowPanelCancelButton"
+                onClick={[Function]}
+                type="button"
+                value="Cancel"
+              />
+              <input
+                className="arrowPanelOkButton"
+                onClick={[Function]}
+                type="button"
+                value="Share"
+              />
+            </div>
+          </div>
         </div>
       </div>
     </div>
     <div
-      className="buttonWithPanel menuButtonsPermalinkButton"
+      className="buttonWithPanel menuButtonsProfileDownloadButton"
     >
       <div
         className="buttonWithPanelButtonWrapper"
       >
         <input
-          className="buttonWithPanelButton menuButtonsPermalinkButtonButton"
+          className="buttonWithPanelButton menuButtonsProfileDownloadButtonButton"
           disabled={false}
           onClick={[Function]}
           type="button"
-          value="Permalink"
+          value="Save as file…"
         />
       </div>
       <div
         className="arrowPanelAnchor"
       >
         <div
-          className="arrowPanel menuButtonsPermalinkPanel"
-        >
-          <div
-            className="arrowPanelArrow"
-          />
-          <div
-            className="arrowPanelContent"
-          >
-            <input
-              className="menuButtonsPermalinkTextField"
-              readOnly="readOnly"
-              type="text"
-              value="http://localhost/"
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="buttonWithPanel menuButtonsUploadErrorButton"
-    >
-      <div
-        className="buttonWithPanelButtonWrapper"
-      >
-        <input
-          className="buttonWithPanelButton menuButtonsUploadErrorButtonButton"
-          disabled={false}
-          onClick={[Function]}
-          type="button"
-          value="Upload Error"
-        />
-      </div>
-      <div
-        className="arrowPanelAnchor"
-      >
-        <div
-          className="arrowPanel hasTitle hasButtons menuButtonsUploadErrorPanel"
+          className="arrowPanel hasTitle menuButtonsProfileDownloadPanel"
         >
           <div
             className="arrowPanelArrow"
@@ -326,184 +477,41 @@ exports[`app/MenuButtons renders the MenuButtons buttons 1`] = `
           <h1
             className="arrowPanelTitle"
           >
-            Upload Error
+            Save Profile to a Local File
           </h1>
           <div
             className="arrowPanelContent"
           >
-            <p>
-              An error occurred during upload:
-            </p>
-            <pre />
-          </div>
-          <div
-            className="arrowPanelButtons"
-          >
-            <input
-              className="arrowPanelCancelButton"
-              onClick={[Function]}
-              type="button"
-              value="Cancel"
-            />
-            <input
-              className="arrowPanelOkButton"
-              onClick={[Function]}
-              type="button"
-              value="Try Again"
-            />
+            <section />
           </div>
         </div>
       </div>
     </div>
-    <div
-      className="buttonWithPanel menuButtonsSecondaryShareButton"
+    <a
+      className="menuButtonsLink"
+      href="/docs/"
+      target="_blank"
+      title="Open the documentation in a new window"
     >
-      <div
-        className="buttonWithPanelButtonWrapper"
-      >
-        <input
-          className="buttonWithPanelButton menuButtonsSecondaryShareButtonButton"
-          disabled={true}
-          onClick={[Function]}
-          type="button"
-          value="Share with URLs"
-        />
-      </div>
-      <div
-        className="arrowPanelAnchor"
-      >
-        <div
-          className="arrowPanel hasTitle hasButtons menuButtonsPrivacyPanel"
-        >
-          <div
-            className="arrowPanelArrow"
-          />
-          <h1
-            className="arrowPanelTitle"
-          >
-            Upload Profile – Privacy Notice
-          </h1>
-          <div
-            className="arrowPanelContent"
-          >
-            <section
-              className="privacyNotice"
-            >
-              <p>
-                You’re about to upload your profile publicly where anyone will be able to access it. To better diagnose performance problems profiles include the following information:
-              </p>
-              <ul>
-                <li>
-                  The URLs of all painted tabs, and running scripts.
-                </li>
-                <li>
-                  The metadata of all your add-ons to identify slow add-ons.
-                </li>
-                <li>
-                  Firefox build and runtime configuration.
-                </li>
-              </ul>
-              <p>
-                To view all the information you can download the full profile to a file and open the json structure with a text editor.
-              </p>
-              <p>
-                By default, the URLs of all network requests will be removed while sharing the profile
-        but keeping the URLs may help to identify the problems. Please select the checkbox
-        below to share the URLs of the network requests:
-              </p>
-            </section>
-            <p
-              className="menuButtonsShareNetworkUrlsContainer"
-            >
-              <label>
-                <input
-                  checked={false}
-                  className="menuButtonsShareNetworkUrlsCheckbox"
-                  disabled={true}
-                  type="checkbox"
-                />
-                Share the URLs of all network requests
-              </label>
-            </p>
-          </div>
-          <div
-            className="arrowPanelButtons"
-          >
-            <input
-              className="arrowPanelCancelButton"
-              onClick={[Function]}
-              type="button"
-              value="Cancel"
-            />
-            <input
-              className="arrowPanelOkButton"
-              onClick={[Function]}
-              type="button"
-              value="Share"
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    className="buttonWithPanel menuButtonsProfileDownloadButton"
-  >
-    <div
-      className="buttonWithPanelButtonWrapper"
-    >
-      <input
-        className="buttonWithPanelButton menuButtonsProfileDownloadButtonButton"
-        disabled={false}
-        onClick={[Function]}
-        type="button"
-        value="Save as file…"
-      />
-    </div>
-    <div
-      className="arrowPanelAnchor"
-    >
-      <div
-        className="arrowPanel hasTitle menuButtonsProfileDownloadPanel"
-      >
-        <div
-          className="arrowPanelArrow"
-        />
-        <h1
-          className="arrowPanelTitle"
-        >
-          Save Profile to a Local File
-        </h1>
-        <div
-          className="arrowPanelContent"
-        >
-          <section />
-        </div>
-      </div>
-    </div>
-  </div>
-  <a
-    className="menuButtonsLink"
-    href="/docs/"
-    target="_blank"
-    title="Open the documentation in a new window"
-  >
-    Docs…
-  </a>
-</div>
+      Docs…
+    </a>
+  </div>,
+]
 `;
 
 exports[`app/MenuButtons renders the MenuButtons buttons 2`] = `
-<div
-  className="menuButtons"
->
+Array [
   <div
     className="menuButtonsOpenMetaInfoButtonBox"
   >
     <div
       className="menuButtonsOpenMetaInfoButtonLabel"
     >
-      Firefox (48.0) Intel Mac OS X 10.11
+      <span
+        className="menuButtonsOpenMetaInfoButtonLabelOverflow"
+      >
+        Firefox (48.0) Intel Mac OS X 10.11
+      </span>
     </div>
     <div
       className="buttonWithPanel menuButtonsOpenMetaInfoButtonButton"
@@ -645,358 +653,364 @@ exports[`app/MenuButtons renders the MenuButtons buttons 2`] = `
         </div>
       </div>
     </div>
-  </div>
+  </div>,
   <div
-    className="menuButtonsCompositeButtonContainer currentButtonIsShareButton"
+    className="menuButtons"
   >
     <div
-      className="buttonWithPanel menuButtonsShareButton"
+      className="menuButtonsCompositeButtonContainer currentButtonIsShareButton"
     >
       <div
-        className="buttonWithPanelButtonWrapper"
-      >
-        <input
-          className="buttonWithPanelButton menuButtonsShareButtonButton"
-          disabled={false}
-          onClick={[Function]}
-          type="button"
-          value="Share..."
-        />
-      </div>
-      <div
-        className="arrowPanelAnchor"
+        className="buttonWithPanel menuButtonsShareButton"
       >
         <div
-          className="arrowPanel hasTitle hasButtons menuButtonsPrivacyPanel"
+          className="buttonWithPanelButtonWrapper"
+        >
+          <input
+            className="buttonWithPanelButton menuButtonsShareButtonButton"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+            value="Share..."
+          />
+        </div>
+        <div
+          className="arrowPanelAnchor"
         >
           <div
-            className="arrowPanelArrow"
-          />
-          <h1
-            className="arrowPanelTitle"
+            className="arrowPanel hasTitle hasButtons menuButtonsPrivacyPanel"
           >
-            Upload Profile – Privacy Notice
-          </h1>
-          <div
-            className="arrowPanelContent"
-          >
-            <section
-              className="privacyNotice"
+            <div
+              className="arrowPanelArrow"
+            />
+            <h1
+              className="arrowPanelTitle"
             >
-              <p>
-                You’re about to upload your profile publicly where anyone will be able to access it. To better diagnose performance problems profiles include the following information:
-              </p>
-              <ul>
-                <li>
-                  The URLs of all painted tabs, and running scripts.
-                </li>
-                <li>
-                  The metadata of all your add-ons to identify slow add-ons.
-                </li>
-                <li>
-                  Firefox build and runtime configuration.
-                </li>
-              </ul>
-              <p>
-                To view all the information you can download the full profile to a file and open the json structure with a text editor.
-              </p>
-              <p>
-                By default, the URLs of all network requests will be removed while sharing the profile
+              Upload Profile – Privacy Notice
+            </h1>
+            <div
+              className="arrowPanelContent"
+            >
+              <section
+                className="privacyNotice"
+              >
+                <p>
+                  You’re about to upload your profile publicly where anyone will be able to access it. To better diagnose performance problems profiles include the following information:
+                </p>
+                <ul>
+                  <li>
+                    The URLs of all painted tabs, and running scripts.
+                  </li>
+                  <li>
+                    The metadata of all your add-ons to identify slow add-ons.
+                  </li>
+                  <li>
+                    Firefox build and runtime configuration.
+                  </li>
+                </ul>
+                <p>
+                  To view all the information you can download the full profile to a file and open the json structure with a text editor.
+                </p>
+                <p>
+                  By default, the URLs of all network requests will be removed while sharing the profile
         but keeping the URLs may help to identify the problems. Please select the checkbox
         below to share the URLs of the network requests:
+                </p>
+              </section>
+              <p
+                className="menuButtonsShareNetworkUrlsContainer"
+              >
+                <label>
+                  <input
+                    checked={false}
+                    className="menuButtonsShareNetworkUrlsCheckbox"
+                    disabled={false}
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Share the URLs of all network requests
+                </label>
               </p>
-            </section>
-            <p
-              className="menuButtonsShareNetworkUrlsContainer"
+            </div>
+            <div
+              className="arrowPanelButtons"
             >
-              <label>
-                <input
-                  checked={false}
-                  className="menuButtonsShareNetworkUrlsCheckbox"
-                  disabled={false}
-                  onChange={[Function]}
-                  type="checkbox"
-                />
-                Share the URLs of all network requests
-              </label>
-            </p>
-          </div>
-          <div
-            className="arrowPanelButtons"
-          >
-            <input
-              className="arrowPanelCancelButton"
-              onClick={[Function]}
-              type="button"
-              value="Cancel"
-            />
-            <input
-              className="arrowPanelOkButton"
-              onClick={[Function]}
-              type="button"
-              value="Share"
-            />
+              <input
+                className="arrowPanelCancelButton"
+                onClick={[Function]}
+                type="button"
+                value="Cancel"
+              />
+              <input
+                className="arrowPanelOkButton"
+                onClick={[Function]}
+                type="button"
+                value="Share"
+              />
+            </div>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      className="menuButtonsUploadingButton"
-    >
       <div
-        className="menuButtonsUploadingButtonInner"
-      >
-        <progress
-          className="menuButtonsUploadingButtonProgress"
-          value={0}
-        />
-        <div
-          className="menuButtonsUploadingButtonLabel"
-        >
-          Uploading...
-        </div>
-      </div>
-    </div>
-    <div
-      className="buttonWithPanel menuButtonsPermalinkButton"
-    >
-      <div
-        className="buttonWithPanelButtonWrapper"
-      >
-        <input
-          className="buttonWithPanelButton menuButtonsPermalinkButtonButton"
-          disabled={false}
-          onClick={[Function]}
-          type="button"
-          value="Permalink"
-        />
-      </div>
-      <div
-        className="arrowPanelAnchor"
+        className="menuButtonsUploadingButton"
       >
         <div
-          className="arrowPanel menuButtonsPermalinkPanel"
+          className="menuButtonsUploadingButtonInner"
         >
-          <div
-            className="arrowPanelArrow"
+          <progress
+            className="menuButtonsUploadingButtonProgress"
+            value={0}
           />
           <div
-            className="arrowPanelContent"
+            className="menuButtonsUploadingButtonLabel"
           >
-            <input
-              className="menuButtonsPermalinkTextField"
-              readOnly="readOnly"
-              type="text"
-              value="http://localhost/"
-            />
+            Uploading...
           </div>
         </div>
       </div>
-    </div>
-    <div
-      className="buttonWithPanel menuButtonsUploadErrorButton"
-    >
       <div
-        className="buttonWithPanelButtonWrapper"
-      >
-        <input
-          className="buttonWithPanelButton menuButtonsUploadErrorButtonButton"
-          disabled={false}
-          onClick={[Function]}
-          type="button"
-          value="Upload Error"
-        />
-      </div>
-      <div
-        className="arrowPanelAnchor"
+        className="buttonWithPanel menuButtonsPermalinkButton"
       >
         <div
-          className="arrowPanel hasTitle hasButtons menuButtonsUploadErrorPanel"
+          className="buttonWithPanelButtonWrapper"
+        >
+          <input
+            className="buttonWithPanelButton menuButtonsPermalinkButtonButton"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+            value="Permalink"
+          />
+        </div>
+        <div
+          className="arrowPanelAnchor"
         >
           <div
-            className="arrowPanelArrow"
-          />
-          <h1
-            className="arrowPanelTitle"
+            className="arrowPanel menuButtonsPermalinkPanel"
           >
-            Upload Error
-          </h1>
-          <div
-            className="arrowPanelContent"
-          >
-            <p>
-              An error occurred during upload:
-            </p>
-            <pre />
-          </div>
-          <div
-            className="arrowPanelButtons"
-          >
-            <input
-              className="arrowPanelCancelButton"
-              onClick={[Function]}
-              type="button"
-              value="Cancel"
+            <div
+              className="arrowPanelArrow"
             />
-            <input
-              className="arrowPanelOkButton"
-              onClick={[Function]}
-              type="button"
-              value="Try Again"
-            />
+            <div
+              className="arrowPanelContent"
+            >
+              <input
+                className="menuButtonsPermalinkTextField"
+                readOnly="readOnly"
+                type="text"
+                value="http://localhost/"
+              />
+            </div>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      className="buttonWithPanel menuButtonsSecondaryShareButton"
-    >
       <div
-        className="buttonWithPanelButtonWrapper"
-      >
-        <input
-          className="buttonWithPanelButton menuButtonsSecondaryShareButtonButton"
-          disabled={false}
-          onClick={[Function]}
-          type="button"
-          value="Share with URLs"
-        />
-      </div>
-      <div
-        className="arrowPanelAnchor"
+        className="buttonWithPanel menuButtonsUploadErrorButton"
       >
         <div
-          className="arrowPanel hasTitle hasButtons menuButtonsPrivacyPanel"
+          className="buttonWithPanelButtonWrapper"
+        >
+          <input
+            className="buttonWithPanelButton menuButtonsUploadErrorButtonButton"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+            value="Upload Error"
+          />
+        </div>
+        <div
+          className="arrowPanelAnchor"
         >
           <div
-            className="arrowPanelArrow"
-          />
-          <h1
-            className="arrowPanelTitle"
+            className="arrowPanel hasTitle hasButtons menuButtonsUploadErrorPanel"
           >
-            Upload Profile – Privacy Notice
-          </h1>
-          <div
-            className="arrowPanelContent"
-          >
-            <section
-              className="privacyNotice"
+            <div
+              className="arrowPanelArrow"
+            />
+            <h1
+              className="arrowPanelTitle"
+            >
+              Upload Error
+            </h1>
+            <div
+              className="arrowPanelContent"
             >
               <p>
-                You’re about to upload your profile publicly where anyone will be able to access it. To better diagnose performance problems profiles include the following information:
+                An error occurred during upload:
               </p>
-              <ul>
-                <li>
-                  The URLs of all painted tabs, and running scripts.
-                </li>
-                <li>
-                  The metadata of all your add-ons to identify slow add-ons.
-                </li>
-                <li>
-                  Firefox build and runtime configuration.
-                </li>
-              </ul>
-              <p>
-                To view all the information you can download the full profile to a file and open the json structure with a text editor.
-              </p>
-              <p>
-                By default, the URLs of all network requests will be removed while sharing the profile
+              <pre />
+            </div>
+            <div
+              className="arrowPanelButtons"
+            >
+              <input
+                className="arrowPanelCancelButton"
+                onClick={[Function]}
+                type="button"
+                value="Cancel"
+              />
+              <input
+                className="arrowPanelOkButton"
+                onClick={[Function]}
+                type="button"
+                value="Try Again"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="buttonWithPanel menuButtonsSecondaryShareButton"
+      >
+        <div
+          className="buttonWithPanelButtonWrapper"
+        >
+          <input
+            className="buttonWithPanelButton menuButtonsSecondaryShareButtonButton"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+            value="Share with URLs"
+          />
+        </div>
+        <div
+          className="arrowPanelAnchor"
+        >
+          <div
+            className="arrowPanel hasTitle hasButtons menuButtonsPrivacyPanel"
+          >
+            <div
+              className="arrowPanelArrow"
+            />
+            <h1
+              className="arrowPanelTitle"
+            >
+              Upload Profile – Privacy Notice
+            </h1>
+            <div
+              className="arrowPanelContent"
+            >
+              <section
+                className="privacyNotice"
+              >
+                <p>
+                  You’re about to upload your profile publicly where anyone will be able to access it. To better diagnose performance problems profiles include the following information:
+                </p>
+                <ul>
+                  <li>
+                    The URLs of all painted tabs, and running scripts.
+                  </li>
+                  <li>
+                    The metadata of all your add-ons to identify slow add-ons.
+                  </li>
+                  <li>
+                    Firefox build and runtime configuration.
+                  </li>
+                </ul>
+                <p>
+                  To view all the information you can download the full profile to a file and open the json structure with a text editor.
+                </p>
+                <p>
+                  By default, the URLs of all network requests will be removed while sharing the profile
         but keeping the URLs may help to identify the problems. Please select the checkbox
         below to share the URLs of the network requests:
+                </p>
+              </section>
+              <p
+                className="menuButtonsShareNetworkUrlsContainer"
+              >
+                <label>
+                  <input
+                    checked={false}
+                    className="menuButtonsShareNetworkUrlsCheckbox"
+                    disabled={true}
+                    type="checkbox"
+                  />
+                  Share the URLs of all network requests
+                </label>
               </p>
-            </section>
-            <p
-              className="menuButtonsShareNetworkUrlsContainer"
+            </div>
+            <div
+              className="arrowPanelButtons"
             >
-              <label>
-                <input
-                  checked={false}
-                  className="menuButtonsShareNetworkUrlsCheckbox"
-                  disabled={true}
-                  type="checkbox"
-                />
-                Share the URLs of all network requests
-              </label>
-            </p>
-          </div>
-          <div
-            className="arrowPanelButtons"
-          >
-            <input
-              className="arrowPanelCancelButton"
-              onClick={[Function]}
-              type="button"
-              value="Cancel"
-            />
-            <input
-              className="arrowPanelOkButton"
-              onClick={[Function]}
-              type="button"
-              value="Share"
-            />
+              <input
+                className="arrowPanelCancelButton"
+                onClick={[Function]}
+                type="button"
+                value="Cancel"
+              />
+              <input
+                className="arrowPanelOkButton"
+                onClick={[Function]}
+                type="button"
+                value="Share"
+              />
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
-  <div
-    className="buttonWithPanel menuButtonsProfileDownloadButton"
-  >
     <div
-      className="buttonWithPanelButtonWrapper"
-    >
-      <input
-        className="buttonWithPanelButton menuButtonsProfileDownloadButtonButton"
-        disabled={false}
-        onClick={[Function]}
-        type="button"
-        value="Save as file…"
-      />
-    </div>
-    <div
-      className="arrowPanelAnchor"
+      className="buttonWithPanel menuButtonsProfileDownloadButton"
     >
       <div
-        className="arrowPanel hasTitle menuButtonsProfileDownloadPanel"
+        className="buttonWithPanelButtonWrapper"
+      >
+        <input
+          className="buttonWithPanelButton menuButtonsProfileDownloadButtonButton"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+          value="Save as file…"
+        />
+      </div>
+      <div
+        className="arrowPanelAnchor"
       >
         <div
-          className="arrowPanelArrow"
-        />
-        <h1
-          className="arrowPanelTitle"
+          className="arrowPanel hasTitle menuButtonsProfileDownloadPanel"
         >
-          Save Profile to a Local File
-        </h1>
-        <div
-          className="arrowPanelContent"
-        >
-          <section />
+          <div
+            className="arrowPanelArrow"
+          />
+          <h1
+            className="arrowPanelTitle"
+          >
+            Save Profile to a Local File
+          </h1>
+          <div
+            className="arrowPanelContent"
+          >
+            <section />
+          </div>
         </div>
       </div>
     </div>
-  </div>
-  <a
-    className="menuButtonsLink"
-    href="/docs/"
-    target="_blank"
-    title="Open the documentation in a new window"
-  >
-    Docs…
-  </a>
-</div>
+    <a
+      className="menuButtonsLink"
+      href="/docs/"
+      target="_blank"
+      title="Open the documentation in a new window"
+    >
+      Docs…
+    </a>
+  </div>,
+]
 `;
 
 exports[`app/MenuButtons renders the MenuButtons buttons with profile.meta.networkURLsRemoved set to true 1`] = `
-<div
-  className="menuButtons"
->
+Array [
   <div
     className="menuButtonsOpenMetaInfoButtonBox"
   >
     <div
       className="menuButtonsOpenMetaInfoButtonLabel"
     >
-      Firefox (48.0) Intel Mac OS X 10.11
+      <span
+        className="menuButtonsOpenMetaInfoButtonLabelOverflow"
+      >
+        Firefox (48.0) Intel Mac OS X 10.11
+      </span>
     </div>
     <div
       className="buttonWithPanel menuButtonsOpenMetaInfoButtonButton"
@@ -1138,173 +1152,322 @@ exports[`app/MenuButtons renders the MenuButtons buttons with profile.meta.netwo
         </div>
       </div>
     </div>
-  </div>
+  </div>,
   <div
-    className="menuButtonsCompositeButtonContainer currentButtonIsShareButton"
+    className="menuButtons"
   >
     <div
-      className="buttonWithPanel menuButtonsShareButton"
+      className="menuButtonsCompositeButtonContainer currentButtonIsShareButton"
     >
       <div
-        className="buttonWithPanelButtonWrapper"
-      >
-        <input
-          className="buttonWithPanelButton menuButtonsShareButtonButton"
-          disabled={true}
-          onClick={[Function]}
-          type="button"
-          value="Sharing will be enabled once symbolication is complete"
-        />
-      </div>
-      <div
-        className="arrowPanelAnchor"
+        className="buttonWithPanel menuButtonsShareButton"
       >
         <div
-          className="arrowPanel hasTitle hasButtons menuButtonsPrivacyPanel"
+          className="buttonWithPanelButtonWrapper"
+        >
+          <input
+            className="buttonWithPanelButton menuButtonsShareButtonButton"
+            disabled={true}
+            onClick={[Function]}
+            type="button"
+            value="Sharing will be enabled once symbolication is complete"
+          />
+        </div>
+        <div
+          className="arrowPanelAnchor"
         >
           <div
-            className="arrowPanelArrow"
-          />
-          <h1
-            className="arrowPanelTitle"
+            className="arrowPanel hasTitle hasButtons menuButtonsPrivacyPanel"
           >
-            Upload Profile – Privacy Notice
-          </h1>
-          <div
-            className="arrowPanelContent"
-          >
-            <section
-              className="privacyNotice"
+            <div
+              className="arrowPanelArrow"
+            />
+            <h1
+              className="arrowPanelTitle"
             >
-              <p>
-                You’re about to upload your profile publicly where anyone will be able to access it. To better diagnose performance problems profiles include the following information:
-              </p>
-              <ul>
-                <li>
-                  The URLs of all painted tabs, and running scripts.
-                </li>
-                <li>
-                  The metadata of all your add-ons to identify slow add-ons.
-                </li>
-                <li>
-                  Firefox build and runtime configuration.
-                </li>
-              </ul>
-              <p>
-                To view all the information you can download the full profile to a file and open the json structure with a text editor.
-              </p>
-              <p>
-                By default, the URLs of all network requests will be removed while sharing the profile
+              Upload Profile – Privacy Notice
+            </h1>
+            <div
+              className="arrowPanelContent"
+            >
+              <section
+                className="privacyNotice"
+              >
+                <p>
+                  You’re about to upload your profile publicly where anyone will be able to access it. To better diagnose performance problems profiles include the following information:
+                </p>
+                <ul>
+                  <li>
+                    The URLs of all painted tabs, and running scripts.
+                  </li>
+                  <li>
+                    The metadata of all your add-ons to identify slow add-ons.
+                  </li>
+                  <li>
+                    Firefox build and runtime configuration.
+                  </li>
+                </ul>
+                <p>
+                  To view all the information you can download the full profile to a file and open the json structure with a text editor.
+                </p>
+                <p>
+                  By default, the URLs of all network requests will be removed while sharing the profile
         but keeping the URLs may help to identify the problems. Please select the checkbox
         below to share the URLs of the network requests:
+                </p>
+              </section>
+              <p
+                className="menuButtonsShareNetworkUrlsContainer"
+              >
+                <label>
+                  <input
+                    checked={false}
+                    className="menuButtonsShareNetworkUrlsCheckbox"
+                    disabled={false}
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Share the URLs of all network requests
+                </label>
               </p>
-            </section>
-            <p
-              className="menuButtonsShareNetworkUrlsContainer"
+            </div>
+            <div
+              className="arrowPanelButtons"
             >
-              <label>
-                <input
-                  checked={false}
-                  className="menuButtonsShareNetworkUrlsCheckbox"
-                  disabled={false}
-                  onChange={[Function]}
-                  type="checkbox"
-                />
-                Share the URLs of all network requests
-              </label>
-            </p>
-          </div>
-          <div
-            className="arrowPanelButtons"
-          >
-            <input
-              className="arrowPanelCancelButton"
-              onClick={[Function]}
-              type="button"
-              value="Cancel"
-            />
-            <input
-              className="arrowPanelOkButton"
-              onClick={[Function]}
-              type="button"
-              value="Share"
-            />
+              <input
+                className="arrowPanelCancelButton"
+                onClick={[Function]}
+                type="button"
+                value="Cancel"
+              />
+              <input
+                className="arrowPanelOkButton"
+                onClick={[Function]}
+                type="button"
+                value="Share"
+              />
+            </div>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      className="menuButtonsUploadingButton"
-    >
       <div
-        className="menuButtonsUploadingButtonInner"
+        className="menuButtonsUploadingButton"
       >
-        <progress
-          className="menuButtonsUploadingButtonProgress"
-          value={0}
-        />
         <div
-          className="menuButtonsUploadingButtonLabel"
+          className="menuButtonsUploadingButtonInner"
         >
-          Uploading...
+          <progress
+            className="menuButtonsUploadingButtonProgress"
+            value={0}
+          />
+          <div
+            className="menuButtonsUploadingButtonLabel"
+          >
+            Uploading...
+          </div>
+        </div>
+      </div>
+      <div
+        className="buttonWithPanel menuButtonsPermalinkButton"
+      >
+        <div
+          className="buttonWithPanelButtonWrapper"
+        >
+          <input
+            className="buttonWithPanelButton menuButtonsPermalinkButtonButton"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+            value="Permalink"
+          />
+        </div>
+        <div
+          className="arrowPanelAnchor"
+        >
+          <div
+            className="arrowPanel menuButtonsPermalinkPanel"
+          >
+            <div
+              className="arrowPanelArrow"
+            />
+            <div
+              className="arrowPanelContent"
+            >
+              <input
+                className="menuButtonsPermalinkTextField"
+                readOnly="readOnly"
+                type="text"
+                value="http://localhost/"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="buttonWithPanel menuButtonsUploadErrorButton"
+      >
+        <div
+          className="buttonWithPanelButtonWrapper"
+        >
+          <input
+            className="buttonWithPanelButton menuButtonsUploadErrorButtonButton"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+            value="Upload Error"
+          />
+        </div>
+        <div
+          className="arrowPanelAnchor"
+        >
+          <div
+            className="arrowPanel hasTitle hasButtons menuButtonsUploadErrorPanel"
+          >
+            <div
+              className="arrowPanelArrow"
+            />
+            <h1
+              className="arrowPanelTitle"
+            >
+              Upload Error
+            </h1>
+            <div
+              className="arrowPanelContent"
+            >
+              <p>
+                An error occurred during upload:
+              </p>
+              <pre />
+            </div>
+            <div
+              className="arrowPanelButtons"
+            >
+              <input
+                className="arrowPanelCancelButton"
+                onClick={[Function]}
+                type="button"
+                value="Cancel"
+              />
+              <input
+                className="arrowPanelOkButton"
+                onClick={[Function]}
+                type="button"
+                value="Try Again"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="buttonWithPanel menuButtonsSecondaryShareButton"
+      >
+        <div
+          className="buttonWithPanelButtonWrapper"
+        >
+          <input
+            className="buttonWithPanelButton menuButtonsSecondaryShareButtonButton"
+            disabled={true}
+            onClick={[Function]}
+            type="button"
+            value="Share with URLs"
+          />
+        </div>
+        <div
+          className="arrowPanelAnchor"
+        >
+          <div
+            className="arrowPanel hasTitle hasButtons menuButtonsPrivacyPanel"
+          >
+            <div
+              className="arrowPanelArrow"
+            />
+            <h1
+              className="arrowPanelTitle"
+            >
+              Upload Profile – Privacy Notice
+            </h1>
+            <div
+              className="arrowPanelContent"
+            >
+              <section
+                className="privacyNotice"
+              >
+                <p>
+                  You’re about to upload your profile publicly where anyone will be able to access it. To better diagnose performance problems profiles include the following information:
+                </p>
+                <ul>
+                  <li>
+                    The URLs of all painted tabs, and running scripts.
+                  </li>
+                  <li>
+                    The metadata of all your add-ons to identify slow add-ons.
+                  </li>
+                  <li>
+                    Firefox build and runtime configuration.
+                  </li>
+                </ul>
+                <p>
+                  To view all the information you can download the full profile to a file and open the json structure with a text editor.
+                </p>
+                <p>
+                  By default, the URLs of all network requests will be removed while sharing the profile
+        but keeping the URLs may help to identify the problems. Please select the checkbox
+        below to share the URLs of the network requests:
+                </p>
+              </section>
+              <p
+                className="menuButtonsShareNetworkUrlsContainer"
+              >
+                <label>
+                  <input
+                    checked={false}
+                    className="menuButtonsShareNetworkUrlsCheckbox"
+                    disabled={true}
+                    type="checkbox"
+                  />
+                  Share the URLs of all network requests
+                </label>
+              </p>
+            </div>
+            <div
+              className="arrowPanelButtons"
+            >
+              <input
+                className="arrowPanelCancelButton"
+                onClick={[Function]}
+                type="button"
+                value="Cancel"
+              />
+              <input
+                className="arrowPanelOkButton"
+                onClick={[Function]}
+                type="button"
+                value="Share"
+              />
+            </div>
+          </div>
         </div>
       </div>
     </div>
     <div
-      className="buttonWithPanel menuButtonsPermalinkButton"
+      className="buttonWithPanel menuButtonsProfileDownloadButton"
     >
       <div
         className="buttonWithPanelButtonWrapper"
       >
         <input
-          className="buttonWithPanelButton menuButtonsPermalinkButtonButton"
+          className="buttonWithPanelButton menuButtonsProfileDownloadButtonButton"
           disabled={false}
           onClick={[Function]}
           type="button"
-          value="Permalink"
+          value="Save as file…"
         />
       </div>
       <div
         className="arrowPanelAnchor"
       >
         <div
-          className="arrowPanel menuButtonsPermalinkPanel"
-        >
-          <div
-            className="arrowPanelArrow"
-          />
-          <div
-            className="arrowPanelContent"
-          >
-            <input
-              className="menuButtonsPermalinkTextField"
-              readOnly="readOnly"
-              type="text"
-              value="http://localhost/"
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="buttonWithPanel menuButtonsUploadErrorButton"
-    >
-      <div
-        className="buttonWithPanelButtonWrapper"
-      >
-        <input
-          className="buttonWithPanelButton menuButtonsUploadErrorButtonButton"
-          disabled={false}
-          onClick={[Function]}
-          type="button"
-          value="Upload Error"
-        />
-      </div>
-      <div
-        className="arrowPanelAnchor"
-      >
-        <div
-          className="arrowPanel hasTitle hasButtons menuButtonsUploadErrorPanel"
+          className="arrowPanel hasTitle menuButtonsProfileDownloadPanel"
         >
           <div
             className="arrowPanelArrow"
@@ -1312,184 +1475,41 @@ exports[`app/MenuButtons renders the MenuButtons buttons with profile.meta.netwo
           <h1
             className="arrowPanelTitle"
           >
-            Upload Error
+            Save Profile to a Local File
           </h1>
           <div
             className="arrowPanelContent"
           >
-            <p>
-              An error occurred during upload:
-            </p>
-            <pre />
-          </div>
-          <div
-            className="arrowPanelButtons"
-          >
-            <input
-              className="arrowPanelCancelButton"
-              onClick={[Function]}
-              type="button"
-              value="Cancel"
-            />
-            <input
-              className="arrowPanelOkButton"
-              onClick={[Function]}
-              type="button"
-              value="Try Again"
-            />
+            <section />
           </div>
         </div>
       </div>
     </div>
-    <div
-      className="buttonWithPanel menuButtonsSecondaryShareButton"
+    <a
+      className="menuButtonsLink"
+      href="/docs/"
+      target="_blank"
+      title="Open the documentation in a new window"
     >
-      <div
-        className="buttonWithPanelButtonWrapper"
-      >
-        <input
-          className="buttonWithPanelButton menuButtonsSecondaryShareButtonButton"
-          disabled={true}
-          onClick={[Function]}
-          type="button"
-          value="Share with URLs"
-        />
-      </div>
-      <div
-        className="arrowPanelAnchor"
-      >
-        <div
-          className="arrowPanel hasTitle hasButtons menuButtonsPrivacyPanel"
-        >
-          <div
-            className="arrowPanelArrow"
-          />
-          <h1
-            className="arrowPanelTitle"
-          >
-            Upload Profile – Privacy Notice
-          </h1>
-          <div
-            className="arrowPanelContent"
-          >
-            <section
-              className="privacyNotice"
-            >
-              <p>
-                You’re about to upload your profile publicly where anyone will be able to access it. To better diagnose performance problems profiles include the following information:
-              </p>
-              <ul>
-                <li>
-                  The URLs of all painted tabs, and running scripts.
-                </li>
-                <li>
-                  The metadata of all your add-ons to identify slow add-ons.
-                </li>
-                <li>
-                  Firefox build and runtime configuration.
-                </li>
-              </ul>
-              <p>
-                To view all the information you can download the full profile to a file and open the json structure with a text editor.
-              </p>
-              <p>
-                By default, the URLs of all network requests will be removed while sharing the profile
-        but keeping the URLs may help to identify the problems. Please select the checkbox
-        below to share the URLs of the network requests:
-              </p>
-            </section>
-            <p
-              className="menuButtonsShareNetworkUrlsContainer"
-            >
-              <label>
-                <input
-                  checked={false}
-                  className="menuButtonsShareNetworkUrlsCheckbox"
-                  disabled={true}
-                  type="checkbox"
-                />
-                Share the URLs of all network requests
-              </label>
-            </p>
-          </div>
-          <div
-            className="arrowPanelButtons"
-          >
-            <input
-              className="arrowPanelCancelButton"
-              onClick={[Function]}
-              type="button"
-              value="Cancel"
-            />
-            <input
-              className="arrowPanelOkButton"
-              onClick={[Function]}
-              type="button"
-              value="Share"
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    className="buttonWithPanel menuButtonsProfileDownloadButton"
-  >
-    <div
-      className="buttonWithPanelButtonWrapper"
-    >
-      <input
-        className="buttonWithPanelButton menuButtonsProfileDownloadButtonButton"
-        disabled={false}
-        onClick={[Function]}
-        type="button"
-        value="Save as file…"
-      />
-    </div>
-    <div
-      className="arrowPanelAnchor"
-    >
-      <div
-        className="arrowPanel hasTitle menuButtonsProfileDownloadPanel"
-      >
-        <div
-          className="arrowPanelArrow"
-        />
-        <h1
-          className="arrowPanelTitle"
-        >
-          Save Profile to a Local File
-        </h1>
-        <div
-          className="arrowPanelContent"
-        >
-          <section />
-        </div>
-      </div>
-    </div>
-  </div>
-  <a
-    className="menuButtonsLink"
-    href="/docs/"
-    target="_blank"
-    title="Open the documentation in a new window"
-  >
-    Docs…
-  </a>
-</div>
+      Docs…
+    </a>
+  </div>,
+]
 `;
 
 exports[`app/MenuButtons renders the MenuButtons buttons with profile.meta.networkURLsRemoved set to true 2`] = `
-<div
-  className="menuButtons"
->
+Array [
   <div
     className="menuButtonsOpenMetaInfoButtonBox"
   >
     <div
       className="menuButtonsOpenMetaInfoButtonLabel"
     >
-      Firefox (48.0) Intel Mac OS X 10.11
+      <span
+        className="menuButtonsOpenMetaInfoButtonLabelOverflow"
+      >
+        Firefox (48.0) Intel Mac OS X 10.11
+      </span>
     </div>
     <div
       className="buttonWithPanel menuButtonsOpenMetaInfoButtonButton"
@@ -1631,358 +1651,364 @@ exports[`app/MenuButtons renders the MenuButtons buttons with profile.meta.netwo
         </div>
       </div>
     </div>
-  </div>
+  </div>,
   <div
-    className="menuButtonsCompositeButtonContainer currentButtonIsShareButton"
+    className="menuButtons"
   >
     <div
-      className="buttonWithPanel menuButtonsShareButton"
+      className="menuButtonsCompositeButtonContainer currentButtonIsShareButton"
     >
       <div
-        className="buttonWithPanelButtonWrapper"
-      >
-        <input
-          className="buttonWithPanelButton menuButtonsShareButtonButton"
-          disabled={false}
-          onClick={[Function]}
-          type="button"
-          value="Share..."
-        />
-      </div>
-      <div
-        className="arrowPanelAnchor"
+        className="buttonWithPanel menuButtonsShareButton"
       >
         <div
-          className="arrowPanel hasTitle hasButtons menuButtonsPrivacyPanel"
+          className="buttonWithPanelButtonWrapper"
+        >
+          <input
+            className="buttonWithPanelButton menuButtonsShareButtonButton"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+            value="Share..."
+          />
+        </div>
+        <div
+          className="arrowPanelAnchor"
         >
           <div
-            className="arrowPanelArrow"
-          />
-          <h1
-            className="arrowPanelTitle"
+            className="arrowPanel hasTitle hasButtons menuButtonsPrivacyPanel"
           >
-            Upload Profile – Privacy Notice
-          </h1>
-          <div
-            className="arrowPanelContent"
-          >
-            <section
-              className="privacyNotice"
+            <div
+              className="arrowPanelArrow"
+            />
+            <h1
+              className="arrowPanelTitle"
             >
-              <p>
-                You’re about to upload your profile publicly where anyone will be able to access it. To better diagnose performance problems profiles include the following information:
-              </p>
-              <ul>
-                <li>
-                  The URLs of all painted tabs, and running scripts.
-                </li>
-                <li>
-                  The metadata of all your add-ons to identify slow add-ons.
-                </li>
-                <li>
-                  Firefox build and runtime configuration.
-                </li>
-              </ul>
-              <p>
-                To view all the information you can download the full profile to a file and open the json structure with a text editor.
-              </p>
-              <p>
-                By default, the URLs of all network requests will be removed while sharing the profile
+              Upload Profile – Privacy Notice
+            </h1>
+            <div
+              className="arrowPanelContent"
+            >
+              <section
+                className="privacyNotice"
+              >
+                <p>
+                  You’re about to upload your profile publicly where anyone will be able to access it. To better diagnose performance problems profiles include the following information:
+                </p>
+                <ul>
+                  <li>
+                    The URLs of all painted tabs, and running scripts.
+                  </li>
+                  <li>
+                    The metadata of all your add-ons to identify slow add-ons.
+                  </li>
+                  <li>
+                    Firefox build and runtime configuration.
+                  </li>
+                </ul>
+                <p>
+                  To view all the information you can download the full profile to a file and open the json structure with a text editor.
+                </p>
+                <p>
+                  By default, the URLs of all network requests will be removed while sharing the profile
         but keeping the URLs may help to identify the problems. Please select the checkbox
         below to share the URLs of the network requests:
+                </p>
+              </section>
+              <p
+                className="menuButtonsShareNetworkUrlsContainer"
+              >
+                <label>
+                  <input
+                    checked={false}
+                    className="menuButtonsShareNetworkUrlsCheckbox"
+                    disabled={false}
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Share the URLs of all network requests
+                </label>
               </p>
-            </section>
-            <p
-              className="menuButtonsShareNetworkUrlsContainer"
+            </div>
+            <div
+              className="arrowPanelButtons"
             >
-              <label>
-                <input
-                  checked={false}
-                  className="menuButtonsShareNetworkUrlsCheckbox"
-                  disabled={false}
-                  onChange={[Function]}
-                  type="checkbox"
-                />
-                Share the URLs of all network requests
-              </label>
-            </p>
-          </div>
-          <div
-            className="arrowPanelButtons"
-          >
-            <input
-              className="arrowPanelCancelButton"
-              onClick={[Function]}
-              type="button"
-              value="Cancel"
-            />
-            <input
-              className="arrowPanelOkButton"
-              onClick={[Function]}
-              type="button"
-              value="Share"
-            />
+              <input
+                className="arrowPanelCancelButton"
+                onClick={[Function]}
+                type="button"
+                value="Cancel"
+              />
+              <input
+                className="arrowPanelOkButton"
+                onClick={[Function]}
+                type="button"
+                value="Share"
+              />
+            </div>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      className="menuButtonsUploadingButton"
-    >
       <div
-        className="menuButtonsUploadingButtonInner"
-      >
-        <progress
-          className="menuButtonsUploadingButtonProgress"
-          value={0}
-        />
-        <div
-          className="menuButtonsUploadingButtonLabel"
-        >
-          Uploading...
-        </div>
-      </div>
-    </div>
-    <div
-      className="buttonWithPanel menuButtonsPermalinkButton"
-    >
-      <div
-        className="buttonWithPanelButtonWrapper"
-      >
-        <input
-          className="buttonWithPanelButton menuButtonsPermalinkButtonButton"
-          disabled={false}
-          onClick={[Function]}
-          type="button"
-          value="Permalink"
-        />
-      </div>
-      <div
-        className="arrowPanelAnchor"
+        className="menuButtonsUploadingButton"
       >
         <div
-          className="arrowPanel menuButtonsPermalinkPanel"
+          className="menuButtonsUploadingButtonInner"
         >
-          <div
-            className="arrowPanelArrow"
+          <progress
+            className="menuButtonsUploadingButtonProgress"
+            value={0}
           />
           <div
-            className="arrowPanelContent"
+            className="menuButtonsUploadingButtonLabel"
           >
-            <input
-              className="menuButtonsPermalinkTextField"
-              readOnly="readOnly"
-              type="text"
-              value="http://localhost/"
-            />
+            Uploading...
           </div>
         </div>
       </div>
-    </div>
-    <div
-      className="buttonWithPanel menuButtonsUploadErrorButton"
-    >
       <div
-        className="buttonWithPanelButtonWrapper"
-      >
-        <input
-          className="buttonWithPanelButton menuButtonsUploadErrorButtonButton"
-          disabled={false}
-          onClick={[Function]}
-          type="button"
-          value="Upload Error"
-        />
-      </div>
-      <div
-        className="arrowPanelAnchor"
+        className="buttonWithPanel menuButtonsPermalinkButton"
       >
         <div
-          className="arrowPanel hasTitle hasButtons menuButtonsUploadErrorPanel"
+          className="buttonWithPanelButtonWrapper"
+        >
+          <input
+            className="buttonWithPanelButton menuButtonsPermalinkButtonButton"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+            value="Permalink"
+          />
+        </div>
+        <div
+          className="arrowPanelAnchor"
         >
           <div
-            className="arrowPanelArrow"
-          />
-          <h1
-            className="arrowPanelTitle"
+            className="arrowPanel menuButtonsPermalinkPanel"
           >
-            Upload Error
-          </h1>
-          <div
-            className="arrowPanelContent"
-          >
-            <p>
-              An error occurred during upload:
-            </p>
-            <pre />
-          </div>
-          <div
-            className="arrowPanelButtons"
-          >
-            <input
-              className="arrowPanelCancelButton"
-              onClick={[Function]}
-              type="button"
-              value="Cancel"
+            <div
+              className="arrowPanelArrow"
             />
-            <input
-              className="arrowPanelOkButton"
-              onClick={[Function]}
-              type="button"
-              value="Try Again"
-            />
+            <div
+              className="arrowPanelContent"
+            >
+              <input
+                className="menuButtonsPermalinkTextField"
+                readOnly="readOnly"
+                type="text"
+                value="http://localhost/"
+              />
+            </div>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      className="buttonWithPanel menuButtonsSecondaryShareButton"
-    >
       <div
-        className="buttonWithPanelButtonWrapper"
-      >
-        <input
-          className="buttonWithPanelButton menuButtonsSecondaryShareButtonButton"
-          disabled={false}
-          onClick={[Function]}
-          type="button"
-          value="Share with URLs"
-        />
-      </div>
-      <div
-        className="arrowPanelAnchor"
+        className="buttonWithPanel menuButtonsUploadErrorButton"
       >
         <div
-          className="arrowPanel hasTitle hasButtons menuButtonsPrivacyPanel"
+          className="buttonWithPanelButtonWrapper"
+        >
+          <input
+            className="buttonWithPanelButton menuButtonsUploadErrorButtonButton"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+            value="Upload Error"
+          />
+        </div>
+        <div
+          className="arrowPanelAnchor"
         >
           <div
-            className="arrowPanelArrow"
-          />
-          <h1
-            className="arrowPanelTitle"
+            className="arrowPanel hasTitle hasButtons menuButtonsUploadErrorPanel"
           >
-            Upload Profile – Privacy Notice
-          </h1>
-          <div
-            className="arrowPanelContent"
-          >
-            <section
-              className="privacyNotice"
+            <div
+              className="arrowPanelArrow"
+            />
+            <h1
+              className="arrowPanelTitle"
+            >
+              Upload Error
+            </h1>
+            <div
+              className="arrowPanelContent"
             >
               <p>
-                You’re about to upload your profile publicly where anyone will be able to access it. To better diagnose performance problems profiles include the following information:
+                An error occurred during upload:
               </p>
-              <ul>
-                <li>
-                  The URLs of all painted tabs, and running scripts.
-                </li>
-                <li>
-                  The metadata of all your add-ons to identify slow add-ons.
-                </li>
-                <li>
-                  Firefox build and runtime configuration.
-                </li>
-              </ul>
-              <p>
-                To view all the information you can download the full profile to a file and open the json structure with a text editor.
-              </p>
-              <p>
-                By default, the URLs of all network requests will be removed while sharing the profile
+              <pre />
+            </div>
+            <div
+              className="arrowPanelButtons"
+            >
+              <input
+                className="arrowPanelCancelButton"
+                onClick={[Function]}
+                type="button"
+                value="Cancel"
+              />
+              <input
+                className="arrowPanelOkButton"
+                onClick={[Function]}
+                type="button"
+                value="Try Again"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="buttonWithPanel menuButtonsSecondaryShareButton"
+      >
+        <div
+          className="buttonWithPanelButtonWrapper"
+        >
+          <input
+            className="buttonWithPanelButton menuButtonsSecondaryShareButtonButton"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+            value="Share with URLs"
+          />
+        </div>
+        <div
+          className="arrowPanelAnchor"
+        >
+          <div
+            className="arrowPanel hasTitle hasButtons menuButtonsPrivacyPanel"
+          >
+            <div
+              className="arrowPanelArrow"
+            />
+            <h1
+              className="arrowPanelTitle"
+            >
+              Upload Profile – Privacy Notice
+            </h1>
+            <div
+              className="arrowPanelContent"
+            >
+              <section
+                className="privacyNotice"
+              >
+                <p>
+                  You’re about to upload your profile publicly where anyone will be able to access it. To better diagnose performance problems profiles include the following information:
+                </p>
+                <ul>
+                  <li>
+                    The URLs of all painted tabs, and running scripts.
+                  </li>
+                  <li>
+                    The metadata of all your add-ons to identify slow add-ons.
+                  </li>
+                  <li>
+                    Firefox build and runtime configuration.
+                  </li>
+                </ul>
+                <p>
+                  To view all the information you can download the full profile to a file and open the json structure with a text editor.
+                </p>
+                <p>
+                  By default, the URLs of all network requests will be removed while sharing the profile
         but keeping the URLs may help to identify the problems. Please select the checkbox
         below to share the URLs of the network requests:
+                </p>
+              </section>
+              <p
+                className="menuButtonsShareNetworkUrlsContainer"
+              >
+                <label>
+                  <input
+                    checked={false}
+                    className="menuButtonsShareNetworkUrlsCheckbox"
+                    disabled={true}
+                    type="checkbox"
+                  />
+                  Share the URLs of all network requests
+                </label>
               </p>
-            </section>
-            <p
-              className="menuButtonsShareNetworkUrlsContainer"
+            </div>
+            <div
+              className="arrowPanelButtons"
             >
-              <label>
-                <input
-                  checked={false}
-                  className="menuButtonsShareNetworkUrlsCheckbox"
-                  disabled={true}
-                  type="checkbox"
-                />
-                Share the URLs of all network requests
-              </label>
-            </p>
-          </div>
-          <div
-            className="arrowPanelButtons"
-          >
-            <input
-              className="arrowPanelCancelButton"
-              onClick={[Function]}
-              type="button"
-              value="Cancel"
-            />
-            <input
-              className="arrowPanelOkButton"
-              onClick={[Function]}
-              type="button"
-              value="Share"
-            />
+              <input
+                className="arrowPanelCancelButton"
+                onClick={[Function]}
+                type="button"
+                value="Cancel"
+              />
+              <input
+                className="arrowPanelOkButton"
+                onClick={[Function]}
+                type="button"
+                value="Share"
+              />
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
-  <div
-    className="buttonWithPanel menuButtonsProfileDownloadButton"
-  >
     <div
-      className="buttonWithPanelButtonWrapper"
-    >
-      <input
-        className="buttonWithPanelButton menuButtonsProfileDownloadButtonButton"
-        disabled={false}
-        onClick={[Function]}
-        type="button"
-        value="Save as file…"
-      />
-    </div>
-    <div
-      className="arrowPanelAnchor"
+      className="buttonWithPanel menuButtonsProfileDownloadButton"
     >
       <div
-        className="arrowPanel hasTitle menuButtonsProfileDownloadPanel"
+        className="buttonWithPanelButtonWrapper"
+      >
+        <input
+          className="buttonWithPanelButton menuButtonsProfileDownloadButtonButton"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+          value="Save as file…"
+        />
+      </div>
+      <div
+        className="arrowPanelAnchor"
       >
         <div
-          className="arrowPanelArrow"
-        />
-        <h1
-          className="arrowPanelTitle"
+          className="arrowPanel hasTitle menuButtonsProfileDownloadPanel"
         >
-          Save Profile to a Local File
-        </h1>
-        <div
-          className="arrowPanelContent"
-        >
-          <section />
+          <div
+            className="arrowPanelArrow"
+          />
+          <h1
+            className="arrowPanelTitle"
+          >
+            Save Profile to a Local File
+          </h1>
+          <div
+            className="arrowPanelContent"
+          >
+            <section />
+          </div>
         </div>
       </div>
     </div>
-  </div>
-  <a
-    className="menuButtonsLink"
-    href="/docs/"
-    target="_blank"
-    title="Open the documentation in a new window"
-  >
-    Docs…
-  </a>
-</div>
+    <a
+      className="menuButtonsLink"
+      href="/docs/"
+      target="_blank"
+      title="Open the documentation in a new window"
+    >
+      Docs…
+    </a>
+  </div>,
+]
 `;
 
 exports[`app/MenuButtons renders the MenuButtons buttons with profile.meta.networkURLsRemoved set to undefined 1`] = `
-<div
-  className="menuButtons"
->
+Array [
   <div
     className="menuButtonsOpenMetaInfoButtonBox"
   >
     <div
       className="menuButtonsOpenMetaInfoButtonLabel"
     >
-      Firefox (48.0) Intel Mac OS X 10.11
+      <span
+        className="menuButtonsOpenMetaInfoButtonLabelOverflow"
+      >
+        Firefox (48.0) Intel Mac OS X 10.11
+      </span>
     </div>
     <div
       className="buttonWithPanel menuButtonsOpenMetaInfoButtonButton"
@@ -2124,173 +2150,322 @@ exports[`app/MenuButtons renders the MenuButtons buttons with profile.meta.netwo
         </div>
       </div>
     </div>
-  </div>
+  </div>,
   <div
-    className="menuButtonsCompositeButtonContainer currentButtonIsShareButton"
+    className="menuButtons"
   >
     <div
-      className="buttonWithPanel menuButtonsShareButton"
+      className="menuButtonsCompositeButtonContainer currentButtonIsShareButton"
     >
       <div
-        className="buttonWithPanelButtonWrapper"
-      >
-        <input
-          className="buttonWithPanelButton menuButtonsShareButtonButton"
-          disabled={true}
-          onClick={[Function]}
-          type="button"
-          value="Sharing will be enabled once symbolication is complete"
-        />
-      </div>
-      <div
-        className="arrowPanelAnchor"
+        className="buttonWithPanel menuButtonsShareButton"
       >
         <div
-          className="arrowPanel hasTitle hasButtons menuButtonsPrivacyPanel"
+          className="buttonWithPanelButtonWrapper"
+        >
+          <input
+            className="buttonWithPanelButton menuButtonsShareButtonButton"
+            disabled={true}
+            onClick={[Function]}
+            type="button"
+            value="Sharing will be enabled once symbolication is complete"
+          />
+        </div>
+        <div
+          className="arrowPanelAnchor"
         >
           <div
-            className="arrowPanelArrow"
-          />
-          <h1
-            className="arrowPanelTitle"
+            className="arrowPanel hasTitle hasButtons menuButtonsPrivacyPanel"
           >
-            Upload Profile – Privacy Notice
-          </h1>
-          <div
-            className="arrowPanelContent"
-          >
-            <section
-              className="privacyNotice"
+            <div
+              className="arrowPanelArrow"
+            />
+            <h1
+              className="arrowPanelTitle"
             >
-              <p>
-                You’re about to upload your profile publicly where anyone will be able to access it. To better diagnose performance problems profiles include the following information:
-              </p>
-              <ul>
-                <li>
-                  The URLs of all painted tabs, and running scripts.
-                </li>
-                <li>
-                  The metadata of all your add-ons to identify slow add-ons.
-                </li>
-                <li>
-                  Firefox build and runtime configuration.
-                </li>
-              </ul>
-              <p>
-                To view all the information you can download the full profile to a file and open the json structure with a text editor.
-              </p>
-              <p>
-                By default, the URLs of all network requests will be removed while sharing the profile
+              Upload Profile – Privacy Notice
+            </h1>
+            <div
+              className="arrowPanelContent"
+            >
+              <section
+                className="privacyNotice"
+              >
+                <p>
+                  You’re about to upload your profile publicly where anyone will be able to access it. To better diagnose performance problems profiles include the following information:
+                </p>
+                <ul>
+                  <li>
+                    The URLs of all painted tabs, and running scripts.
+                  </li>
+                  <li>
+                    The metadata of all your add-ons to identify slow add-ons.
+                  </li>
+                  <li>
+                    Firefox build and runtime configuration.
+                  </li>
+                </ul>
+                <p>
+                  To view all the information you can download the full profile to a file and open the json structure with a text editor.
+                </p>
+                <p>
+                  By default, the URLs of all network requests will be removed while sharing the profile
         but keeping the URLs may help to identify the problems. Please select the checkbox
         below to share the URLs of the network requests:
+                </p>
+              </section>
+              <p
+                className="menuButtonsShareNetworkUrlsContainer"
+              >
+                <label>
+                  <input
+                    checked={false}
+                    className="menuButtonsShareNetworkUrlsCheckbox"
+                    disabled={false}
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Share the URLs of all network requests
+                </label>
               </p>
-            </section>
-            <p
-              className="menuButtonsShareNetworkUrlsContainer"
+            </div>
+            <div
+              className="arrowPanelButtons"
             >
-              <label>
-                <input
-                  checked={false}
-                  className="menuButtonsShareNetworkUrlsCheckbox"
-                  disabled={false}
-                  onChange={[Function]}
-                  type="checkbox"
-                />
-                Share the URLs of all network requests
-              </label>
-            </p>
-          </div>
-          <div
-            className="arrowPanelButtons"
-          >
-            <input
-              className="arrowPanelCancelButton"
-              onClick={[Function]}
-              type="button"
-              value="Cancel"
-            />
-            <input
-              className="arrowPanelOkButton"
-              onClick={[Function]}
-              type="button"
-              value="Share"
-            />
+              <input
+                className="arrowPanelCancelButton"
+                onClick={[Function]}
+                type="button"
+                value="Cancel"
+              />
+              <input
+                className="arrowPanelOkButton"
+                onClick={[Function]}
+                type="button"
+                value="Share"
+              />
+            </div>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      className="menuButtonsUploadingButton"
-    >
       <div
-        className="menuButtonsUploadingButtonInner"
+        className="menuButtonsUploadingButton"
       >
-        <progress
-          className="menuButtonsUploadingButtonProgress"
-          value={0}
-        />
         <div
-          className="menuButtonsUploadingButtonLabel"
+          className="menuButtonsUploadingButtonInner"
         >
-          Uploading...
+          <progress
+            className="menuButtonsUploadingButtonProgress"
+            value={0}
+          />
+          <div
+            className="menuButtonsUploadingButtonLabel"
+          >
+            Uploading...
+          </div>
+        </div>
+      </div>
+      <div
+        className="buttonWithPanel menuButtonsPermalinkButton"
+      >
+        <div
+          className="buttonWithPanelButtonWrapper"
+        >
+          <input
+            className="buttonWithPanelButton menuButtonsPermalinkButtonButton"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+            value="Permalink"
+          />
+        </div>
+        <div
+          className="arrowPanelAnchor"
+        >
+          <div
+            className="arrowPanel menuButtonsPermalinkPanel"
+          >
+            <div
+              className="arrowPanelArrow"
+            />
+            <div
+              className="arrowPanelContent"
+            >
+              <input
+                className="menuButtonsPermalinkTextField"
+                readOnly="readOnly"
+                type="text"
+                value="http://localhost/"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="buttonWithPanel menuButtonsUploadErrorButton"
+      >
+        <div
+          className="buttonWithPanelButtonWrapper"
+        >
+          <input
+            className="buttonWithPanelButton menuButtonsUploadErrorButtonButton"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+            value="Upload Error"
+          />
+        </div>
+        <div
+          className="arrowPanelAnchor"
+        >
+          <div
+            className="arrowPanel hasTitle hasButtons menuButtonsUploadErrorPanel"
+          >
+            <div
+              className="arrowPanelArrow"
+            />
+            <h1
+              className="arrowPanelTitle"
+            >
+              Upload Error
+            </h1>
+            <div
+              className="arrowPanelContent"
+            >
+              <p>
+                An error occurred during upload:
+              </p>
+              <pre />
+            </div>
+            <div
+              className="arrowPanelButtons"
+            >
+              <input
+                className="arrowPanelCancelButton"
+                onClick={[Function]}
+                type="button"
+                value="Cancel"
+              />
+              <input
+                className="arrowPanelOkButton"
+                onClick={[Function]}
+                type="button"
+                value="Try Again"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="buttonWithPanel menuButtonsSecondaryShareButton"
+      >
+        <div
+          className="buttonWithPanelButtonWrapper"
+        >
+          <input
+            className="buttonWithPanelButton menuButtonsSecondaryShareButtonButton"
+            disabled={true}
+            onClick={[Function]}
+            type="button"
+            value="Share with URLs"
+          />
+        </div>
+        <div
+          className="arrowPanelAnchor"
+        >
+          <div
+            className="arrowPanel hasTitle hasButtons menuButtonsPrivacyPanel"
+          >
+            <div
+              className="arrowPanelArrow"
+            />
+            <h1
+              className="arrowPanelTitle"
+            >
+              Upload Profile – Privacy Notice
+            </h1>
+            <div
+              className="arrowPanelContent"
+            >
+              <section
+                className="privacyNotice"
+              >
+                <p>
+                  You’re about to upload your profile publicly where anyone will be able to access it. To better diagnose performance problems profiles include the following information:
+                </p>
+                <ul>
+                  <li>
+                    The URLs of all painted tabs, and running scripts.
+                  </li>
+                  <li>
+                    The metadata of all your add-ons to identify slow add-ons.
+                  </li>
+                  <li>
+                    Firefox build and runtime configuration.
+                  </li>
+                </ul>
+                <p>
+                  To view all the information you can download the full profile to a file and open the json structure with a text editor.
+                </p>
+                <p>
+                  By default, the URLs of all network requests will be removed while sharing the profile
+        but keeping the URLs may help to identify the problems. Please select the checkbox
+        below to share the URLs of the network requests:
+                </p>
+              </section>
+              <p
+                className="menuButtonsShareNetworkUrlsContainer"
+              >
+                <label>
+                  <input
+                    checked={false}
+                    className="menuButtonsShareNetworkUrlsCheckbox"
+                    disabled={true}
+                    type="checkbox"
+                  />
+                  Share the URLs of all network requests
+                </label>
+              </p>
+            </div>
+            <div
+              className="arrowPanelButtons"
+            >
+              <input
+                className="arrowPanelCancelButton"
+                onClick={[Function]}
+                type="button"
+                value="Cancel"
+              />
+              <input
+                className="arrowPanelOkButton"
+                onClick={[Function]}
+                type="button"
+                value="Share"
+              />
+            </div>
+          </div>
         </div>
       </div>
     </div>
     <div
-      className="buttonWithPanel menuButtonsPermalinkButton"
+      className="buttonWithPanel menuButtonsProfileDownloadButton"
     >
       <div
         className="buttonWithPanelButtonWrapper"
       >
         <input
-          className="buttonWithPanelButton menuButtonsPermalinkButtonButton"
+          className="buttonWithPanelButton menuButtonsProfileDownloadButtonButton"
           disabled={false}
           onClick={[Function]}
           type="button"
-          value="Permalink"
+          value="Save as file…"
         />
       </div>
       <div
         className="arrowPanelAnchor"
       >
         <div
-          className="arrowPanel menuButtonsPermalinkPanel"
-        >
-          <div
-            className="arrowPanelArrow"
-          />
-          <div
-            className="arrowPanelContent"
-          >
-            <input
-              className="menuButtonsPermalinkTextField"
-              readOnly="readOnly"
-              type="text"
-              value="http://localhost/"
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="buttonWithPanel menuButtonsUploadErrorButton"
-    >
-      <div
-        className="buttonWithPanelButtonWrapper"
-      >
-        <input
-          className="buttonWithPanelButton menuButtonsUploadErrorButtonButton"
-          disabled={false}
-          onClick={[Function]}
-          type="button"
-          value="Upload Error"
-        />
-      </div>
-      <div
-        className="arrowPanelAnchor"
-      >
-        <div
-          className="arrowPanel hasTitle hasButtons menuButtonsUploadErrorPanel"
+          className="arrowPanel hasTitle menuButtonsProfileDownloadPanel"
         >
           <div
             className="arrowPanelArrow"
@@ -2298,184 +2473,41 @@ exports[`app/MenuButtons renders the MenuButtons buttons with profile.meta.netwo
           <h1
             className="arrowPanelTitle"
           >
-            Upload Error
+            Save Profile to a Local File
           </h1>
           <div
             className="arrowPanelContent"
           >
-            <p>
-              An error occurred during upload:
-            </p>
-            <pre />
-          </div>
-          <div
-            className="arrowPanelButtons"
-          >
-            <input
-              className="arrowPanelCancelButton"
-              onClick={[Function]}
-              type="button"
-              value="Cancel"
-            />
-            <input
-              className="arrowPanelOkButton"
-              onClick={[Function]}
-              type="button"
-              value="Try Again"
-            />
+            <section />
           </div>
         </div>
       </div>
     </div>
-    <div
-      className="buttonWithPanel menuButtonsSecondaryShareButton"
+    <a
+      className="menuButtonsLink"
+      href="/docs/"
+      target="_blank"
+      title="Open the documentation in a new window"
     >
-      <div
-        className="buttonWithPanelButtonWrapper"
-      >
-        <input
-          className="buttonWithPanelButton menuButtonsSecondaryShareButtonButton"
-          disabled={true}
-          onClick={[Function]}
-          type="button"
-          value="Share with URLs"
-        />
-      </div>
-      <div
-        className="arrowPanelAnchor"
-      >
-        <div
-          className="arrowPanel hasTitle hasButtons menuButtonsPrivacyPanel"
-        >
-          <div
-            className="arrowPanelArrow"
-          />
-          <h1
-            className="arrowPanelTitle"
-          >
-            Upload Profile – Privacy Notice
-          </h1>
-          <div
-            className="arrowPanelContent"
-          >
-            <section
-              className="privacyNotice"
-            >
-              <p>
-                You’re about to upload your profile publicly where anyone will be able to access it. To better diagnose performance problems profiles include the following information:
-              </p>
-              <ul>
-                <li>
-                  The URLs of all painted tabs, and running scripts.
-                </li>
-                <li>
-                  The metadata of all your add-ons to identify slow add-ons.
-                </li>
-                <li>
-                  Firefox build and runtime configuration.
-                </li>
-              </ul>
-              <p>
-                To view all the information you can download the full profile to a file and open the json structure with a text editor.
-              </p>
-              <p>
-                By default, the URLs of all network requests will be removed while sharing the profile
-        but keeping the URLs may help to identify the problems. Please select the checkbox
-        below to share the URLs of the network requests:
-              </p>
-            </section>
-            <p
-              className="menuButtonsShareNetworkUrlsContainer"
-            >
-              <label>
-                <input
-                  checked={false}
-                  className="menuButtonsShareNetworkUrlsCheckbox"
-                  disabled={true}
-                  type="checkbox"
-                />
-                Share the URLs of all network requests
-              </label>
-            </p>
-          </div>
-          <div
-            className="arrowPanelButtons"
-          >
-            <input
-              className="arrowPanelCancelButton"
-              onClick={[Function]}
-              type="button"
-              value="Cancel"
-            />
-            <input
-              className="arrowPanelOkButton"
-              onClick={[Function]}
-              type="button"
-              value="Share"
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    className="buttonWithPanel menuButtonsProfileDownloadButton"
-  >
-    <div
-      className="buttonWithPanelButtonWrapper"
-    >
-      <input
-        className="buttonWithPanelButton menuButtonsProfileDownloadButtonButton"
-        disabled={false}
-        onClick={[Function]}
-        type="button"
-        value="Save as file…"
-      />
-    </div>
-    <div
-      className="arrowPanelAnchor"
-    >
-      <div
-        className="arrowPanel hasTitle menuButtonsProfileDownloadPanel"
-      >
-        <div
-          className="arrowPanelArrow"
-        />
-        <h1
-          className="arrowPanelTitle"
-        >
-          Save Profile to a Local File
-        </h1>
-        <div
-          className="arrowPanelContent"
-        >
-          <section />
-        </div>
-      </div>
-    </div>
-  </div>
-  <a
-    className="menuButtonsLink"
-    href="/docs/"
-    target="_blank"
-    title="Open the documentation in a new window"
-  >
-    Docs…
-  </a>
-</div>
+      Docs…
+    </a>
+  </div>,
+]
 `;
 
 exports[`app/MenuButtons renders the MenuButtons buttons with profile.meta.networkURLsRemoved set to undefined 2`] = `
-<div
-  className="menuButtons"
->
+Array [
   <div
     className="menuButtonsOpenMetaInfoButtonBox"
   >
     <div
       className="menuButtonsOpenMetaInfoButtonLabel"
     >
-      Firefox (48.0) Intel Mac OS X 10.11
+      <span
+        className="menuButtonsOpenMetaInfoButtonLabelOverflow"
+      >
+        Firefox (48.0) Intel Mac OS X 10.11
+      </span>
     </div>
     <div
       className="buttonWithPanel menuButtonsOpenMetaInfoButtonButton"
@@ -2617,343 +2649,347 @@ exports[`app/MenuButtons renders the MenuButtons buttons with profile.meta.netwo
         </div>
       </div>
     </div>
-  </div>
+  </div>,
   <div
-    className="menuButtonsCompositeButtonContainer currentButtonIsShareButton"
+    className="menuButtons"
   >
     <div
-      className="buttonWithPanel menuButtonsShareButton"
+      className="menuButtonsCompositeButtonContainer currentButtonIsShareButton"
     >
       <div
-        className="buttonWithPanelButtonWrapper"
-      >
-        <input
-          className="buttonWithPanelButton menuButtonsShareButtonButton"
-          disabled={false}
-          onClick={[Function]}
-          type="button"
-          value="Share..."
-        />
-      </div>
-      <div
-        className="arrowPanelAnchor"
+        className="buttonWithPanel menuButtonsShareButton"
       >
         <div
-          className="arrowPanel hasTitle hasButtons menuButtonsPrivacyPanel"
+          className="buttonWithPanelButtonWrapper"
+        >
+          <input
+            className="buttonWithPanelButton menuButtonsShareButtonButton"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+            value="Share..."
+          />
+        </div>
+        <div
+          className="arrowPanelAnchor"
         >
           <div
-            className="arrowPanelArrow"
-          />
-          <h1
-            className="arrowPanelTitle"
+            className="arrowPanel hasTitle hasButtons menuButtonsPrivacyPanel"
           >
-            Upload Profile – Privacy Notice
-          </h1>
-          <div
-            className="arrowPanelContent"
-          >
-            <section
-              className="privacyNotice"
+            <div
+              className="arrowPanelArrow"
+            />
+            <h1
+              className="arrowPanelTitle"
             >
-              <p>
-                You’re about to upload your profile publicly where anyone will be able to access it. To better diagnose performance problems profiles include the following information:
-              </p>
-              <ul>
-                <li>
-                  The URLs of all painted tabs, and running scripts.
-                </li>
-                <li>
-                  The metadata of all your add-ons to identify slow add-ons.
-                </li>
-                <li>
-                  Firefox build and runtime configuration.
-                </li>
-              </ul>
-              <p>
-                To view all the information you can download the full profile to a file and open the json structure with a text editor.
-              </p>
-              <p>
-                By default, the URLs of all network requests will be removed while sharing the profile
+              Upload Profile – Privacy Notice
+            </h1>
+            <div
+              className="arrowPanelContent"
+            >
+              <section
+                className="privacyNotice"
+              >
+                <p>
+                  You’re about to upload your profile publicly where anyone will be able to access it. To better diagnose performance problems profiles include the following information:
+                </p>
+                <ul>
+                  <li>
+                    The URLs of all painted tabs, and running scripts.
+                  </li>
+                  <li>
+                    The metadata of all your add-ons to identify slow add-ons.
+                  </li>
+                  <li>
+                    Firefox build and runtime configuration.
+                  </li>
+                </ul>
+                <p>
+                  To view all the information you can download the full profile to a file and open the json structure with a text editor.
+                </p>
+                <p>
+                  By default, the URLs of all network requests will be removed while sharing the profile
         but keeping the URLs may help to identify the problems. Please select the checkbox
         below to share the URLs of the network requests:
+                </p>
+              </section>
+              <p
+                className="menuButtonsShareNetworkUrlsContainer"
+              >
+                <label>
+                  <input
+                    checked={false}
+                    className="menuButtonsShareNetworkUrlsCheckbox"
+                    disabled={false}
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  Share the URLs of all network requests
+                </label>
               </p>
-            </section>
-            <p
-              className="menuButtonsShareNetworkUrlsContainer"
+            </div>
+            <div
+              className="arrowPanelButtons"
             >
-              <label>
-                <input
-                  checked={false}
-                  className="menuButtonsShareNetworkUrlsCheckbox"
-                  disabled={false}
-                  onChange={[Function]}
-                  type="checkbox"
-                />
-                Share the URLs of all network requests
-              </label>
-            </p>
-          </div>
-          <div
-            className="arrowPanelButtons"
-          >
-            <input
-              className="arrowPanelCancelButton"
-              onClick={[Function]}
-              type="button"
-              value="Cancel"
-            />
-            <input
-              className="arrowPanelOkButton"
-              onClick={[Function]}
-              type="button"
-              value="Share"
-            />
+              <input
+                className="arrowPanelCancelButton"
+                onClick={[Function]}
+                type="button"
+                value="Cancel"
+              />
+              <input
+                className="arrowPanelOkButton"
+                onClick={[Function]}
+                type="button"
+                value="Share"
+              />
+            </div>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      className="menuButtonsUploadingButton"
-    >
       <div
-        className="menuButtonsUploadingButtonInner"
-      >
-        <progress
-          className="menuButtonsUploadingButtonProgress"
-          value={0}
-        />
-        <div
-          className="menuButtonsUploadingButtonLabel"
-        >
-          Uploading...
-        </div>
-      </div>
-    </div>
-    <div
-      className="buttonWithPanel menuButtonsPermalinkButton"
-    >
-      <div
-        className="buttonWithPanelButtonWrapper"
-      >
-        <input
-          className="buttonWithPanelButton menuButtonsPermalinkButtonButton"
-          disabled={false}
-          onClick={[Function]}
-          type="button"
-          value="Permalink"
-        />
-      </div>
-      <div
-        className="arrowPanelAnchor"
+        className="menuButtonsUploadingButton"
       >
         <div
-          className="arrowPanel menuButtonsPermalinkPanel"
+          className="menuButtonsUploadingButtonInner"
         >
-          <div
-            className="arrowPanelArrow"
+          <progress
+            className="menuButtonsUploadingButtonProgress"
+            value={0}
           />
           <div
-            className="arrowPanelContent"
+            className="menuButtonsUploadingButtonLabel"
           >
-            <input
-              className="menuButtonsPermalinkTextField"
-              readOnly="readOnly"
-              type="text"
-              value="http://localhost/"
-            />
+            Uploading...
           </div>
         </div>
       </div>
-    </div>
-    <div
-      className="buttonWithPanel menuButtonsUploadErrorButton"
-    >
       <div
-        className="buttonWithPanelButtonWrapper"
-      >
-        <input
-          className="buttonWithPanelButton menuButtonsUploadErrorButtonButton"
-          disabled={false}
-          onClick={[Function]}
-          type="button"
-          value="Upload Error"
-        />
-      </div>
-      <div
-        className="arrowPanelAnchor"
+        className="buttonWithPanel menuButtonsPermalinkButton"
       >
         <div
-          className="arrowPanel hasTitle hasButtons menuButtonsUploadErrorPanel"
+          className="buttonWithPanelButtonWrapper"
+        >
+          <input
+            className="buttonWithPanelButton menuButtonsPermalinkButtonButton"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+            value="Permalink"
+          />
+        </div>
+        <div
+          className="arrowPanelAnchor"
         >
           <div
-            className="arrowPanelArrow"
-          />
-          <h1
-            className="arrowPanelTitle"
+            className="arrowPanel menuButtonsPermalinkPanel"
           >
-            Upload Error
-          </h1>
-          <div
-            className="arrowPanelContent"
-          >
-            <p>
-              An error occurred during upload:
-            </p>
-            <pre />
-          </div>
-          <div
-            className="arrowPanelButtons"
-          >
-            <input
-              className="arrowPanelCancelButton"
-              onClick={[Function]}
-              type="button"
-              value="Cancel"
+            <div
+              className="arrowPanelArrow"
             />
-            <input
-              className="arrowPanelOkButton"
-              onClick={[Function]}
-              type="button"
-              value="Try Again"
-            />
+            <div
+              className="arrowPanelContent"
+            >
+              <input
+                className="menuButtonsPermalinkTextField"
+                readOnly="readOnly"
+                type="text"
+                value="http://localhost/"
+              />
+            </div>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      className="buttonWithPanel menuButtonsSecondaryShareButton"
-    >
       <div
-        className="buttonWithPanelButtonWrapper"
-      >
-        <input
-          className="buttonWithPanelButton menuButtonsSecondaryShareButtonButton"
-          disabled={false}
-          onClick={[Function]}
-          type="button"
-          value="Share with URLs"
-        />
-      </div>
-      <div
-        className="arrowPanelAnchor"
+        className="buttonWithPanel menuButtonsUploadErrorButton"
       >
         <div
-          className="arrowPanel hasTitle hasButtons menuButtonsPrivacyPanel"
+          className="buttonWithPanelButtonWrapper"
+        >
+          <input
+            className="buttonWithPanelButton menuButtonsUploadErrorButtonButton"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+            value="Upload Error"
+          />
+        </div>
+        <div
+          className="arrowPanelAnchor"
         >
           <div
-            className="arrowPanelArrow"
-          />
-          <h1
-            className="arrowPanelTitle"
+            className="arrowPanel hasTitle hasButtons menuButtonsUploadErrorPanel"
           >
-            Upload Profile – Privacy Notice
-          </h1>
-          <div
-            className="arrowPanelContent"
-          >
-            <section
-              className="privacyNotice"
+            <div
+              className="arrowPanelArrow"
+            />
+            <h1
+              className="arrowPanelTitle"
+            >
+              Upload Error
+            </h1>
+            <div
+              className="arrowPanelContent"
             >
               <p>
-                You’re about to upload your profile publicly where anyone will be able to access it. To better diagnose performance problems profiles include the following information:
+                An error occurred during upload:
               </p>
-              <ul>
-                <li>
-                  The URLs of all painted tabs, and running scripts.
-                </li>
-                <li>
-                  The metadata of all your add-ons to identify slow add-ons.
-                </li>
-                <li>
-                  Firefox build and runtime configuration.
-                </li>
-              </ul>
-              <p>
-                To view all the information you can download the full profile to a file and open the json structure with a text editor.
-              </p>
-              <p>
-                By default, the URLs of all network requests will be removed while sharing the profile
+              <pre />
+            </div>
+            <div
+              className="arrowPanelButtons"
+            >
+              <input
+                className="arrowPanelCancelButton"
+                onClick={[Function]}
+                type="button"
+                value="Cancel"
+              />
+              <input
+                className="arrowPanelOkButton"
+                onClick={[Function]}
+                type="button"
+                value="Try Again"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="buttonWithPanel menuButtonsSecondaryShareButton"
+      >
+        <div
+          className="buttonWithPanelButtonWrapper"
+        >
+          <input
+            className="buttonWithPanelButton menuButtonsSecondaryShareButtonButton"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+            value="Share with URLs"
+          />
+        </div>
+        <div
+          className="arrowPanelAnchor"
+        >
+          <div
+            className="arrowPanel hasTitle hasButtons menuButtonsPrivacyPanel"
+          >
+            <div
+              className="arrowPanelArrow"
+            />
+            <h1
+              className="arrowPanelTitle"
+            >
+              Upload Profile – Privacy Notice
+            </h1>
+            <div
+              className="arrowPanelContent"
+            >
+              <section
+                className="privacyNotice"
+              >
+                <p>
+                  You’re about to upload your profile publicly where anyone will be able to access it. To better diagnose performance problems profiles include the following information:
+                </p>
+                <ul>
+                  <li>
+                    The URLs of all painted tabs, and running scripts.
+                  </li>
+                  <li>
+                    The metadata of all your add-ons to identify slow add-ons.
+                  </li>
+                  <li>
+                    Firefox build and runtime configuration.
+                  </li>
+                </ul>
+                <p>
+                  To view all the information you can download the full profile to a file and open the json structure with a text editor.
+                </p>
+                <p>
+                  By default, the URLs of all network requests will be removed while sharing the profile
         but keeping the URLs may help to identify the problems. Please select the checkbox
         below to share the URLs of the network requests:
+                </p>
+              </section>
+              <p
+                className="menuButtonsShareNetworkUrlsContainer"
+              >
+                <label>
+                  <input
+                    checked={false}
+                    className="menuButtonsShareNetworkUrlsCheckbox"
+                    disabled={true}
+                    type="checkbox"
+                  />
+                  Share the URLs of all network requests
+                </label>
               </p>
-            </section>
-            <p
-              className="menuButtonsShareNetworkUrlsContainer"
+            </div>
+            <div
+              className="arrowPanelButtons"
             >
-              <label>
-                <input
-                  checked={false}
-                  className="menuButtonsShareNetworkUrlsCheckbox"
-                  disabled={true}
-                  type="checkbox"
-                />
-                Share the URLs of all network requests
-              </label>
-            </p>
-          </div>
-          <div
-            className="arrowPanelButtons"
-          >
-            <input
-              className="arrowPanelCancelButton"
-              onClick={[Function]}
-              type="button"
-              value="Cancel"
-            />
-            <input
-              className="arrowPanelOkButton"
-              onClick={[Function]}
-              type="button"
-              value="Share"
-            />
+              <input
+                className="arrowPanelCancelButton"
+                onClick={[Function]}
+                type="button"
+                value="Cancel"
+              />
+              <input
+                className="arrowPanelOkButton"
+                onClick={[Function]}
+                type="button"
+                value="Share"
+              />
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
-  <div
-    className="buttonWithPanel menuButtonsProfileDownloadButton"
-  >
     <div
-      className="buttonWithPanelButtonWrapper"
-    >
-      <input
-        className="buttonWithPanelButton menuButtonsProfileDownloadButtonButton"
-        disabled={false}
-        onClick={[Function]}
-        type="button"
-        value="Save as file…"
-      />
-    </div>
-    <div
-      className="arrowPanelAnchor"
+      className="buttonWithPanel menuButtonsProfileDownloadButton"
     >
       <div
-        className="arrowPanel hasTitle menuButtonsProfileDownloadPanel"
+        className="buttonWithPanelButtonWrapper"
+      >
+        <input
+          className="buttonWithPanelButton menuButtonsProfileDownloadButtonButton"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+          value="Save as file…"
+        />
+      </div>
+      <div
+        className="arrowPanelAnchor"
       >
         <div
-          className="arrowPanelArrow"
-        />
-        <h1
-          className="arrowPanelTitle"
+          className="arrowPanel hasTitle menuButtonsProfileDownloadPanel"
         >
-          Save Profile to a Local File
-        </h1>
-        <div
-          className="arrowPanelContent"
-        >
-          <section />
+          <div
+            className="arrowPanelArrow"
+          />
+          <h1
+            className="arrowPanelTitle"
+          >
+            Save Profile to a Local File
+          </h1>
+          <div
+            className="arrowPanelContent"
+          >
+            <section />
+          </div>
         </div>
       </div>
     </div>
-  </div>
-  <a
-    className="menuButtonsLink"
-    href="/docs/"
-    target="_blank"
-    title="Open the documentation in a new window"
-  >
-    Docs…
-  </a>
-</div>
+    <a
+      className="menuButtonsLink"
+      href="/docs/"
+      target="_blank"
+      title="Open the documentation in a new window"
+    >
+      Docs…
+    </a>
+  </div>,
+]
 `;


### PR DESCRIPTION
This has been bugging me since I typically work with the DevTools docked to the right. This changes the top bar so that it shrinks for BOTH the range selections, and for the meta info. The menu buttons on the right remain as a fixed size. In addition, for really small windows, this stops everything from overflowing.

We don't have specific tests for this behavior, as it's CSS, so some manual testing would be appreciated.

> Before
> <img width="431" alt="image" src="https://user-images.githubusercontent.com/1588648/49753859-37f7da80-fc7a-11e8-9b16-5235cfd87ea8.png">

> After
> <img width="434" alt="image" src="https://user-images.githubusercontent.com/1588648/49753875-40501580-fc7a-11e8-9ccb-c1bcee9adf57.png">

--

> Before
> <img width="787" alt="image" src="https://user-images.githubusercontent.com/1588648/49753886-4ba34100-fc7a-11e8-8955-710ea819c9c7.png">

> After
> <img width="786" alt="image" src="https://user-images.githubusercontent.com/1588648/49753904-55c53f80-fc7a-11e8-9d48-fcaf8348416e.png">
