### PR TITLE
Make computeCallTreeCountsAndTimings a selector

### DIFF
--- a/src/profile-logic/call-tree.js
+++ b/src/profile-logic/call-tree.js
@@ -33,7 +33,7 @@ type CallNodeTimes = {
   selfTime: Float32Array,
   totalTime: Float32Array,
 };
-type CallTreeCountsAndTimings = {
+export type CallTreeCountsAndTimings = {
   callNodeChildCount: Uint32Array,
   callNodeTimes: CallNodeTimes,
   rootCount: number,
@@ -408,7 +408,7 @@ export function getCallTree(
   callNodeInfo: CallNodeInfo,
   categories: CategoryList,
   implementationFilter: string,
-  invertCallstack: boolean
+  callTreeCountsAndTimings: CallTreeCountsAndTimings
 ): CallTree {
   return timeCode('getCallTree', () => {
     const {
@@ -416,12 +416,7 @@ export function getCallTree(
       callNodeChildCount,
       rootTotalTime,
       rootCount,
-    } = computeCallTreeCountsAndTimings(
-      thread,
-      callNodeInfo,
-      interval,
-      invertCallstack
-    );
+    } = callTreeCountsAndTimings;
 
     const jsOnly = implementationFilter === 'js';
     const isIntegerInterval = Math.floor(interval) === interval;

--- a/src/profile-logic/flame-graph.js
+++ b/src/profile-logic/flame-graph.js
@@ -3,15 +3,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import type { UnitIntervalOfProfileRange, Milliseconds } from '../types/units';
+import type { UnitIntervalOfProfileRange } from '../types/units';
 import type { Thread } from '../types/profile';
 import type {
   CallNodeInfo,
   CallNodeTable,
   IndexIntoCallNodeTable,
 } from '../types/profile-derived';
-
-import { computeCallTreeCountsAndTimings } from './call-tree';
+import type { CallTreeCountsAndTimings } from './call-tree';
 
 export type FlameGraphDepth = number;
 export type IndexIntoFlameGraphTiming = number;
@@ -171,20 +170,15 @@ export function getRootsAndChildren(
  */
 export function getFlameGraphTiming(
   thread: Thread,
-  interval: Milliseconds,
   callNodeInfo: CallNodeInfo,
-  invertCallstack: boolean
+  callTreeCountsAndTimings: CallTreeCountsAndTimings
 ): FlameGraphTiming {
   const {
     callNodeChildCount,
     callNodeTimes,
     rootTotalTime,
-  } = computeCallTreeCountsAndTimings(
-    thread,
-    callNodeInfo,
-    interval,
-    invertCallstack
-  );
+  } = callTreeCountsAndTimings;
+
   const { roots, children } = getRootsAndChildren(
     thread,
     callNodeInfo.callNodeTable,

--- a/src/selectors/profile-view.js
+++ b/src/selectors/profile-view.js
@@ -707,13 +707,23 @@ export const selectorsForThread = (
       }
     );
 
+    const getCallTreeCountsAndTimings: Selector<
+      CallTree.CallTreeCountsAndTimings
+    > = createSelector(
+      getPreviewFilteredThread,
+      getCallNodeInfo,
+      getProfileInterval,
+      UrlState.getInvertCallstack,
+      CallTree.computeCallTreeCountsAndTimings
+    );
+
     const getCallTree: Selector<CallTree.CallTree> = createSelector(
       getPreviewFilteredThread,
       getProfileInterval,
       getCallNodeInfo,
       getCategories,
       UrlState.getImplementationFilter,
-      UrlState.getInvertCallstack,
+      getCallTreeCountsAndTimings,
       CallTree.getCallTree
     );
 
@@ -737,9 +747,8 @@ export const selectorsForThread = (
       FlameGraph.FlameGraphTiming
     > = createSelector(
       getPreviewFilteredThread,
-      getProfileInterval,
       getCallNodeInfo,
-      UrlState.getInvertCallstack,
+      getCallTreeCountsAndTimings,
       FlameGraph.getFlameGraphTiming
     );
 

--- a/src/test/unit/profile-tree.test.js
+++ b/src/test/unit/profile-tree.test.js
@@ -54,13 +54,19 @@ describe('unfiltered call tree', function() {
       thread.funcTable,
       defaultCategory
     );
+    const callTreeCountsAndTimings = computeCallTreeCountsAndTimings(
+      thread,
+      callNodeInfo,
+      interval,
+      false
+    );
     return getCallTree(
       thread,
       interval,
       callNodeInfo,
       categories,
       'combined',
-      false
+      callTreeCountsAndTimings
     );
   }
 
@@ -412,13 +418,19 @@ describe('inverted call tree', function() {
       thread.funcTable,
       defaultCategory
     );
+    const callTreeCountsAndTimings = computeCallTreeCountsAndTimings(
+      thread,
+      callNodeInfo,
+      interval,
+      true
+    );
     const callTree = getCallTree(
       thread,
       interval,
       callNodeInfo,
       categories,
       'combined',
-      true
+      callTreeCountsAndTimings
     );
     it('computes an non-inverted call tree', function() {
       expect(formatTreeIncludeCategories(callTree)).toEqual([
@@ -444,13 +456,19 @@ describe('inverted call tree', function() {
       invertedThread.funcTable,
       defaultCategory
     );
+    const invertedCallTreeCountsAndTimings = computeCallTreeCountsAndTimings(
+      invertedThread,
+      invertedCallNodeInfo,
+      interval,
+      true
+    );
     const invertedCallTree = getCallTree(
       invertedThread,
       interval,
       invertedCallNodeInfo,
       categories,
       'combined',
-      true
+      invertedCallTreeCountsAndTimings
     );
 
     /**


### PR DESCRIPTION
The flame graph currently invokes computeCallTreeCountsAndTimings
twice, once for the actual flame graph timing structure and once for
the tooltips. By making computeCallTreeCountsAndTimings a selector, it
can be memoized and we'll not waste CPU time on computing the same
thing twice.

This speeds up the flame graph a bit (#844).