### PR TITLE
Flow tests for react-redux, and proper dispatch-wrapped action creators

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,7 @@ jobs:
       - run: yarn license-check
       - run: yarn lint
       - run: yarn flow --quiet
-      - run: yarn flow stop # stop flow to recover some memory
+      - run: yarn flow-stop # stop flow to recover some memory
       - run: yarn test --coverage --runInBand
       - run: yarn build-prod:quiet
       - run: bash <(curl -s https://codecov.io/bash)
-

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,3 +1,8 @@
+[options]
+suppress_comment=\\(.\\|\n\\)*\\$ExpectError
+suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe
+include_warnings=true
+
 [ignore]
 .*node_modules/.*
 res/analytics.js

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,5 @@
 [options]
-suppress_comment=\\(.\\|\n\\)*\\$ExpectError
+suppress_comment=\\(.\\|\n\\)*\\$FlowExpectError
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe
 include_warnings=true
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ test_script:
   - yarn lint
   - yarn flow --quiet
   # stop flow to recover some memory
-  - yarn flow stop
+  - yarn flow-stop
   - yarn test
   - yarn build-prod:quiet
 
@@ -29,4 +29,3 @@ cache:
 
 # Don't actually build.
 build: off
-

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint *.js bin src",
     "lint-fix": "yarn lint --fix",
     "prettier-json": "prettier --write src/**/*.json",
-    "flow": "flow",
+    "flow": "flow --max-warnings 0",
     "flow-coverage": "flow-coverage-report -i 'src/**/*.js' -t html -t text",
     "flow-generate-libdefs": "flow-typed install --libdefDir src/types/libdef",
     "init-docs": "gitbook install ./docs-user",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint-fix": "yarn lint --fix",
     "prettier-json": "prettier --write src/**/*.json",
     "flow": "flow --max-warnings 0",
+    "flow-stop": "flow stop",
     "flow-coverage": "flow-coverage-report -i 'src/**/*.js' -t html -t text",
     "flow-generate-libdefs": "flow-typed install --libdefDir src/types/libdef",
     "init-docs": "gitbook install ./docs-user",

--- a/src/components/app/Home.js
+++ b/src/components/app/Home.js
@@ -17,6 +17,7 @@ import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import type {
   ExplicitConnectOptions,
   ConnectedProps,
+  WrapFunctionInDispatch,
 } from '../../utils/connect';
 
 require('./Home.css');
@@ -53,7 +54,9 @@ class InstallButton extends React.PureComponent<InstallButtonProps> {
 }
 
 type ActionButtonsProps = {
-  retrieveProfileFromFile: typeof retrieveProfileFromFile,
+  retrieveProfileFromFile: WrapFunctionInDispatch<
+    typeof retrieveProfileFromFile
+  >,
   triggerLoadingFromUrl: typeof triggerLoadingFromUrl,
 };
 

--- a/src/components/app/Home.js
+++ b/src/components/app/Home.js
@@ -53,12 +53,12 @@ class InstallButton extends React.PureComponent<InstallButtonProps> {
   }
 }
 
