### PR TITLE
Enforce new Selector<T> type and consistent spacing for selectors

### DIFF
--- a/src/actions/profile-view.js
+++ b/src/actions/profile-view.js
@@ -669,7 +669,8 @@ export function hideLocalTrack(
 
       if (
         nextSelectedThreadIndex === null &&
-        globalTrack.mainThreadIndex !== null
+        globalTrack.mainThreadIndex !== null &&
+        globalTrack.mainThreadIndex !== undefined
       ) {
         // Case 2a: Use the current process's main thread.
         nextSelectedThreadIndex = globalTrack.mainThreadIndex;

--- a/src/components/timeline/GlobalTrack.js
+++ b/src/components/timeline/GlobalTrack.js
@@ -31,7 +31,7 @@ import TimelineTrackScreenshots from './TrackScreenshots';
 import TimelineLocalTrack from './LocalTrack';
 import Reorderable from '../shared/Reorderable';
 import type { TabSlug } from '../../app-logic/tabs-handling';
-import type { TrackReference } from '../../types/actions';
+import type { GlobalTrackReference } from '../../types/actions';
 import type { Pid } from '../../types/profile';
 import type {
   TrackIndex,
@@ -44,7 +44,7 @@ import type {
 } from '../../utils/connect';
 
 type OwnProps = {|
-  +trackReference: TrackReference,
+  +trackReference: GlobalTrackReference,
   +trackIndex: TrackIndex,
   +style?: Object /* This is used by Reorderable */,
 |};

--- a/src/components/timeline/index.js
+++ b/src/components/timeline/index.js
@@ -35,7 +35,7 @@ import {
 } from '../../actions/profile-view';
 
 import type { TrackIndex, GlobalTrack } from '../../types/profile-derived';
-import type { TrackReference, TimelineType } from '../../types/actions';
+import type { GlobalTrackReference, TimelineType } from '../../types/actions';
 import type { Milliseconds, StartEndRange } from '../../types/units';
 import type {
   ExplicitConnectOptions,
@@ -48,7 +48,7 @@ type StateProps = {|
   +committedRange: StartEndRange,
   +globalTracks: GlobalTrack[],
   +globalTrackOrder: TrackIndex[],
-  +globalTrackReferences: TrackReference[],
+  +globalTrackReferences: GlobalTrackReference[],
   +panelLayoutGeneration: number,
   +zeroAt: Milliseconds,
   +timelineType: TimelineType,

--- a/src/selectors/app.js
+++ b/src/selectors/app.js
@@ -10,26 +10,34 @@ import { tabSlugs } from '../app-logic/tabs-handling';
 import { selectedThreadSelectors } from './profile-view';
 
 import type { TabSlug } from '../app-logic/tabs-handling';
-import type { State, AppState, AppViewState } from '../types/state';
+import type { AppState, AppViewState } from '../types/state';
+import type { Selector } from '../types/store';
 
-export const getApp = (state: State): AppState => state.app;
-export const getView = (state: State): AppViewState => getApp(state).view;
-export const getIsUrlSetupDone = (state: State): boolean =>
+/**
+ * Simple selectors into the app state.
+ */
+export const getApp: Selector<AppState> = state => state.app;
+export const getView: Selector<AppViewState> = state => getApp(state).view;
+export const getIsUrlSetupDone: Selector<boolean> = state =>
   getApp(state).isUrlSetupDone;
-export const getHasZoomedViaMousewheel = (state: State): boolean => {
+export const getHasZoomedViaMousewheel: Selector<boolean> = state => {
   return getApp(state).hasZoomedViaMousewheel;
 };
-export const getIsSidebarOpen = (state: State): boolean =>
+export const getIsSidebarOpen: Selector<boolean> = state =>
   getApp(state).isSidebarOpenPerPanel[getSelectedTab(state)];
-export const getPanelLayoutGeneration = (state: State) =>
+export const getPanelLayoutGeneration: Selector<number> = state =>
   getApp(state).panelLayoutGeneration;
-export const getLastVisibleThreadTabSlug = (state: State) =>
+export const getLastVisibleThreadTabSlug: Selector<TabSlug> = state =>
   getApp(state).lastVisibleThreadTabSlug;
 
-export const getVisibleTabs = createSelector(
+/**
+ * Visible tabs are computed based on the current state of the profile. Some
+ * effort is made to not show a tab when there is no data available for it.
+ */
+export const getVisibleTabs: Selector<$ReadOnlyArray<TabSlug>> = createSelector(
   selectedThreadSelectors.getIsNetworkChartEmptyInFullRange,
   selectedThreadSelectors.getJsTracerTable,
-  (isNetworkChartEmpty, jsTracerTable): $ReadOnlyArray<TabSlug> => {
+  (isNetworkChartEmpty, jsTracerTable) => {
     let visibleTabs = tabSlugs;
     if (isNetworkChartEmpty) {
       visibleTabs = visibleTabs.filter(tabSlug => tabSlug !== 'network-chart');

--- a/src/selectors/stack-chart.js
+++ b/src/selectors/stack-chart.js
@@ -3,10 +3,17 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
-import type { State } from '../types/state';
+import type { StackChartState } from '../types/state';
+import type { Selector } from '../types/store';
+import type { GetCategory } from '../profile-logic/color-categories';
+import type { GetLabel } from '../profile-logic/labeling-strategies';
 
-export const getStackChart = (state: State) => state.stackChart;
-export const getCategoryColorStrategy = (state: State) =>
+/**
+ * Simple selectors in the StackChartState.
+ */
+export const getStackChart: Selector<StackChartState> = state =>
+  state.stackChart;
+export const getCategoryColorStrategy: Selector<GetCategory> = state =>
   getStackChart(state).categoryColorStrategy;
-export const getLabelingStrategy = (state: State) =>
+export const getLabelingStrategy: Selector<GetLabel> = state =>
   getStackChart(state).labelingStrategy;

--- a/src/test/store/icons.test.js
+++ b/src/test/store/icons.test.js
@@ -59,14 +59,6 @@ describe('actions/icons', function() {
       expect(initialState.size).toEqual(0);
     });
 
-    it('getIconForCallNode returns null for any icon', function() {
-      const subject = iconsAccessors.getIconForCallNode(
-        getInitialState(),
-        _createCallNodeWithIcon(validIcons[0])
-      );
-      expect(subject).toBeNull();
-    });
-
     it('getIconClassNameForCallNode returns an empty string for any icon', function() {
       const subject = iconsAccessors.getIconClassNameForCallNode(
         getInitialState(),
@@ -111,12 +103,6 @@ describe('actions/icons', function() {
       );
 
       validIcons.forEach((icon, i) => {
-        subject = iconsAccessors.getIconForCallNode(
-          state,
-          _createCallNodeWithIcon(icon)
-        );
-        expect(subject).toEqual(icon);
-
         subject = iconsAccessors.getIconClassNameForCallNode(
           state,
           _createCallNodeWithIcon(icon)
@@ -140,12 +126,6 @@ describe('actions/icons', function() {
       const state = getState();
       let subject = iconsAccessors.getIcons(state);
       expect([...subject]).toEqual([]);
-
-      subject = iconsAccessors.getIconForCallNode(
-        state,
-        _createCallNodeWithIcon(invalidIcon)
-      );
-      expect(subject).toBeNull();
 
       subject = iconsAccessors.getIconClassNameForCallNode(
         state,

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -58,9 +58,17 @@ export type FunctionsUpdatePerThread = {
  * Note that TrackIndexes aren't globally unique: they're unique among global
  * tracks, and they're unique among local tracks for a specific Pid.
  */
-export type TrackReference =
-  | {| +type: 'global', +trackIndex: TrackIndex |}
-  | {| +type: 'local', +trackIndex: TrackIndex, +pid: Pid |};
+export type GlobalTrackReference = {|
+  +type: 'global',
+  +trackIndex: TrackIndex,
+|};
+export type LocalTrackReference = {|
+  +type: 'local',
+  +trackIndex: TrackIndex,
+  +pid: Pid,
+|};
+export type TrackReference = GlobalTrackReference | LocalTrackReference;
+
 export type RequestedLib = {|
   +debugName: string,
   +breakpadId: string,

--- a/src/types/store.js
+++ b/src/types/store.js
@@ -18,6 +18,48 @@ import type { State as StateRef } from './state';
 export type Action = ActionsRef;
 export type State = StateRef;
 
+/**
+ * The selector type enforces the selector pattern, and should be used when
+ * defining selectors. These selectors can be simple functions, or created using
+ * the reselect library. This type enforces the common pattern of a pure function that
+ * only accesses the state, and selects, or derives something from it.
+ *
+ * See the type below for additional considerations.
+ */
+export type Selector<T> = State => T;
+
+/**
+ * Selectors generally come in two different varieties: selectors that trivially access
+ * a value, and selectors that do some kind of complex or expensive computation.
+ *
+ * Simple selectors are used to build up a language of functions for looking up values
+ * in the state. For instance a selector named `getMyProperty` could trivially
+ * access that from the state `state => state.myProperty`. This function can then be
+ * used in other selectors to de-couple the access of some state, from where the state
+ * is actually stored. These are really cheap to run.
+ *
+ * Selectors using the "reselect" library can memoize complicated or expensive
+ * derived state. These selectors often combine multiple pieces of state and then
+ * run some kind of function to derive the desired information. This way when any of
+ * the pieces of dependent state used for the calculation change, then the entire
+ * function is invalidated and runs again.
+ *
+ * A "dangerous" problem arises if this memoized function takes an argument that does
+ * not come directly from the state. The additional argument can break the typical
+ * memoization pattern, and could be used incorrectly to re-compute something expensive.
+ * Care should be taken that a value isn't needlessly recomputed. The following type is
+ * used as a hint that something a bit different is going on with the selector, and
+ * memoization might not be happening in the same way.
+ *
+ * See: https://github.com/reduxjs/reselect/blob/master/README.md#q-how-do-i-create-a-selector-that-takes-an-argument
+ */
+export type DangerousSelectorWithArguments<T, A1, A2 = void, A3 = void> = (
+  State,
+  A1,
+  A2,
+  A3
+) => T;
+
 type ThunkDispatch = <Returns>(action: ThunkAction<Returns>) => Returns;
 type PlainDispatch = (action: Action) => Action;
 export type GetState = () => State;


### PR DESCRIPTION
* Create a `Selector<T>` type.
* Create a `NonMemoizedSelector1<T, Arg>` type, for selectors that take multiple arguments. I also created the `NonMemoizedSelector2` which is unused, but there for future readers/authors to understand the intent of the function.
* Enforce consistent spacing.
* Write docs for all selectors except the profile view selectors.
* Refine the TrackReference  type to use GlobalTrackReference and LocalTrackReference.
* Removed unused `getIconForCallNode` selector.

This PR grew a bit in the writing, let me know if you want me to back out some of the changes and split up the PRs smaller. All the changes felt related to tightening up the types, spacing, and comments around selectors, but it is a bigger changeset because of it.