### PR TITLE
Add option to expose WebpackDevServer publicly for non-localhost development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,16 @@ When working on a new feature and code changes, it's important that things work 
  * Continuous integration for pull requests
    - We use CircleCI to run our tests for every PR that is submitted. This gives reviewers a great way to know if things are still working as expected.
 
+## Exposing the web application publicly
+
+If you'd like to use perf.html via URLs that are not `localhost` (e.g. live preview, proxy, other device...) you can expose the web application publicly like so:
+
+```bash
+PERFHTML_HOST="0.0.0.0" yarn start
+```
+
+You'll probably also want to add you non-localhost domains to the `allowedHosts` in `server.js`.
+
 ## Finding something to work on
 
 If this is your first time here, check out the label [Good First Issue](https://github.com/devtools-html/perf.html/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22). We will mentor you through the process of completing a first bug, and these are usually pretty good self-contained problems. After leveling up on a few good first issues, we also have the [Polish](https://github.com/devtools-html/perf.html/issues?q=is%3Aopen+is%3Aissue+label%3Apolish) tag for bugs that no one is actively working on, but are well-scoped and ready to be tackled!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ If you'd like to use perf.html via URLs that are not `localhost` (e.g. live prev
 PERFHTML_HOST="0.0.0.0" yarn start
 ```
 
-You'll probably also want to add you non-localhost domains to the `allowedHosts` in `server.js`.
+You'll probably also want to add your non-localhost domains to the `allowedHosts` property in `server.js`.
 
 ## Finding something to work on
 

--- a/server.js
+++ b/server.js
@@ -58,34 +58,32 @@ if (localConfigExists) {
   }
 }
 
-new WebpackDevServer(webpack(config), serverConfig).listen(
-  port,
-  host,
-  function(err) {
-    if (err) {
-      console.log(err);
-    }
-    const barAscii =
-      '------------------------------------------------------------------------------------------';
+new WebpackDevServer(webpack(config), serverConfig).listen(port, host, function(
+  err
+) {
+  if (err) {
+    console.log(err);
+  }
+  const barAscii =
+    '------------------------------------------------------------------------------------------';
 
-    console.log(barAscii);
-    console.log(`> perf.html is available at: http://${host}:${port}\n`);
-    if (port === 4242) {
-      console.log(
-        '> You can change this default port with the environment variable PERFHTML_PORT.\n'
-      );
-    }
-    if (localConfigExists) {
-      console.log(
-        '> We used your local file "webpack.local-config.js" to mutate webpack’s config values.'
-      );
-    } else {
-      console.log(stripIndent`
+  console.log(barAscii);
+  console.log(`> perf.html is available at: http://${host}:${port}\n`);
+  if (port === 4242) {
+    console.log(
+      '> You can change this default port with the environment variable PERFHTML_PORT.\n'
+    );
+  }
+  if (localConfigExists) {
+    console.log(
+      '> We used your local file "webpack.local-config.js" to mutate webpack’s config values.'
+    );
+  } else {
+    console.log(stripIndent`
       > You can customize the webpack dev server by creating a webpack.local-config.js
       > file that exports a single function that mutates the config values:
       >  (webpackConfig, serverConfig) => void
     `);
-    }
-    console.log(barAscii);
   }
-);
+  console.log(barAscii);
+});

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ const WebpackDevServer = require('webpack-dev-server');
 const config = require('./webpack.config');
 const { oneLine, stripIndent } = require('common-tags');
 const port = process.env.PERFHTML_PORT || 4242;
+const host = process.env.PERFHTML_HOST || 'localhost';
 const fs = require('fs');
 const path = require('path');
 const localConfigExists = fs.existsSync(
@@ -11,6 +12,7 @@ const localConfigExists = fs.existsSync(
 );
 
 const serverConfig = {
+  allowedHosts: ['localhost'],
   contentBase: config.output.path,
   publicPath: config.output.publicPath,
   hot: process.env.NODE_ENV === 'development' ? true : false,
@@ -58,7 +60,7 @@ if (localConfigExists) {
 
 new WebpackDevServer(webpack(config), serverConfig).listen(
   port,
-  'localhost',
+  host,
   function(err) {
     if (err) {
       console.log(err);
@@ -67,7 +69,7 @@ new WebpackDevServer(webpack(config), serverConfig).listen(
       '------------------------------------------------------------------------------------------';
 
     console.log(barAscii);
-    console.log(`> perf.html is available at: http://localhost:${port}\n`);
+    console.log(`> perf.html is available at: http://${host}:${port}\n`);
     if (port === 4242) {
       console.log(
         '> You can change this default port with the environment variable PERFHTML_PORT.\n'

--- a/server.js
+++ b/server.js
@@ -68,7 +68,7 @@ new WebpackDevServer(webpack(config), serverConfig).listen(port, host, function(
     '------------------------------------------------------------------------------------------';
 
   console.log(barAscii);
-  console.log(`> perf.html is available at: http://${host}:${port}\n`);
+  console.log(`> perf.html is listening at: http://${host}:${port}\n`);
   if (port === 4242) {
     console.log(
       '> You can change this default port with the environment variable PERFHTML_PORT.\n'


### PR DESCRIPTION
If you'd like to use perf.html via URLs that are not `localhost` (e.g. from behind a proxy, or from another device) I suggest to expose the web application publicly like so:

```bash
PERFHTML_PUBLICHOST=true yarn start
```