### PR TITLE
Fix a label to make it more accurate

### DIFF
--- a/src/components/shared/MarkerTooltipContents.js
+++ b/src/components/shared/MarkerTooltipContents.js
@@ -580,7 +580,7 @@ function getMarkerDetails(
                 )}
                 {_markerDetail(
                   'gcusage',
-                  'Heap usage',
+                  'Heap size',
                   timings.allocated_bytes,
                   formatBytes
                 )}

--- a/src/test/components/__snapshots__/MarkerTooltipContents.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerTooltipContents.test.js.snap
@@ -497,7 +497,7 @@ Array [
       <div
         className="tooltipLabel"
       >
-        Heap usage
+        Heap size
         :
       </div>
       46.1MB


### PR DESCRIPTION
The allocated_bytes field represents the heap capacity before the GC
begins.