-type ActionButtonsProps = {
-  retrieveProfileFromFile: WrapFunctionInDispatch<
+type ActionButtonsProps = {|
+  +retrieveProfileFromFile: WrapFunctionInDispatch<
     typeof retrieveProfileFromFile
   >,
-  triggerLoadingFromUrl: typeof triggerLoadingFromUrl,
-};
+  +triggerLoadingFromUrl: typeof triggerLoadingFromUrl,
+|};
 
 type ActionButtonsState = {
   isLoadFromUrlPressed: boolean,
@@ -315,7 +315,10 @@ class Home extends React.PureComponent<HomeProps, HomeState> {
               Install the Gecko Profiler Add-on to start recording a performance
               profile in Firefox, then analyze it and share it with perf.html.
             </p>
-            <ActionButtons {...this.props} />
+            <ActionButtons
+              retrieveProfileFromFile={this.props.retrieveProfileFromFile}
+              triggerLoadingFromUrl={this.props.triggerLoadingFromUrl}
+            />
           </div>
         </div>
       </InstructionTransition>
@@ -344,7 +347,10 @@ class Home extends React.PureComponent<HomeProps, HomeState> {
               <kbd>Capture Profile</kbd> to load the data into perf.html.
             </p>
             {this._renderShortcuts()}
-            <ActionButtons {...this.props} />
+            <ActionButtons
+              retrieveProfileFromFile={this.props.retrieveProfileFromFile}
+              triggerLoadingFromUrl={this.props.triggerLoadingFromUrl}
+            />
           </div>
         </div>
       </InstructionTransition>
@@ -377,7 +383,10 @@ class Home extends React.PureComponent<HomeProps, HomeState> {
               to load the data into perf.html.
             </p>
             {this._renderShortcuts()}
-            <ActionButtons {...this.props} />
+            <ActionButtons
+              retrieveProfileFromFile={this.props.retrieveProfileFromFile}
+              triggerLoadingFromUrl={this.props.triggerLoadingFromUrl}
+            />
           </div>
         </div>
       </InstructionTransition>
@@ -405,7 +414,10 @@ class Home extends React.PureComponent<HomeProps, HomeState> {
               <a href="https://www.mozilla.org/en-US/firefox/new/">Firefox</a>.
               However, existing profiles can be viewed in any modern browser.
             </p>
-            <ActionButtons {...this.props} />
+            <ActionButtons
+              retrieveProfileFromFile={this.props.retrieveProfileFromFile}
+              triggerLoadingFromUrl={this.props.triggerLoadingFromUrl}
+            />
           </div>
         </div>
       </InstructionTransition>

--- a/src/components/js-tracer/Canvas.js
+++ b/src/components/js-tracer/Canvas.js
@@ -33,6 +33,7 @@ import type {
 } from '../../types/profile';
 import type { JsTracerTiming } from '../../types/profile-derived';
 import type { Viewport } from '../shared/chart/Viewport';
+import type { WrapFunctionInDispatch } from '../../utils/connect';
 
 type OwnProps = {|
   +rangeStart: Milliseconds,
@@ -42,7 +43,9 @@ type OwnProps = {|
   +rowHeight: CssPixels,
   +threadIndex: ThreadIndex,
   +doFadeIn: boolean,
-  +updatePreviewSelection: typeof updatePreviewSelection,
+  +updatePreviewSelection: WrapFunctionInDispatch<
+    typeof updatePreviewSelection
+  >,
 |};
 
 type Props = {|

--- a/src/components/marker-chart/Canvas.js
+++ b/src/components/marker-chart/Canvas.js
@@ -27,6 +27,7 @@ import type {
   IndexIntoMarkerTiming,
 } from '../../types/profile-derived';
 import type { Viewport } from '../shared/chart/Viewport';
+import type { WrapFunctionInDispatch } from '../../utils/connect';
 
 type MarkerDrawingInformation = {
   x: CssPixels,
@@ -44,7 +45,9 @@ type OwnProps = {|
   +rowHeight: CssPixels,
   +markers: TracingMarker[],
   +threadIndex: ThreadIndex,
-  +updatePreviewSelection: typeof updatePreviewSelection,
+  +updatePreviewSelection: WrapFunctionInDispatch<
+    typeof updatePreviewSelection
+  >,
   +marginLeft: CssPixels,
   +marginRight: CssPixels,
 |};

--- a/src/components/shared/FilterNavigatorBar.js
+++ b/src/components/shared/FilterNavigatorBar.js
@@ -12,7 +12,7 @@ import './FilterNavigatorBar.css';
 type Props = {|
   +className: string,
   +items: string[],
-  +onPop: number => mixed,
+  +onPop: number => *,
   +selectedItem: number,
   +uncommittedItem?: string,
 |};

--- a/src/components/shared/thread/SelectedActivityGraph.js
+++ b/src/components/shared/thread/SelectedActivityGraph.js
@@ -28,7 +28,6 @@ import type {
   CategoryList,
   IndexIntoSamplesTable,
 } from '../../../types/profile';
-import type { ConnectedThunk } from '../../../types/store';
 import type { Milliseconds } from '../../../types/units';
 import type {
   CallNodeInfo,
@@ -66,9 +65,7 @@ type StateProps = {|
 |};
 
 type DispatchProps = {|
-  +selectBestAncestorCallNodeAndExpandCallTree: ConnectedThunk<
-    typeof selectBestAncestorCallNodeAndExpandCallTree
-  >,
+  +selectBestAncestorCallNodeAndExpandCallTree: typeof selectBestAncestorCallNodeAndExpandCallTree,
   +selectLeafCallNode: typeof selectLeafCallNode,
   +focusCallTree: typeof focusCallTree,
 |};

--- a/src/components/stack-chart/Canvas.js
+++ b/src/components/stack-chart/Canvas.js
@@ -38,6 +38,7 @@ import type {
 import type { GetCategory } from '../../profile-logic/color-categories';
 import type { GetLabel } from '../../profile-logic/labeling-strategies';
 import type { Viewport } from '../shared/chart/Viewport';
+import type { WrapFunctionInDispatch } from '../../utils/connect';
 
 type OwnProps = {|
   +thread: Thread,
@@ -48,7 +49,9 @@ type OwnProps = {|
   +stackFrameHeight: CssPixels,
   +getCategory: GetCategory,
   +getLabel: GetLabel,
-  +updatePreviewSelection: typeof updatePreviewSelection,
+  +updatePreviewSelection: WrapFunctionInDispatch<
+    typeof updatePreviewSelection
+  >,
   +callNodeInfo: CallNodeInfo,
   +selectedCallNodeIndex: IndexIntoCallNodeTable | null,
   +onSelectionChange: (IndexIntoCallNodeTable | null) => void,

--- a/src/components/timeline/TracingMarkers.js
+++ b/src/components/timeline/TracingMarkers.js
@@ -71,7 +71,10 @@ export type StateProps = {|
   +isModifyingSelection: boolean,
 |};
 
-type Props = ConnectedProps<SizeProps, OwnProps, StateProps>;
+type Props = {|
+  ...ConnectedProps<OwnProps, StateProps, {||}>,
+  ...SizeProps,
+|};
 
 type State = {
   hoveredItem: TracingMarker | null,

--- a/src/test/README.md
+++ b/src/test/README.md
@@ -22,7 +22,7 @@ The aim of all new code is to have good test coverage. A handy way to do this is
 
 ## Flow type tests
 
-Flow type tests are a little different, because they do not use Jest. Instead, types are created that should pass the type system. In addition, the special comment `// $ExpectError` can be used for when errors are expected to be generated. If the types do not generate an error, then Flow will emit a warning (not an error) that something is wrong.
+Flow type tests are a little different, because they do not use Jest. Instead, types are created that should pass the type system. In addition, the special comment `// $FlowExpectError` can be used for when errors are expected to be generated. If the types do not generate an error, then Flow will emit a warning (not an error) that something is wrong.
 
 ## The tests
 

--- a/src/test/README.md
+++ b/src/test/README.md
@@ -20,10 +20,15 @@ when Jest's mocking capabilities are falling short. This should be used as a las
 
 The aim of all new code is to have good test coverage. A handy way to do this is to run a code coverage report. This can be done by running `yarn test-coverage`. This will build the coverage report, and serve it locally. All new code can be manually scanned to see where there is no coverage. Alternately [codecov.io](https://codecov.io/gh/devtools-html/perf.html) provides a full coverage report for each PR, and the master branch.
 
+## Flow type tests
+
+Flow type tests are a little different, because they do not use Jest. Instead, types are created that should pass the type system. In addition, the special comment `// $ExpectError` can be used for when errors are expected to be generated. If the types do not generate an error, then Flow will emit a warning (not an error) that something is wrong.
+
 ## The tests
 
 | Test type                  | Description |
 | -------------------------- | ----------- |
 | [components](./components) | Tests for React components, utilizing Enzyme for full behavioral testing, and snapshot tests to ensure that components output correct markup. |
 | [store](./store)           | Testing the [Redux](http://redux.js.org/) store using actions and selectors. |
+| [types](./types)           | Flow type tests. |
 | [unit](./unit)             | Unit testing |

--- a/src/test/types/react-redux.js
+++ b/src/test/types/react-redux.js
@@ -1,0 +1,162 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+// @flow
+
+import * as React from 'react';
+import explicitConnect from '../../utils/connect';
+
+import type {
+  ExplicitConnectOptions,
+  ConnectedProps,
+} from '../../utils/connect';
+import type { State, Action, ThunkAction } from '../../types/store';
+/* eslint-disable no-unused-vars, react/prefer-stateless-function, flowtype/no-unused-expressions */
+
+// Use this any value to create fake variables.
+const ANY_VALUE = (0: any);
+
+/**
+ * These type tests create various values that should all type check correctly to show
+ * that the react-redux system is working correctly.
+ */
+
+type OwnProps = {|
+  +ownPropString: string,
+  +ownPropNumber: number,
+|};
+
+type StateProps = {|
+  +statePropString: string,
+  +statePropNumber: number,
+|};
+
+type ExampleActionCreator = string => Action;
+type ExampleThunkActionCreator = string => ThunkAction<number>;
+
+type DispatchProps = {|
+  +dispatchString: ExampleActionCreator,
+  +dispatchThunk: ExampleThunkActionCreator,
+|};
+
+type Props = ConnectedProps<OwnProps, StateProps, DispatchProps>;
+
+class ExampleComponent extends React.PureComponent<Props> {
+  render() {
+    const {
+      ownPropString,
+      ownPropNumber,
+      statePropString,
+      statePropNumber,
+      dispatchString,
+      dispatchThunk,
+    } = this.props;
+
+    // Ensure that the React component has the correct types inside of it.
+    (ownPropString: string);
+    (ownPropNumber: number);
+    (statePropString: string);
+    (statePropNumber: number);
+    (dispatchString: ExampleActionCreator);
+    (dispatchThunk: ExampleThunkActionCreator);
+
+    return null;
+  }
+}
+
+const validMapStateToProps = (state, ownProps) => {
+  // Coerce the inferred types, to ensure that we are doing the right thing.
+  (state: State);
+  (ownProps: OwnProps);
+  return {
+    statePropString: 'string',
+    statePropNumber: 0,
+  };
+};
+
+const validDispatchToProps = (ANY_VALUE: {|
+  +dispatchString: string => Action,
+  +dispatchThunk: string => ThunkAction<number>,
+|});
+
+// Test the common case of create a component with valid values.
+const ConnectedExampleComponent = explicitConnect(
+  ({
+    mapStateToProps: validMapStateToProps,
+    mapDispatchToProps: validDispatchToProps,
+    component: ExampleComponent,
+  }: ExplicitConnectOptions<OwnProps, StateProps, DispatchProps>)
+);
+
+{
+  // Test that mapStateToProps will error out if provided an extra value.
+  const options: ExplicitConnectOptions<OwnProps, StateProps, DispatchProps> = {
+    // $ExpectError
+    mapStateToProps: state => ({
+      statePropString: 'string',
+      statePropNumber: 0,
+      extraValue: null,
+    }),
+    mapDispatchToProps: validDispatchToProps,
+    component: ExampleComponent,
+  };
+  explicitConnect(options);
+}
+
+{
+  // Test that mapStateToProps will error if provided an extra value.
+  const options: ExplicitConnectOptions<OwnProps, StateProps, DispatchProps> = {
+    mapStateToProps: state => ({
+      statePropString: 'string',
+      // $ExpectError
+      statePropNumber: 'not a number',
+    }),
+    mapDispatchToProps: validDispatchToProps,
+    component: ExampleComponent,
+  };
+  explicitConnect(options);
+}
+
+{
+  // Test that mapDispatchToProps will error if a value is omitted.
+  const options: ExplicitConnectOptions<OwnProps, StateProps, DispatchProps> = {
+    mapStateToProps: validMapStateToProps,
+    // $ExpectError
+    mapDispatchToProps: (ANY_VALUE: {|
+      +dispatchThunk: string => ThunkAction<number>,
+    |}),
+    component: ExampleComponent,
+  };
+  explicitConnect(options);
+}
+
+{
+  // Test that mapDispatchToProps will error if a variable type definition is wrong.
+  const options: ExplicitConnectOptions<OwnProps, StateProps, DispatchProps> = {
+    mapStateToProps: validMapStateToProps,
+    mapDispatchToProps: (ANY_VALUE: {|
+      // $ExpectError
+      +dispatchString: string => string,
+      +dispatchThunk: string => ThunkAction<number>,
+    |}),
+    component: ExampleComponent,
+  };
+  explicitConnect(options);
+}
+
+{
+  // The connected component correctly takes OwnProps.
+  <ConnectedExampleComponent ownPropString="string" ownPropNumber={0} />;
+}
+
+{
+  // It throws an error when an OwnProps is incorrect.
+  // $ExpectError
+  <ConnectedExampleComponent ownPropString={0} ownPropNumber={0} />;
+}
+
+{
+  // It throws an error if no OwnProps are provided.
+  // $ExpectError
+  <ConnectedExampleComponent />;
+}

--- a/src/types/store.js
+++ b/src/types/store.js
@@ -81,24 +81,3 @@ export type Dispatch = PlainDispatch & ThunkDispatch;
  * of all Actions, as well as specific Dispatch behavior.
  */
 export type Store = ReduxStore<State, Action, Dispatch>;
-
-/**
- * This type definition takes a ThunkAction, and strips out the function
- * that accepts the (Dispatch, GetState). This is effectively what wrapping
- * the action in the connect function does.
- *
- * For instance:
- *   (...Args) => (Dispatch, GetState) => Returns
- *
- * Gets transformed into:
- *   (...Args) => Returns
- */
-export type ConnectedThunk<Fn> = $Call<
-  <Args, Returns>(
-    // Take as input a ThunkAction.
-    (...Args) => (Dispatch, GetState) => Returns
-    // Return the wrapped action.
-  ) => (...Args) => Returns,
-  // Apply this to the function:
-  Fn
->;

--- a/src/utils/connect.js
+++ b/src/utils/connect.js
@@ -40,12 +40,6 @@ type ConnectOptions = {
 /**
  * This function type describes the operation of taking a simple action creator, and
  * just returning it.
- *
- * For instance:
- *   (...Args) => Action
- *
- * Gets transformed into:
- *   (...Args) => void
  */
 type WrapActionCreator<Args> = (
   // Take as input an action creator.
@@ -71,7 +65,8 @@ type WrapThunkActionCreator<Args, Returns> = (
 /**
  * This type takes a Props object and wraps each function in Redux's connect function.
  * It is primarily exported for testing as explicitConnect should do this for us
- * automatically.
+ * automatically. It leaves normal action creators alone, but with ThunkActions it
+ * removes the (Dispatch, GetState) part of a ThunkAction.
  */
 export type WrapDispatchProps<DispatchProps: Object> = $ObjMap<
   DispatchProps,

--- a/src/utils/connect.js
+++ b/src/utils/connect.js
@@ -5,7 +5,7 @@
 
 import * as React from 'react';
 import { connect } from 'react-redux';
-import type { Dispatch, State } from '../types/store';
+import type { Dispatch, State, ThunkAction, Action } from '../types/store';
 
 type MapStateToProps<OwnProps: Object, StateProps: Object> = (
   state: State,
@@ -37,6 +37,57 @@ type ConnectOptions = {
   withRef?: boolean,
 };
 
+/**
+ * This function type describes the operation of taking a simple action creator, and
+ * just returning it.
+ *
+ * For instance:
+ *   (...Args) => Action
+ *
+ * Gets transformed into:
+ *   (...Args) => void
+ */
+type WrapActionCreator<Args> = (
+  // Take as input an action creator.
+  (...Args) => Action
+  // If this function matches the above signature, do not modify it.
+) => (...Args) => Action;
+
+/**
+ * This function type describes the operation of removing the (Dispatch, GetState) from
+ * a thunk action creator.
+ * For instance:
+ *   (...Args) => (Dispatch, GetState) => Returns
+ *
+ * Gets transformed into:
+ *   (...Args) => Returns
+ */
+type WrapThunkActionCreator<Args, Returns> = (
+  // Take as input a ThunkAction.
+  (...Args) => ThunkAction<Returns>
+  // Return the wrapped action.
+) => (...Args) => Returns;
+
+/**
+ * This type takes a Props object and wraps each function in Redux's connect function.
+ * It is primarily exported for testing as explicitConnect should do this for us
+ * automatically.
+ */
+export type WrapDispatchProps<DispatchProps: Object> = $ObjMap<
+  DispatchProps,
+  WrapActionCreator<*> & WrapThunkActionCreator<*, *>
+>;
+
+/**
+ * This type takes a single action creator, and returns the type as if the dispatch
+ * function was wrapped around it. It leaves normal action creators alone, but with
+ * ThunkActions it removes the (Dispatch, GetState) part of a ThunkAction.
+ */
+export type WrapFunctionInDispatch<Fn: Function> = $Call<
+  WrapActionCreator<*> & WrapThunkActionCreator<*, *>,
+  Fn
+>;
+
 export type ExplicitConnectOptions<
   OwnProps: Object,
   StateProps: Object,
@@ -63,7 +114,7 @@ export type ConnectedProps<
 > = $ReadOnly<{|
   ...OwnProps,
   ...StateProps,
-  ...DispatchProps,
+  ...WrapDispatchProps<DispatchProps>,
 |}>;
 
 export type ConnectedComponent<


### PR DESCRIPTION
There are 2 commits here, the first was to add tests for our existing `react-redux` situation with `explicitConnect`. The second was to create types that could properly modify the DispatchProps.

Julien, I am flagging you for review, but feel free to ignore this until after break.