### PR TITLE
 Change the style of defining reducers, and use the Reducer type everywhere

### DIFF
--- a/src/reducers/README.md
+++ b/src/reducers/README.md
@@ -2,10 +2,27 @@
 
 This directory contains all of the [reducers](http://redux.js.org/docs/basics/Reducers.html) that are used to store state within this app. Reducers all accept some part of the store's state, and an action that is passed through a switch. This action is [Flow](https://flow.org/) typed as a [union](https://flow.org/en/docs/types/unions/) of all action objects, but [Flow](https://flow.org/) can understand the switch statements and will correctly infer which action is being used inside of the reducers. State is assumed to be immutable so that strict equality checks can tell when new bits of state are different.
 
-# Selectors
+## How to write a reducer
+
+```js
+const isThisTrueOrFalse: Reducer<boolean> = (state = false, action) => {
+  switch (action.type) {
+    case 'CHANGE_TO_TRUE':
+      return true;
+    case 'CHANGE_TO_FALSE':
+      return false;
+    default:
+      return state;
+  }
+};
+```
+
+This simplistic reducer shows how to write a reducer for this project. Use a function that is typed as the [`Reducer<State>`](../types/state.js) type. The generic type takes a single type parameter, the type definition for the state. This type then enforces that the function being set follows that type signature, so no types are needed on the arguments or return type. The `action` argument is correctly typed to be the `Action` type, and the `state` and `return` value should be correctly set to the `State` value.
+
+## Selectors
 
 See [`src/selectors`](../selectors)) for how this state is accessed.
 
