### PR TITLE
Make the background of the symbolication overlay not transparent

### DIFF
--- a/res/css/style.css
+++ b/res/css/style.css
@@ -424,7 +424,7 @@ body,
   padding-top: 8px;
   left: 30%;
   right: 30%;
-  background: rgba(0, 0, 0, 0.07);
+  background: var(--grey-20);
   text-align: center;
   padding-left: 10px;
   padding-right: 10px;


### PR DESCRIPTION
Resolves #1578.

> <img width="671" alt="image" src="https://user-images.githubusercontent.com/1588648/50792795-d2ecd000-128b-11e9-9717-babf686097d2.png">


@edieblu have you done a review on the profiler yet? Let me know on Slack if you want to walk through the process.