### PR TITLE
Refactor the empty profile creation data structures

### DIFF
--- a/src/profile-logic/call-tree.js
+++ b/src/profile-logic/call-tree.js
@@ -4,11 +4,8 @@
 
 // @flow
 import { timeCode } from '../utils/time-code';
-import {
-  getSampleCallNodes,
-  resourceTypes,
-  getOriginAnnotationForFunc,
-} from './profile-data';
+import { getSampleCallNodes, getOriginAnnotationForFunc } from './profile-data';
+import { resourceTypes } from './data-structures';
 import { UniqueStringArray } from '../utils/unique-string-array';
 import type {
   CategoryList,

--- a/src/profile-logic/data-structures.js
+++ b/src/profile-logic/data-structures.js
@@ -1,0 +1,264 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+import { UniqueStringArray } from '../utils/unique-string-array';
+import { CURRENT_VERSION as GECKO_PROFILE_VERSION } from './gecko-profile-versioning';
+import { CURRENT_VERSION as PROCESSED_PROFILE_VERSION } from './processed-profile-versioning';
+
+import type {
+  Thread,
+  SamplesTable,
+  FrameTable,
+  StackTable,
+  FuncTable,
+  RawMarkerTable,
+  ResourceTable,
+  Profile,
+  ExtensionTable,
+  CategoryList,
+  JsTracerTable,
+} from '../types/profile';
+
+/**
+ * This module collects all of the creation of new empty profile data structures.
+ */
+
+export function getEmptyStackTable(): StackTable {
+  return {
+    // Important!
+    // If modifying this structure, please update all callers of this function to ensure
+    // that they are pushing on correctly to the data structure. These pushes may not
+    // be caught by the type system.
+    frame: [],
+    prefix: [],
+    category: [],
+    length: 0,
+  };
+}
+
+export function getEmptySamplesTable(): SamplesTable {
+  return {
+    // Important!
+    // If modifying this structure, please update all callers of this function to ensure
+    // that they are pushing on correctly to the data structure. These pushes may not
+    // be caught by the type system.
+    responsiveness: [],
+    stack: [],
+    time: [],
+    rss: [],
+    uss: [],
+    length: 0,
+  };
+}
+
+export function getEmptyFrameTable(): FrameTable {
+  return {
+    // Important!
+    // If modifying this structure, please update all callers of this function to ensure
+    // that they are pushing on correctly to the data structure. These pushes may not
+    // be caught by the type system.
+    address: [],
+    category: [],
+    func: [],
+    implementation: [],
+    line: [],
+    column: [],
+    optimizations: [],
+    length: 0,
+  };
+}
+
+export function cloneFrameTable(frameTable: FrameTable): FrameTable {
+  return {
+    // Important!
+    // If modifying this structure, please update all callers of this function to ensure
+    // that they are pushing on correctly to the data structure. These pushes may not
+    // be caught by the type system.
+    address: frameTable.address.slice(),
+    category: frameTable.category.slice(),
+    func: frameTable.func.slice(),
+    implementation: frameTable.implementation.slice(),
+    line: frameTable.line.slice(),
+    column: frameTable.column.slice(),
+    optimizations: frameTable.optimizations.slice(),
+    length: frameTable.length,
+  };
+}
+
+export function getEmptyFuncTable(): FuncTable {
+  return {
+    // Important!
+    // If modifying this structure, please update all callers of this function to ensure
+    // that they are pushing on correctly to the data structure. These pushes may not
+    // be caught by the type system.
+    address: [],
+    isJS: [],
+    relevantForJS: [],
+    name: [],
+    resource: [],
+    fileName: [],
+    lineNumber: [],
+    columnNumber: [],
+    length: 0,
+  };
+}
+
+export function cloneFuncTable(funcTable: FuncTable): FuncTable {
+  return {
+    // Important!
+    // If modifying this structure, please update all callers of this function to ensure
+    // that they are pushing on correctly to the data structure. These pushes may not
+    // be caught by the type system.
+    address: funcTable.address.slice(),
+    isJS: funcTable.isJS.slice(),
+    relevantForJS: funcTable.relevantForJS.slice(),
+    name: funcTable.name.slice(),
+    resource: funcTable.resource.slice(),
+    fileName: funcTable.fileName.slice(),
+    lineNumber: funcTable.lineNumber.slice(),
+    columnNumber: funcTable.columnNumber.slice(),
+    length: funcTable.length,
+  };
+}
+
+export function getEmptyResourceTable(): ResourceTable {
+  return {
+    // Important!
+    // If modifying this structure, please update all callers of this function to ensure
+    // that they are pushing on correctly to the data structure. These pushes may not
+    // be caught by the type system.
+    lib: [],
+    name: [],
+    host: [],
+    type: [],
+    length: 0,
+  };
+}
+
+export function getEmptyRawMarkerTable(): RawMarkerTable {
+  // Important!
+  // If modifying this structure, please update all callers of this function to ensure
+  // that they are pushing on correctly to the data structure. These pushes may not
+  // be caught by the type system.
+  return {
+    data: [],
+    name: [],
+    time: [],
+    length: 0,
+  };
+}
+
+export function getResourceTypes(): * {
+  return {
+    unknown: 0,
+    library: 1,
+    addon: 2,
+    webhost: 3,
+    otherhost: 4,
+    url: 5,
+  };
+}
+
+/**
+ * Export a read-only copy of the resource types.
+ */
+export const resourceTypes = (getResourceTypes(): $Exact<
+  $ReadOnly<$Call<typeof getResourceTypes>>
+>);
+
+export function getEmptyExtensions(): ExtensionTable {
+  return {
+    // Important!
+    // If modifying this structure, please update all callers of this function to ensure
+    // that they are pushing on correctly to the data structure. These pushes may not
+    // be caught by the type system.
+    id: [],
+    name: [],
+    baseURL: [],
+    length: 0,
+  };
+}
+
+export function getDefaultCategories(): CategoryList {
+  return [
+    { name: 'Idle', color: 'transparent' },
+    { name: 'Other', color: 'grey' },
+    { name: 'Layout', color: 'purple' },
+    { name: 'JavaScript', color: 'yellow' },
+    { name: 'GC / CC', color: 'orange' },
+    { name: 'Network', color: 'lightblue' },
+    { name: 'Graphics', color: 'green' },
+    { name: 'DOM', color: 'blue' },
+  ];
+}
+
+export function getEmptyJsTracerTable(): JsTracerTable {
+  return {
+    // Important!
+    // If modifying this structure, please update all callers of this function to ensure
+    // that they are pushing on correctly to the data structure. These pushes may not
+    // be caught by the type system.
+    events: [],
+    timestamps: [],
+    durations: [],
+    lines: [],
+    columns: [],
+    length: 0,
+  };
+}
+
+export function getEmptyThread(overrides?: $Shape<Thread>): Thread {
+  const defaultThread: Thread = {
+    processType: 'default',
+    processStartupTime: 0,
+    processShutdownTime: null,
+    registerTime: 0,
+    unregisterTime: null,
+    pausedRanges: [],
+    name: 'Empty',
+    pid: 0,
+    tid: 0,
+    samples: getEmptySamplesTable(),
+    markers: getEmptyRawMarkerTable(),
+    stackTable: getEmptyStackTable(),
+    frameTable: getEmptyFrameTable(),
+    stringTable: new UniqueStringArray(),
+    libs: [],
+    funcTable: getEmptyFuncTable(),
+    resourceTable: getEmptyResourceTable(),
+  };
+
+  return {
+    ...defaultThread,
+    ...overrides,
+  };
+}
+
+export function getEmptyProfile(): Profile {
+  return {
+    meta: {
+      interval: 1,
+      startTime: 0,
+      abi: '',
+      misc: '',
+      oscpu: '',
+      platform: '',
+      processType: 0,
+      extensions: getEmptyExtensions(),
+      categories: getDefaultCategories(),
+      product: 'Firefox',
+      stackwalk: 0,
+      toolkit: '',
+      version: GECKO_PROFILE_VERSION,
+      preprocessedProfileVersion: PROCESSED_PROFILE_VERSION,
+      appBuildID: '',
+      sourceURL: '',
+      physicalCPUs: 0,
+      logicalCPUs: 0,
+    },
+    pages: [],
+    threads: [],
+  };
+}

--- a/src/profile-logic/import/chrome.js
+++ b/src/profile-logic/import/chrome.js
@@ -10,8 +10,10 @@ import type {
   IndexIntoStackTable,
 } from '../../types/profile';
 
-import { getEmptyProfile } from '../../profile-logic/profile-data';
-import { getEmptyThread } from '../../test/fixtures/profiles/processed-profile';
+import {
+  getEmptyProfile,
+  getEmptyThread,
+} from '../../profile-logic/data-structures';
 import { ensureExists } from '../../utils/flow';
 
 // Chrome Tracing Event Spec:

--- a/src/profile-logic/old-cleopatra-profile-format.js
+++ b/src/profile-logic/old-cleopatra-profile-format.js
@@ -4,7 +4,7 @@
 
 // @flow
 import { UniqueStringArray } from '../utils/unique-string-array';
-import { resourceTypes } from './profile-data';
+import { resourceTypes } from './data-structures';
 import { CURRENT_VERSION } from './gecko-profile-versioning.js';
 
 /**

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -6,7 +6,7 @@
 import { isChromeProfile, convertChromeProfile } from './import/chrome';
 import { getContainingLibrary } from './symbolication';
 import { UniqueStringArray } from '../utils/unique-string-array';
-import { resourceTypes, emptyExtensions } from './profile-data';
+import { resourceTypes, getEmptyExtensions } from './data-structures';
 import { immutableUpdate } from '../utils/flow';
 import {
   CURRENT_VERSION,
@@ -146,7 +146,7 @@ export function extractFuncsAndResourcesFromFrameLocations(
   relevantForJSPerFrame: boolean[],
   stringTable: UniqueStringArray,
   libs: Lib[],
-  extensions: ExtensionTable = emptyExtensions
+  extensions: ExtensionTable = getEmptyExtensions()
 ): [FuncTable, ResourceTable, IndexIntoFuncTable[]] {
   // Explicitly create FuncTable. If Flow complains about this, then all of
   // the functions in this file starting with the word "extract" should be updated.
@@ -925,7 +925,7 @@ export function processProfile(
 
   const extensions: ExtensionTable = geckoProfile.meta.extensions
     ? _toStructOfArrays(geckoProfile.meta.extensions)
-    : emptyExtensions;
+    : getEmptyExtensions();
 
   for (const thread of geckoProfile.threads) {
     threads.push(_processThread(thread, geckoProfile, extensions));

--- a/src/profile-logic/process-profile.js
+++ b/src/profile-logic/process-profile.js
@@ -6,7 +6,12 @@
 import { isChromeProfile, convertChromeProfile } from './import/chrome';
 import { getContainingLibrary } from './symbolication';
 import { UniqueStringArray } from '../utils/unique-string-array';
-import { resourceTypes, getEmptyExtensions } from './data-structures';
+import {
+  resourceTypes,
+  getEmptyExtensions,
+  getEmptyFuncTable,
+  getEmptyResourceTable,
+} from './data-structures';
 import { immutableUpdate } from '../utils/flow';
 import {
   CURRENT_VERSION,
@@ -148,29 +153,13 @@ export function extractFuncsAndResourcesFromFrameLocations(
   libs: Lib[],
   extensions: ExtensionTable = getEmptyExtensions()
 ): [FuncTable, ResourceTable, IndexIntoFuncTable[]] {
-  // Explicitly create FuncTable. If Flow complains about this, then all of
-  // the functions in this file starting with the word "extract" should be updated.
-  const funcTable: FuncTable = {
-    length: 0,
-    name: [],
-    resource: [],
-    relevantForJS: [],
-    address: [],
-    isJS: [],
-    fileName: [],
-    lineNumber: [],
-    columnNumber: [],
-  };
+  // Important! If the flow type for the FuncTable was changed, update all the functions
+  // in this file that start with the word "extract".
+  const funcTable = getEmptyFuncTable();
 
-  // Explicitly create ResourceTable. If Flow complains about this, then all of
-  // the functions in this file starting with the word "extract" should be updated.
-  const resourceTable: ResourceTable = {
-    length: 0,
-    type: [],
-    name: [],
-    lib: [],
-    host: [],
-  };
+  // Important! If the flow type for the ResourceTable was changed, update all the functions
+  // in this file that start with the word "extract".
+  const resourceTable = getEmptyResourceTable();
 
   // Bundle all of the variables up into an object to pass them around to functions.
   const extractionInfo: ExtractionInfo = {

--- a/src/profile-logic/processed-profile-versioning.js
+++ b/src/profile-logic/processed-profile-versioning.js
@@ -13,7 +13,7 @@
  */
 
 import { sortDataTable } from '../utils/data-table-utils';
-import { resourceTypes } from './profile-data';
+import { resourceTypes } from './data-structures';
 import {
   upgradeGCMinorMarker,
   upgradeGCMajorMarker_Processed8to9,

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -8,8 +8,6 @@ import type {
   Thread,
   SamplesTable,
   StackTable,
-  ExtensionTable,
-  CategoryList,
   FrameTable,
   FuncTable,
   ResourceTable,
@@ -25,8 +23,6 @@ import type {
   CallNodePath,
   IndexIntoCallNodeTable,
 } from '../types/profile-derived';
-import { CURRENT_VERSION as GECKO_PROFILE_VERSION } from './gecko-profile-versioning';
-import { CURRENT_VERSION as PROCESSED_PROFILE_VERSION } from './processed-profile-versioning';
 
 import type { Milliseconds, StartEndRange } from '../types/units';
 import { timeCode } from '../utils/time-code';
@@ -39,33 +35,6 @@ import type { UniqueStringArray } from '../utils/unique-string-array';
  * Various helpers for dealing with the profile as a data structure.
  * @module profile-data
  */
-
-export const resourceTypes = {
-  unknown: 0,
-  library: 1,
-  addon: 2,
-  webhost: 3,
-  otherhost: 4,
-  url: 5,
-};
-
-export const emptyExtensions: ExtensionTable = Object.freeze({
-  id: Object.freeze([]),
-  name: Object.freeze([]),
-  baseURL: Object.freeze([]),
-  length: 0,
-});
-
-export const defaultCategories: CategoryList = Object.freeze([
-  { name: 'Idle', color: 'transparent' },
-  { name: 'Other', color: 'grey' },
-  { name: 'Layout', color: 'purple' },
-  { name: 'JavaScript', color: 'yellow' },
-  { name: 'GC / CC', color: 'orange' },
-  { name: 'Network', color: 'lightblue' },
-  { name: 'Graphics', color: 'green' },
-  { name: 'DOM', color: 'blue' },
-]);
 
 /**
  * Generate the CallNodeInfo which contains the CallNodeTable, and a map to convert
@@ -1397,33 +1366,6 @@ export function getThreadProcessDetails(thread: Thread): string {
   }
 
   return label;
-}
-
-export function getEmptyProfile(): Profile {
-  return {
-    meta: {
-      interval: 1,
-      startTime: 0,
-      abi: '',
-      misc: '',
-      oscpu: '',
-      platform: '',
-      processType: 0,
-      extensions: emptyExtensions,
-      categories: [...defaultCategories],
-      product: 'Firefox',
-      stackwalk: 0,
-      toolkit: '',
-      version: GECKO_PROFILE_VERSION,
-      preprocessedProfileVersion: PROCESSED_PROFILE_VERSION,
-      appBuildID: '',
-      sourceURL: '',
-      physicalCPUs: 0,
-      logicalCPUs: 0,
-    },
-    pages: [],
-    threads: [],
-  };
 }
 
 /**

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -23,6 +23,11 @@ import type {
   CallNodePath,
   IndexIntoCallNodeTable,
 } from '../types/profile-derived';
+import {
+  getEmptyStackTable,
+  cloneFrameTable,
+  cloneFuncTable,
+} from './data-structures';
 
 import type { Milliseconds, StartEndRange } from '../types/units';
 import { timeCode } from '../utils/time-code';
@@ -723,33 +728,9 @@ export function collapsePlatformStackFrames(thread: Thread): Thread {
     const { stackTable, funcTable, frameTable, samples, stringTable } = thread;
 
     // Create new tables for the data.
-    const newStackTable: StackTable = {
-      length: 0,
-      frame: [],
-      category: [],
-      prefix: [],
-    };
-    const newFrameTable: FrameTable = {
-      length: frameTable.length,
-      implementation: frameTable.implementation.slice(),
-      optimizations: frameTable.optimizations.slice(),
-      line: frameTable.line.slice(),
-      column: frameTable.column.slice(),
-      category: frameTable.category.slice(),
-      func: frameTable.func.slice(),
-      address: frameTable.address.slice(),
-    };
-    const newFuncTable: FuncTable = {
-      length: funcTable.length,
-      name: funcTable.name.slice(),
-      resource: funcTable.resource.slice(),
-      relevantForJS: funcTable.relevantForJS.slice(),
-      address: funcTable.address.slice(),
-      isJS: funcTable.isJS.slice(),
-      fileName: funcTable.fileName.slice(),
-      lineNumber: funcTable.lineNumber.slice(),
-      columnNumber: funcTable.columnNumber.slice(),
-    };
+    const newStackTable = getEmptyStackTable();
+    const newFrameTable = cloneFrameTable(frameTable);
+    const newFuncTable = cloneFuncTable(funcTable);
 
     // Create a Map that takes a prefix and frame as input, and maps it to the new stack
     // index. Since Maps can't be keyed off of two values, do a little math to key off

--- a/src/profile-logic/symbolication.js
+++ b/src/profile-logic/symbolication.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
-import { resourceTypes } from './profile-data';
+import { resourceTypes } from './data-structures';
 import { SymbolsNotFoundError } from './errors';
 
 import type {

--- a/src/profile-logic/transforms.js
+++ b/src/profile-logic/transforms.js
@@ -14,12 +14,15 @@ import {
 import { timeCode } from '../utils/time-code';
 import { assertExhaustiveCheck, convertToTransformType } from '../utils/flow';
 import { CallTree } from '../profile-logic/call-tree';
+import {
+  cloneFrameTable,
+  cloneFuncTable,
+  getEmptyStackTable,
+} from './data-structures';
 import { getFunctionName } from './function-info';
 
 import type {
   Thread,
-  FrameTable,
-  StackTable,
   FuncTable,
   IndexIntoCategoryList,
   IndexIntoFuncTable,
@@ -563,12 +566,7 @@ export function mergeCallNode(
     // A root stack's prefix will be null. Maintain that relationship from old to new
     // stacks by mapping from null to null.
     oldStackToNewStack.set(null, null);
-    const newStackTable = {
-      length: 0,
-      prefix: [],
-      frame: [],
-      category: [],
-    };
+    const newStackTable = getEmptyStackTable();
     // Provide two arrays to efficiently cache values for the algorithm. This probably
     // could be refactored to use only one array here.
     const stackDepths = [];
@@ -666,12 +664,7 @@ export function mergeFunction(
   // A root stack's prefix will be null. Maintain that relationship from old to new
   // stacks by mapping from null to null.
   oldStackToNewStack.set(null, null);
-  const newStackTable = {
-    length: 0,
-    prefix: [],
-    frame: [],
-    category: [],
-  };
+  const newStackTable = getEmptyStackTable();
   for (let stackIndex = 0; stackIndex < stackTable.length; stackIndex++) {
     const prefix = stackTable.prefix[stackIndex];
     const frameIndex = stackTable.frame[stackIndex];
@@ -755,33 +748,9 @@ export function collapseResource(
 ): Thread {
   const { stackTable, funcTable, frameTable, resourceTable, samples } = thread;
   const resourceNameIndex = resourceTable.name[resourceIndexToCollapse];
-  const newFrameTable: FrameTable = {
-    address: frameTable.address.slice(),
-    category: frameTable.category.slice(),
-    func: frameTable.func.slice(),
-    implementation: frameTable.implementation.slice(),
-    line: frameTable.line.slice(),
-    column: frameTable.column.slice(),
-    optimizations: frameTable.optimizations.slice(),
-    length: frameTable.length,
-  };
-  const newFuncTable: FuncTable = {
-    address: funcTable.address.slice(),
-    isJS: funcTable.isJS.slice(),
-    name: funcTable.name.slice(),
-    resource: funcTable.resource.slice(),
-    relevantForJS: funcTable.relevantForJS.slice(),
-    fileName: funcTable.fileName.slice(),
-    lineNumber: funcTable.lineNumber.slice(),
-    columnNumber: funcTable.columnNumber.slice(),
-    length: funcTable.length,
-  };
-  const newStackTable: StackTable = {
-    length: 0,
-    prefix: [],
-    frame: [],
-    category: [],
-  };
+  const newFrameTable = cloneFrameTable(frameTable);
+  const newFuncTable = cloneFuncTable(funcTable);
+  const newStackTable = getEmptyStackTable();
   const oldStackToNewStack: Map<
     IndexIntoStackTable | null,
     IndexIntoStackTable | null
@@ -935,12 +904,7 @@ export function collapseDirectRecursion(
   // stacks by mapping from null to null.
   oldStackToNewStack.set(null, null);
   const recursiveStacks = new Set();
-  const newStackTable = {
-    length: 0,
-    prefix: [],
-    frame: [],
-    category: [],
-  };
+  const newStackTable = getEmptyStackTable();
   const funcMatchesImplementation = FUNC_MATCHES[implementation];
 
   for (let stackIndex = 0; stackIndex < stackTable.length; stackIndex++) {
@@ -1040,12 +1004,7 @@ export function collapseFunctionSubtree(
   // stacks by mapping from null to null.
   oldStackToNewStack.set(null, null);
   const collapsedStacks = new Set();
-  const newStackTable = {
-    length: 0,
-    prefix: [],
-    frame: [],
-    category: [],
-  };
+  const newStackTable = getEmptyStackTable();
 
   for (let stackIndex = 0; stackIndex < stackTable.length; stackIndex++) {
     const prefix = stackTable.prefix[stackIndex];
@@ -1136,12 +1095,7 @@ export function focusSubtree(
     // A root stack's prefix will be null. Maintain that relationship from old to new
     // stacks by mapping from null to null.
     oldStackToNewStack.set(null, null);
-    const newStackTable = {
-      length: 0,
-      prefix: [],
-      frame: [],
-      category: [],
-    };
+    const newStackTable = getEmptyStackTable();
     for (let stackIndex = 0; stackIndex < stackTable.length; stackIndex++) {
       const prefix = stackTable.prefix[stackIndex];
       const prefixMatchesUpTo = prefix !== null ? stackMatches[prefix] : 0;
@@ -1255,12 +1209,7 @@ export function focusFunction(
     // A root stack's prefix will be null. Maintain that relationship from old to new
     // stacks by mapping from null to null.
     oldStackToNewStack.set(null, null);
-    const newStackTable = {
-      length: 0,
-      prefix: [],
-      frame: [],
-      category: [],
-    };
+    const newStackTable = getEmptyStackTable();
     for (let stackIndex = 0; stackIndex < stackTable.length; stackIndex++) {
       const prefix = stackTable.prefix[stackIndex];
       const frameIndex = stackTable.frame[stackIndex];

--- a/src/profile-logic/transforms.js
+++ b/src/profile-logic/transforms.js
@@ -630,7 +630,8 @@ export function mergeCallNode(
         oldStackToNewStack.set(stackIndex, newStackIndex);
       }
     }
-    const newSamples = Object.assign({}, samples, {
+    const newSamples = {
+      ...samples,
       stack: samples.stack.map(oldStack => {
         const newStack = oldStackToNewStack.get(oldStack);
         if (newStack === undefined) {
@@ -640,11 +641,13 @@ export function mergeCallNode(
         }
         return newStack;
       }),
-    });
-    return Object.assign({}, thread, {
+    };
+
+    return {
+      ...thread,
       stackTable: newStackTable,
       samples: newSamples,
-    });
+    };
   });
 }
 
@@ -687,7 +690,8 @@ export function mergeFunction(
       oldStackToNewStack.set(stackIndex, newStackIndex);
     }
   }
-  const newSamples = Object.assign({}, samples, {
+  const newSamples = {
+    ...samples,
     stack: samples.stack.map(oldStack => {
       const newStack = oldStackToNewStack.get(oldStack);
       if (newStack === undefined) {
@@ -697,11 +701,12 @@ export function mergeFunction(
       }
       return newStack;
     }),
-  });
-  return Object.assign({}, thread, {
+  };
+  return {
+    ...thread,
     stackTable: newStackTable,
     samples: newSamples,
-  });
+  };
 }
 
 /**
@@ -735,9 +740,10 @@ export function dropFunction(
   );
 
   // Return the thread with the replaced samples.
-  return Object.assign({}, thread, {
-    samples: Object.assign({}, samples, { stack }),
-  });
+  return {
+    ...thread,
+    samples: { ...samples, stack },
+  };
 }
 
 export function collapseResource(
@@ -870,7 +876,8 @@ export function collapseResource(
     }
   }
 
-  const newSamples = Object.assign({}, samples, {
+  const newSamples = {
+    ...samples,
     stack: samples.stack.map(oldStack => {
       const newStack = oldStackToNewStack.get(oldStack);
       if (newStack === undefined) {
@@ -880,14 +887,15 @@ export function collapseResource(
       }
       return newStack;
     }),
-  });
+  };
 
-  return Object.assign({}, thread, {
+  return {
+    ...thread,
     stackTable: newStackTable,
     frameTable: newFrameTable,
     funcTable: newFuncTable,
     samples: newSamples,
-  });
+  };
 }
 
 export function collapseDirectRecursion(
@@ -951,7 +959,8 @@ export function collapseDirectRecursion(
       }
     }
   }
-  const newSamples = Object.assign({}, samples, {
+  const newSamples = {
+    ...samples,
     stack: samples.stack.map(oldStack => {
       const newStack = oldStackToNewStack.get(oldStack);
       if (newStack === undefined) {
@@ -961,11 +970,12 @@ export function collapseDirectRecursion(
       }
       return newStack;
     }),
-  });
-  return Object.assign({}, thread, {
+  };
+  return {
+    ...thread,
     stackTable: newStackTable,
     samples: newSamples,
-  });
+  };
 }
 const FUNC_MATCHES = {
   combined: (_thread: Thread, _funcIndex: IndexIntoFuncTable) => true,
@@ -1056,7 +1066,8 @@ export function collapseFunctionSubtree(
       }
     }
   }
-  const newSamples = Object.assign({}, samples, {
+  const newSamples = {
+    ...samples,
     stack: samples.stack.map(oldStack => {
       const newStack = oldStackToNewStack.get(oldStack);
       if (newStack === undefined) {
@@ -1066,11 +1077,12 @@ export function collapseFunctionSubtree(
       }
       return newStack;
     }),
-  });
-  return Object.assign({}, thread, {
+  };
+  return {
+    ...thread,
     stackTable: newStackTable,
     samples: newSamples,
-  });
+  };
 }
 
 /**
@@ -1125,7 +1137,8 @@ export function focusSubtree(
       }
       stackMatches[stackIndex] = stackMatchesUpTo;
     }
-    const newSamples = Object.assign({}, samples, {
+    const newSamples = {
+      ...samples,
       stack: samples.stack.map(oldStack => {
         if (oldStack === null || stackMatches[oldStack] !== prefixDepth) {
           return null;
@@ -1138,11 +1151,12 @@ export function focusSubtree(
         }
         return newStack;
       }),
-    });
-    return Object.assign({}, thread, {
+    };
+    return {
+      ...thread,
       stackTable: newStackTable,
       samples: newSamples,
-    });
+    };
   });
 }
 
@@ -1181,7 +1195,8 @@ export function focusInvertedSubtree(
     // A root stack's prefix will be null. Maintain that relationship from old to new
     // stacks by mapping from null to null.
     oldStackToNewStack.set(null, null);
-    const newSamples = Object.assign({}, samples, {
+    const newSamples = {
+      ...samples,
       stack: samples.stack.map(stackIndex => {
         let newStackIndex = oldStackToNewStack.get(stackIndex);
         if (newStackIndex === undefined) {
@@ -1190,10 +1205,11 @@ export function focusInvertedSubtree(
         }
         return newStackIndex;
       }),
-    });
-    return Object.assign({}, thread, {
+    };
+    return {
+      ...thread,
       samples: newSamples,
-    });
+    };
   });
 }
 export function focusFunction(
@@ -1246,10 +1262,11 @@ export function focusFunction(
         return newStack;
       }),
     });
-    return Object.assign({}, thread, {
+    return {
+      ...thread,
       stackTable: newStackTable,
       samples: newSamples,
-    });
+    };
   });
 }
 

--- a/src/test/components/ProfileCallTreeView.test.js
+++ b/src/test/components/ProfileCallTreeView.test.js
@@ -11,11 +11,11 @@ import { Provider } from 'react-redux';
 import mockCanvasContext from '../fixtures/mocks/canvas-context';
 import { storeWithProfile } from '../fixtures/stores';
 import { getBoundingBox } from '../fixtures/utils';
+import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
 import {
-  getProfileFromTextSamples,
   getEmptyThread,
   getEmptyProfile,
-} from '../fixtures/profiles/processed-profile';
+} from '../../profile-logic/data-structures';
 import {
   changeCallTreeSearchString,
   changeImplementationFilter,

--- a/src/test/fixtures/profiles/call-nodes.js
+++ b/src/test/fixtures/profiles/call-nodes.js
@@ -11,8 +11,10 @@ import type {
   Profile,
 } from '../../../types/profile';
 
-import { getEmptyThread, getEmptyProfile } from './processed-profile';
-
+import {
+  getEmptyThread,
+  getEmptyProfile,
+} from '../../../profile-logic/data-structures';
 /**
  * Note that this fixture doesn't use the `getProfileFromTextSamples()` function to
  * generate the profile, as it's testing the relationships between frames, and thus

--- a/src/test/fixtures/profiles/call-nodes.js
+++ b/src/test/fixtures/profiles/call-nodes.js
@@ -7,13 +7,13 @@ import type {
   FuncTable,
   SamplesTable,
   FrameTable,
-  StackTable,
   Profile,
 } from '../../../types/profile';
 
 import {
   getEmptyThread,
   getEmptyProfile,
+  getEmptyStackTable,
 } from '../../../profile-logic/data-structures';
 /**
  * Note that this fixture doesn't use the `getProfileFromTextSamples()` function to
@@ -89,13 +89,7 @@ export default function getProfile(): Profile {
     length: frameFuncs.length,
   };
 
-  const stackTable: StackTable = {
-    frame: [],
-    category: [],
-    prefix: [],
-    length: 0,
-    depth: [], // ??? depth?
-  };
+  const stackTable = getEmptyStackTable();
 
   // Provide a utility function for readability.
   function addToStackTable(frame, prefix, category) {

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -9,6 +9,7 @@ import {
   getEmptyJsTracerTable,
 } from '../../../profile-logic/data-structures';
 import { UniqueStringArray } from '../../../utils/unique-string-array';
+
 import type {
   Profile,
   Thread,

--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -3,7 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // @flow
-import { getEmptyProfile } from '../../../profile-logic/profile-data';
+import {
+  getEmptyProfile,
+  getEmptyThread,
+  getEmptyJsTracerTable,
+} from '../../../profile-logic/data-structures';
 import { UniqueStringArray } from '../../../utils/unique-string-array';
 import type {
   Profile,
@@ -58,8 +62,6 @@ function _refineMockPayload(
   // into a MarkerPayload using the function signature.
   return (payload: any);
 }
-
-export { getEmptyProfile } from '../../../profile-logic/profile-data';
 
 export function addMarkersToThreadWithCorrespondingSamples(
   thread: Thread,
@@ -117,75 +119,6 @@ export function getProfileWithNamedThreads(threadNames: string[]): Profile {
   const profile = getEmptyProfile();
   profile.threads = threadNames.map(name => getEmptyThread({ name }));
   return profile;
-}
-
-export function getEmptyThread(overrides?: $Shape<Thread>): Thread {
-  const defaultThread: Thread = {
-    processType: 'default',
-    processStartupTime: 0,
-    processShutdownTime: null,
-    registerTime: 0,
-    unregisterTime: null,
-    pausedRanges: [],
-    name: 'Empty',
-    pid: 0,
-    tid: 0,
-    samples: {
-      responsiveness: [],
-      stack: [],
-      time: [],
-      rss: [],
-      uss: [],
-      length: 0,
-    },
-    markers: {
-      data: [],
-      name: [],
-      time: [],
-      length: 0,
-    },
-    stackTable: {
-      frame: [],
-      prefix: [],
-      category: [],
-      length: 0,
-    },
-    frameTable: {
-      address: [],
-      category: [],
-      func: [],
-      implementation: [],
-      line: [],
-      column: [],
-      optimizations: [],
-      length: 0,
-    },
-    stringTable: new UniqueStringArray(),
-    libs: [],
-    funcTable: {
-      address: [],
-      isJS: [],
-      relevantForJS: [],
-      name: [],
-      resource: [],
-      fileName: [],
-      lineNumber: [],
-      columnNumber: [],
-      length: 0,
-    },
-    resourceTable: {
-      length: 0,
-      lib: [],
-      name: [],
-      host: [],
-      type: [],
-    },
-  };
-
-  return {
-    ...defaultThread,
-    ...overrides,
-  };
 }
 
 /**
@@ -580,17 +513,6 @@ export function getScreenshotTrackProfile() {
         },
       ])
   );
-}
-
-export function getEmptyJsTracerTable(): JsTracerTable {
-  return {
-    events: [],
-    timestamps: [],
-    durations: [],
-    lines: [],
-    columns: [],
-    length: 0,
-  };
 }
 
 export function getJsTracerTable(

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -7,15 +7,17 @@ import type { TrackReference } from '../../types/actions';
 import type { TabSlug } from '../../app-logic/tabs-handling';
 
 import {
-  getEmptyThread,
   getProfileFromTextSamples,
   getProfileWithMarkers,
   getNetworkTrackProfile,
   getScreenshotTrackProfile,
   getNetworkMarker,
 } from '../fixtures/profiles/processed-profile';
+import {
+  getEmptyThread,
+  getEmptyProfile,
+} from '../../profile-logic/data-structures';
 import { withAnalyticsMock } from '../fixtures/mocks/analytics';
-import { getEmptyProfile } from '../../profile-logic/profile-data';
 import { getProfileWithNiceTracks } from '../fixtures/profiles/tracks';
 import { blankStore, storeWithProfile } from '../fixtures/stores';
 import { assertSetContainsOnly } from '../fixtures/custom-assertions';

--- a/src/test/store/receive-profile.test.js
+++ b/src/test/store/receive-profile.test.js
@@ -7,6 +7,7 @@ import type { Profile } from '../../types/profile';
 
 import sinon from 'sinon';
 
+import { getEmptyProfile } from '../../profile-logic/data-structures';
 import { viewProfileFromPathInZipFile } from '../../actions/zipped-profiles';
 import { blankStore } from '../fixtures/stores';
 import * as ProfileViewSelectors from '../../selectors/profile';
@@ -22,7 +23,6 @@ import {
 } from '../../actions/receive-profile';
 
 import { createGeckoProfile } from '../fixtures/profiles/gecko-profile';
-import { getEmptyProfile } from '../../profile-logic/profile-data';
 import JSZip from 'jszip';
 import { serializeProfile } from '../../profile-logic/process-profile';
 import {

--- a/src/test/store/symbolication.test.js
+++ b/src/test/store/symbolication.test.js
@@ -8,7 +8,7 @@ import exampleSymbolTable from '../fixtures/example-symbol-table';
 import { SymbolStore } from '../../profile-logic/symbol-store.js';
 import * as ProfileViewSelectors from '../../selectors/profile';
 import { selectedThreadSelectors } from '../../selectors/per-thread';
-import { resourceTypes } from '../../profile-logic/profile-data';
+import { resourceTypes } from '../../profile-logic/data-structures';
 import { doSymbolicateProfile } from '../../actions/receive-profile';
 import {
   changeSelectedCallNode,

--- a/src/test/store/tracks.test.js
+++ b/src/test/store/tracks.test.js
@@ -4,9 +4,9 @@
 // @flow
 import {
   getScreenshotTrackProfile,
-  getEmptyThread,
   getNetworkTrackProfile,
 } from '../fixtures/profiles/processed-profile';
+import { getEmptyThread } from '../../profile-logic/data-structures';
 import { storeWithProfile } from '../fixtures/stores';
 import * as ProfileViewSelectors from '../../selectors/profile';
 import * as UrlStateSelectors from '../../selectors/url-state';

--- a/src/test/unit/profile-data.test.js
+++ b/src/test/unit/profile-data.test.js
@@ -11,7 +11,6 @@ import {
 } from '../../profile-logic/symbolication';
 import { processProfile } from '../../profile-logic/process-profile';
 import {
-  resourceTypes,
   getCallNodeInfo,
   filterThreadByImplementation,
   getCallNodePathFromIndex,
@@ -24,6 +23,7 @@ import {
   getTreeOrderComparator,
   getSamplesSelectedStates,
 } from '../../profile-logic/profile-data';
+import { resourceTypes } from '../../profile-logic/data-structures';
 import {
   createGeckoProfile,
   createGeckoProfileWithJsTimings,

--- a/src/test/unit/profile-tree.test.js
+++ b/src/test/unit/profile-tree.test.js
@@ -12,10 +12,10 @@ import { getRootsAndChildren } from '../../profile-logic/flame-graph';
 import {
   getCallNodeInfo,
   invertCallstack,
-  resourceTypes,
   getCallNodeIndexFromPath,
   getOriginAnnotationForFunc,
 } from '../../profile-logic/profile-data';
+import { resourceTypes } from '../../profile-logic/data-structures';
 import { formatTree, formatTreeIncludeCategories } from '../fixtures/utils';
 
 import type { Profile } from '../../types/profile';


### PR DESCRIPTION
This is the code re-organization we discussed on Slack. It is broken down into 3 commits. 

* The first is the minimal re-organization of the files, and the new functions to create each part of the profile.
* The second includes the removals of all the inline creation of data structures that I could find.
* The third is some minor clean-up I included with removing the `Object.assign`s in the data transforms code. I was worried about the type integrity there.