### PR TITLE
Fix an off by one error in the thread activity graph clicking

### DIFF
--- a/src/components/shared/thread/ActivityGraphFills.js
+++ b/src/components/shared/thread/ActivityGraphFills.js
@@ -543,7 +543,7 @@ export class ActivityFillGraphQuerier {
     const sampleTimeRangeStart =
       sample > 0 ? (samples.time[sample - 1] + sampleTime) / 2 : -Infinity;
     const sampleTimeRangeEnd =
-      sample < samples.length
+      sample + 1 < samples.length
         ? (samples.time[sample + 1] + sampleTime) / 2
         : Infinity;
 


### PR DESCRIPTION
Resolves #1596 

This is the fix for the error you found in #1557, which was an already existing error.