-# Flow typing
+## Flow typing
 
 The state is fully [Flow](https://flow.org/) typed and the definitions live in the [`src/types/state.js`](../types/state.js) file.

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -7,7 +7,6 @@ import { combineReducers } from 'redux';
 import { tabSlugs } from '../app-logic/tabs-handling';
 
 import type { TabSlug } from '../app-logic/tabs-handling';
-import type { Action } from '../types/store';
 import type {
   AppState,
   AppViewState,
@@ -15,10 +14,10 @@ import type {
   Reducer,
 } from '../types/state';
 
-function view(
-  state: AppViewState = { phase: 'INITIALIZING' },
-  action: Action
-): AppViewState {
+const view: Reducer<AppViewState> = (
+  state = { phase: 'INITIALIZING' },
+  action
+) => {
   if (state.phase === 'DATA_LOADED') {
     // Let's not come back at another phase if we're already displaying a profile
     return state;
@@ -45,18 +44,18 @@ function view(
     default:
       return state;
   }
-}
+};
 
-function isUrlSetupDone(state: boolean = false, action: Action) {
+const isUrlSetupDone: Reducer<boolean> = (state = false, action) => {
   switch (action.type) {
     case 'URL_SETUP_DONE':
       return true;
     default:
       return state;
   }
-}
+};
 
-function hasZoomedViaMousewheel(state: boolean = false, action: Action) {
+const hasZoomedViaMousewheel: Reducer<boolean> = (state = false, action) => {
   switch (action.type) {
     case 'HAS_ZOOMED_VIA_MOUSEWHEEL': {
       return true;
@@ -64,17 +63,18 @@ function hasZoomedViaMousewheel(state: boolean = false, action: Action) {
     default:
       return state;
   }
+};
+
+function _getNoSidebarsOpen() {
+  const state = {};
+  tabSlugs.forEach(tabSlug => (state[tabSlug] = false));
+  return state;
 }
 
-function isSidebarOpenPerPanel(
-  state: IsSidebarOpenPerPanelState,
-  action: Action
-): IsSidebarOpenPerPanelState {
-  if (state === undefined) {
-    state = {};
-    tabSlugs.forEach(tabSlug => (state[tabSlug] = false));
-  }
-
+const isSidebarOpenPerPanel: Reducer<IsSidebarOpenPerPanelState> = (
+  state = _getNoSidebarsOpen(),
+  action
+) => {
   switch (action.type) {
     case 'CHANGE_SIDEBAR_OPEN_STATE': {
       const { tab, isOpen } = action;
@@ -89,7 +89,7 @@ function isSidebarOpenPerPanel(
     default:
       return state;
   }
-}
+};
 
 /**
  * The panels that make up the timeline, details view, and sidebar can all change
@@ -99,7 +99,7 @@ function isSidebarOpenPerPanel(
  * any of the panels. This provides a mechanism for subscribing components to
  * deterministically update their sizing correctly.
  */
-function panelLayoutGeneration(state: number = 0, action: Action): number {
+const panelLayoutGeneration: Reducer<number> = (state = 0, action) => {
   switch (action.type) {
     case 'INCREMENT_PANEL_LAYOUT_GENERATION':
     // Sidebar: (fallthrough)
@@ -119,7 +119,7 @@ function panelLayoutGeneration(state: number = 0, action: Action): number {
     default:
       return state;
   }
-}
+};
 
 /**
  * Clicking on tracks can switch between different tabs. This piece of state holds
@@ -128,10 +128,10 @@ function panelLayoutGeneration(state: number = 0, action: Action): number {
  * panel, then clicks on a thread or process track. With this state we can smoothly
  * transition them back to the panel they were using.
  */
-function lastVisibleThreadTabSlug(
-  state: TabSlug = 'calltree',
-  action: Action
-): TabSlug {
+const lastVisibleThreadTabSlug: Reducer<TabSlug> = (
+  state = 'calltree',
+  action
+) => {
   switch (action.type) {
     case 'SELECT_TRACK':
     case 'CHANGE_SELECTED_TAB':
@@ -142,7 +142,7 @@ function lastVisibleThreadTabSlug(
     default:
       return state;
   }
-}
+};
 
 const appStateReducer: Reducer<AppState> = combineReducers({
   view,

--- a/src/reducers/icons.js
+++ b/src/reducers/icons.js
@@ -3,10 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import type { Action } from '../types/actions';
 import type { Reducer } from '../types/state';
 
-function favicons(state: Set<string> = new Set(), action: Action) {
+const favicons: Reducer<Set<string>> = (state = new Set(), action) => {
   switch (action.type) {
     case 'ICON_HAS_LOADED':
       return new Set([...state, action.icon]);
@@ -14,7 +13,6 @@ function favicons(state: Set<string> = new Set(), action: Action) {
     default:
       return state;
   }
-}
+};
 
-const iconsStateReducer: Reducer<Set<string>> = favicons;
-export default iconsStateReducer;
+export default favicons;

--- a/src/reducers/profile-view.js
+++ b/src/reducers/profile-view.js
@@ -16,7 +16,6 @@ import type { Profile, Pid } from '../types/profile';
 import type { LocalTrack, GlobalTrack } from '../types/profile-derived';
 import type { StartEndRange } from '../types/units';
 import type {
-  Action,
   PreviewSelection,
   RequestedLib,
   TrackReference,
@@ -29,7 +28,7 @@ import type {
   ThreadViewOptions,
 } from '../types/state';
 
-function profile(state: Profile | null = null, action: Action): Profile | null {
+const profile: Reducer<Profile | null> = (state = null, action) => {
   switch (action.type) {
     case 'VIEW_PROFILE':
       return action.profile;
@@ -63,42 +62,42 @@ function profile(state: Profile | null = null, action: Action): Profile | null {
     default:
       return state;
   }
-}
+};
 
 /**
  * This information is stored, rather than derived via selectors, since the coalesced
  * function update would force it to be recomputed on every symbolication update
  * pass. It is valid for the lifetime of the profile.
  */
-function globalTracks(state: GlobalTrack[] = [], action: Action) {
+const globalTracks: Reducer<GlobalTrack[]> = (state = [], action) => {
   switch (action.type) {
     case 'VIEW_PROFILE':
       return action.globalTracks;
     default:
       return state;
   }
-}
+};
 
 /**
  * This can be derived like the globalTracks information, but is stored in the state
  * for the same reason.
  */
-function localTracksByPid(
-  state: Map<Pid, LocalTrack[]> = new Map(),
-  action: Action
-) {
+const localTracksByPid: Reducer<Map<Pid, LocalTrack[]>> = (
+  state = new Map(),
+  action
+) => {
   switch (action.type) {
     case 'VIEW_PROFILE':
       return action.localTracksByPid;
     default:
       return state;
   }
-}
+};
 
-function symbolicationStatus(
-  state: SymbolicationStatus = 'DONE',
-  action: Action
-) {
+const symbolicationStatus: Reducer<SymbolicationStatus> = (
+  state = 'DONE',
+  action
+) => {
   switch (action.type) {
     case 'START_SYMBOLICATING':
       return 'SYMBOLICATING';
@@ -107,12 +106,12 @@ function symbolicationStatus(
     default:
       return state;
   }
-}
+};
 
-function viewOptionsPerThread(
-  state: ThreadViewOptions[] = [],
-  action: Action
-): ThreadViewOptions[] {
+const viewOptionsPerThread: Reducer<ThreadViewOptions[]> = (
+  state = [],
+  action
+) => {
   switch (action.type) {
     case 'VIEW_PROFILE':
       return action.profile.threads.map(() => ({
@@ -346,9 +345,12 @@ function viewOptionsPerThread(
     default:
       return state;
   }
-}
+};
 
-function waitingForLibs(state: Set<RequestedLib> = new Set(), action: Action) {
+const waitingForLibs: Reducer<Set<RequestedLib>> = (
+  state = new Set(),
+  action
+) => {
   switch (action.type) {
     case 'REQUESTING_SYMBOL_TABLE': {
       const newState = new Set(state);
@@ -363,13 +365,12 @@ function waitingForLibs(state: Set<RequestedLib> = new Set(), action: Action) {
     default:
       return state;
   }
-}
+};
 
-function previewSelection(
-  state: PreviewSelection = { hasSelection: false, isModifying: false },
-  action: Action
-): PreviewSelection {
-  // TODO: Rename to timeRangeSelection
+const previewSelection: Reducer<PreviewSelection> = (
+  state = { hasSelection: false, isModifying: false },
+  action
+) => {
   switch (action.type) {
     case 'UPDATE_PREVIEW_SELECTION':
       return action.previewSelection;
@@ -379,9 +380,9 @@ function previewSelection(
     default:
       return state;
   }
-}
+};
 
-function scrollToSelectionGeneration(state: number = 0, action: Action) {
+const scrollToSelectionGeneration: Reducer<number> = (state = 0, action) => {
   switch (action.type) {
     case 'CHANGE_INVERT_CALLSTACK':
     case 'CHANGE_SELECTED_CALL_NODE':
@@ -394,60 +395,63 @@ function scrollToSelectionGeneration(state: number = 0, action: Action) {
     default:
       return state;
   }
-}
+};
 
-function focusCallTreeGeneration(state: number = 0, action: Action) {
+const focusCallTreeGeneration: Reducer<number> = (state = 0, action) => {
   switch (action.type) {
     case 'FOCUS_CALL_TREE':
       return state + 1;
     default:
       return state;
   }
-}
+};
 
-function rootRange(
-  state: StartEndRange = { start: 0, end: 1 },
-  action: Action
-) {
+const rootRange: Reducer<StartEndRange> = (
+  state = { start: 0, end: 1 },
+  action
+) => {
   switch (action.type) {
     case 'VIEW_PROFILE':
       return ProfileData.getTimeRangeIncludingAllThreads(action.profile);
     default:
       return state;
   }
-}
+};
 
-function rightClickedTrack(
+const rightClickedTrack: Reducer<TrackReference> = (
   // Make the initial value the first global track, which is assumed to exists.
   // This makes the track reference always exist, which in turn makes it so that
   // we do not have to check for a null TrackReference.
-  state: TrackReference = { type: 'global', trackIndex: 0 },
-  action: Action
-) {
+  state = { type: 'global', trackIndex: 0 },
+  action
+) => {
   switch (action.type) {
     case 'CHANGE_RIGHT_CLICKED_TRACK':
       return action.trackReference;
     default:
       return state;
   }
-}
+};
 
-function isCallNodeContextMenuVisible(state: boolean = false, action: Action) {
+const isCallNodeContextMenuVisible: Reducer<boolean> = (
+  state = false,
+  action
+) => {
   switch (action.type) {
     case 'SET_CALL_NODE_CONTEXT_MENU_VISIBILITY':
       return action.isVisible;
     default:
       return state;
   }
-}
+};
 
-function profileSharingStatus(
-  state: ProfileSharingStatus = {
+const profileSharingStatus: Reducer<ProfileSharingStatus> = (
+  state = {
     sharedWithUrls: false,
     sharedWithoutUrls: false,
   },
-  action: Action
-): ProfileSharingStatus {
+  action
+) => {
   switch (action.type) {
     case 'SET_PROFILE_SHARING_STATUS':
       return action.profileSharingStatus;
@@ -466,7 +470,7 @@ function profileSharingStatus(
     default:
       return state;
   }
-}
+};
 
 /**
  * Provide a mechanism to wrap the reducer in a special function that can reset
@@ -489,7 +493,7 @@ const wrapReducerInResetter = (
   };
 };
 
-export default wrapReducerInResetter(
+const profileViewReducer: Reducer<ProfileViewState> = wrapReducerInResetter(
   combineReducers({
     viewOptions: combineReducers({
       perThread: viewOptionsPerThread,
@@ -508,3 +512,5 @@ export default wrapReducerInResetter(
     profile,
   })
 );
+
+export default profileViewReducer;

--- a/src/reducers/stack-chart.js
+++ b/src/reducers/stack-chart.js
@@ -8,27 +8,35 @@ import { getCategoryByImplementation } from '../profile-logic/color-categories';
 import { getFunctionName } from '../profile-logic/labeling-strategies';
 import type { GetLabel } from '../profile-logic/labeling-strategies';
 import type { GetCategory } from '../profile-logic/color-categories';
-import type { Action } from '../types/actions';
+import type { StackChartState, Reducer } from '../types/state';
 
-function categoryColorStrategy(
-  state: GetCategory = getCategoryByImplementation,
-  action: Action
-) {
+const categoryColorStrategy: Reducer<GetCategory> = (
+  state = getCategoryByImplementation,
+  action
+) => {
   switch (action.type) {
     case 'CHANGE_STACK_CHART_COLOR_STRATEGY':
       return action.getCategory;
     default:
       return state;
   }
-}
+};
 
-function labelingStrategy(state: GetLabel = getFunctionName, action: Action) {
+const labelingStrategy: Reducer<GetLabel> = (
+  state = getFunctionName,
+  action
+) => {
   switch (action.type) {
     case 'CHANGE_STACK_CHART_LABELING_STRATEGY':
       return action.getLabel;
     default:
       return state;
   }
-}
+};
 
-export default combineReducers({ categoryColorStrategy, labelingStrategy });
+const stackChartReducer: Reducer<StackChartState> = combineReducers({
+  categoryColorStrategy,
+  labelingStrategy,
+});
+
+export default stackChartReducer;

--- a/src/reducers/url-state.js
+++ b/src/reducers/url-state.js
@@ -10,7 +10,6 @@ import type { TrackIndex } from '../types/profile-derived';
 import type { StartEndRange } from '../types/units';
 import type { TransformStacksPerThread } from '../types/transforms';
 import type {
-  Action,
   DataSource,
   ImplementationFilter,
   TimelineType,
@@ -18,7 +17,7 @@ import type {
 import type { UrlState, Reducer } from '../types/state';
 import type { TabSlug } from '../app-logic/tabs-handling';
 
-function dataSource(state: DataSource = 'none', action: Action) {
+const dataSource: Reducer<DataSource> = (state = 'none', action) => {
   switch (action.type) {
     case 'WAITING_FOR_PROFILE_FROM_FILE':
       return 'from-file';
@@ -27,25 +26,25 @@ function dataSource(state: DataSource = 'none', action: Action) {
     default:
       return state;
   }
-}
+};
 
-function hash(state: string = '', action: Action) {
+const hash: Reducer<string> = (state = '', action) => {
   switch (action.type) {
     case 'PROFILE_PUBLISHED':
       return action.hash;
     default:
       return state;
   }
-}
+};
 
-function profileUrl(state: string = '', action: Action) {
+const profileUrl: Reducer<string> = (state = '', action) => {
   switch (action.type) {
     default:
       return state;
   }
-}
+};
 
-function selectedTab(state: TabSlug = 'calltree', action: Action): TabSlug {
+const selectedTab: Reducer<TabSlug> = (state = 'calltree', action) => {
   switch (action.type) {
     case 'CHANGE_SELECTED_TAB':
     case 'SELECT_TRACK':
@@ -53,9 +52,9 @@ function selectedTab(state: TabSlug = 'calltree', action: Action): TabSlug {
     default:
       return state;
   }
-}
+};
 
-function committedRanges(state: StartEndRange[] = [], action: Action) {
+const committedRanges: Reducer<StartEndRange[]> = (state = [], action) => {
   switch (action.type) {
     case 'COMMIT_RANGE': {
       const { start, end } = action;
@@ -66,12 +65,9 @@ function committedRanges(state: StartEndRange[] = [], action: Action) {
     default:
       return state;
   }
-}
+};
 
-function selectedThread(
-  state: ThreadIndex | null = null,
-  action: Action
-): ThreadIndex | null {
+const selectedThread: Reducer<ThreadIndex | null> = (state = null, action) => {
   switch (action.type) {
     case 'CHANGE_SELECTED_THREAD':
     case 'SELECT_TRACK':
@@ -86,27 +82,27 @@ function selectedThread(
     default:
       return state;
   }
-}
+};
 
-function callTreeSearchString(state: string = '', action: Action) {
+const callTreeSearchString: Reducer<string> = (state = '', action) => {
   switch (action.type) {
     case 'CHANGE_CALL_TREE_SEARCH_STRING':
       return action.searchString;
     default:
       return state;
   }
-}
+};
 
-function markersSearchString(state: string = '', action: Action) {
+const markersSearchString: Reducer<string> = (state = '', action) => {
   switch (action.type) {
     case 'CHANGE_MARKER_SEARCH_STRING':
       return action.searchString;
     default:
       return state;
   }
-}
+};
 
-function transforms(state: TransformStacksPerThread = {}, action: Action) {
+const transforms: Reducer<TransformStacksPerThread> = (state = {}, action) => {
   switch (action.type) {
     case 'ADD_TRANSFORM_TO_STACK': {
       const { threadIndex, transform } = action;
@@ -125,59 +121,56 @@ function transforms(state: TransformStacksPerThread = {}, action: Action) {
     default:
       return state;
   }
-}
+};
 
-function timelineType(
-  state: TimelineType = 'category',
-  action: Action
-): TimelineType {
+const timelineType: Reducer<TimelineType> = (state = 'category', action) => {
   switch (action.type) {
     case 'CHANGE_TIMELINE_TYPE':
       return action.timelineType;
     default:
       return state;
   }
-}
+};
 
 /**
  * Represents the current filter applied to the stack frames, where it will show
  * frames only by implementation.
  */
-function implementation(
-  state: ImplementationFilter = 'combined',
-  action: Action
-) {
+const implementation: Reducer<ImplementationFilter> = (
+  state = 'combined',
+  action
+) => {
   switch (action.type) {
     case 'CHANGE_IMPLEMENTATION_FILTER':
       return action.implementation;
     default:
       return state;
   }
-}
+};
 
-function invertCallstack(state: boolean = false, action: Action) {
+const invertCallstack: Reducer<boolean> = (state = false, action) => {
   switch (action.type) {
     case 'CHANGE_INVERT_CALLSTACK':
       return action.invertCallstack;
     default:
       return state;
   }
-}
+};
 
 /**
  * This state controls whether or not to show a summary view of self time, or the full
  * stack-based view of the JS tracer data.
  */
-function showJsTracerSummary(state: boolean = false, action: Action) {
+const showJsTracerSummary: Reducer<boolean> = (state = false, action) => {
   switch (action.type) {
     case 'CHANGE_SHOW_JS_TRACER_SUMMARY':
       return action.showSummary;
     default:
       return state;
   }
-}
+};
 
-function globalTrackOrder(state: TrackIndex[] = [], action: Action) {
+const globalTrackOrder: Reducer<TrackIndex[]> = (state = [], action) => {
   switch (action.type) {
     case 'VIEW_PROFILE':
     case 'CHANGE_GLOBAL_TRACK_ORDER':
@@ -185,12 +178,12 @@ function globalTrackOrder(state: TrackIndex[] = [], action: Action) {
     default:
       return state;
   }
-}
+};
 
-function hiddenGlobalTracks(
-  state: Set<TrackIndex> = new Set(),
-  action: Action
-) {
+const hiddenGlobalTracks: Reducer<Set<TrackIndex>> = (
+  state = new Set(),
+  action
+) => {
   switch (action.type) {
     case 'VIEW_PROFILE':
     case 'ISOLATE_LOCAL_TRACK':
@@ -210,12 +203,12 @@ function hiddenGlobalTracks(
     default:
       return state;
   }
-}
+};
 
-function hiddenLocalTracksByPid(
-  state: Map<Pid, Set<TrackIndex>> = new Map(),
-  action: Action
-) {
+const hiddenLocalTracksByPid: Reducer<Map<Pid, Set<TrackIndex>>> = (
+  state = new Map(),
+  action
+) => {
   switch (action.type) {
     case 'VIEW_PROFILE':
       return action.hiddenLocalTracksByPid;
@@ -242,12 +235,12 @@ function hiddenLocalTracksByPid(
     default:
       return state;
   }
-}
+};
 
-function localTrackOrderByPid(
-  state: Map<Pid, TrackIndex[]> = new Map(),
-  action: Action
-) {
+const localTrackOrderByPid: Reducer<Map<Pid, TrackIndex[]>> = (
+  state = new Map(),
+  action
+) => {
   switch (action.type) {
     case 'VIEW_PROFILE':
       return action.localTrackOrderByPid;
@@ -259,12 +252,9 @@ function localTrackOrderByPid(
     default:
       return state;
   }
-}
+};
 
-function pathInZipFile(
-  state: string | null = null,
-  action: Action
-): string | null {
+const pathInZipFile: Reducer<string | null> = (state = null, action) => {
   switch (action.type) {
     // Update the URL the moment the zip file is starting to be
     // processed, not when it is viewed. The processing is async.
@@ -275,7 +265,7 @@ function pathInZipFile(
     default:
       return state;
   }
-}
+};
 
 /**
  * These values are specific to an individual profile.
@@ -331,7 +321,7 @@ const wrapReducerInResetter = (
   };
 };
 
-const urlStateReducer = wrapReducerInResetter(
+const urlStateReducer: Reducer<UrlState> = wrapReducerInResetter(
   combineReducers({
     dataSource,
     hash,

--- a/src/reducers/zipped-profiles.js
+++ b/src/reducers/zipped-profiles.js
@@ -8,7 +8,6 @@ import { oneLine } from 'common-tags';
 import { ensureExists } from '../utils/flow';
 import * as ZipFiles from '../profile-logic/zip-files';
 
-import type { Action } from '../types/store';
 import type {
   ZipFileState,
   Reducer,
@@ -19,14 +18,14 @@ import type {
  * This reducer contains all of the state that deals with loading in profiles from
  * zip files.
  */
-function zipFile(
-  state: ZipFileState = {
+const zipFile: Reducer<ZipFileState> = (
+  state = {
     phase: 'NO_ZIP_FILE',
     zip: null,
     pathInZipFile: null,
   },
-  action: Action
-): ZipFileState {
+  action
+) => {
   switch (action.type) {
     case 'UPDATE_URL_STATE': {
       if (
@@ -99,9 +98,9 @@ function zipFile(
     default:
       return state;
   }
-}
+};
 
-function error(state: null | Error = null, action: Action): null | Error {
+const error: Reducer<null | Error> = (state = null, action) => {
   switch (action.type) {
     case 'FAILED_TO_PROCESS_PROFILE_FROM_ZIP_FILE':
     case 'FATAL_ERROR':
@@ -109,7 +108,7 @@ function error(state: null | Error = null, action: Action): null | Error {
     default:
       return state;
   }
-}
+};
 
 /**
  * This function ensures that the state transitions are logical and make sense. The
@@ -173,10 +172,10 @@ function _validateStateTransition(
   return next;
 }
 
-function selectedZipFileIndex(
-  state: null | ZipFiles.IndexIntoZipFileTable = null,
-  action: Action
-) {
+const selectedZipFileIndex: Reducer<null | ZipFiles.IndexIntoZipFileTable> = (
+  state = null,
+  action
+) => {
   switch (action.type) {
     case 'CHANGE_SELECTED_ZIP_FILE': {
       return action.selectedZipFileIndex;
@@ -184,14 +183,16 @@ function selectedZipFileIndex(
     default:
       return state;
   }
-}
+};
 
-function expandedZipFileIndexes(
+const expandedZipFileIndexes: Reducer<
+  Array<ZipFiles.IndexIntoZipFileTable | null>
+> = (
   // In practice this should never contain null, but needs to support the
   // TreeView interface.
-  state: Array<ZipFiles.IndexIntoZipFileTable | null> = [],
-  action: Action
-) {
+  state = [],
+  action
+) => {
   switch (action.type) {
     case 'CHANGE_EXPANDED_ZIP_FILES': {
       return action.expandedZipFileIndexes;
@@ -199,7 +200,7 @@ function expandedZipFileIndexes(
     default:
       return state;
   }
-}
+};
 
 const zipFileReducer: Reducer<ZippedProfilesState> = combineReducers({
   zipFile,


### PR DESCRIPTION
Please only review the last commit, this is built off of #1559.

This PR changes the style to:

```js
const isThisTrueOrFalse: Reducer<boolean> = (state = false, action) => {
  switch (action.type) {
    case 'CHANGE_TO_TRUE':
      return true;
    case 'CHANGE_TO_FALSE':
      return false;
    default:
      return state;
  }
};
```

Please note that I removed all redundant type signatures from the arrow functions, as those are being enforced by the `: Reducer<State>` type.