### PR TITLE
Add Log marker support

### DIFF
--- a/src/components/shared/MarkerTooltipContents.js
+++ b/src/components/shared/MarkerTooltipContents.js
@@ -378,6 +378,14 @@ function getMarkerDetails(
           </div>
         );
       }
+      case 'Log': {
+        return (
+          <div className="tooltipDetails">
+            {_markerDetail('module', 'Module', data.module)}
+            {_markerDetail('name', 'Name', data.name)}
+          </div>
+        );
+      }
       case 'GCMinor': {
         if (data.nursery) {
           const nursery = data.nursery;

--- a/src/test/components/MarkerTooltipContents.test.js
+++ b/src/test/components/MarkerTooltipContents.test.js
@@ -281,6 +281,15 @@ describe('MarkerTooltipContents', function() {
         },
       ],
       [
+        'Log',
+        21.7,
+        {
+          type: 'Log',
+          name: 'Random log message',
+          module: 'RandomModule',
+        },
+      ],
+      [
         'Styles',
         20.5,
         {

--- a/src/test/components/__snapshots__/MarkerTooltipContents.test.js.snap
+++ b/src/test/components/__snapshots__/MarkerTooltipContents.test.js.snap
@@ -863,6 +863,59 @@ exports[`MarkerTooltipContents renders tooltips for various markers: Load 1234: 
 </div>
 `;
 
+exports[`MarkerTooltipContents renders tooltips for various markers: Log-21.7 1`] = `
+<div
+  className="tooltipMarker propClass"
+>
+  <div
+    className="tooltipHeader"
+  >
+    <div
+      className="tooltipOneLine"
+    >
+      <div
+        className="tooltipTiming"
+      >
+        0.000ms
+      </div>
+      <div
+        className="tooltipTitle"
+      >
+        Log
+      </div>
+    </div>
+    <div
+      className="tooltipDetails"
+    >
+      <div
+        className="tooltipLabel"
+      >
+        Thread:
+      </div>
+      Main Thread
+    </div>
+  </div>
+  <div
+    className="tooltipDetails"
+  >
+    <div
+      className="tooltipLabel"
+    >
+      Module
+      :
+    </div>
+    RandomModule
+    <div
+      className="tooltipLabel"
+    >
+      Name
+      :
+    </div>
+    Random log message
+  </div>
+</div>
+`;
+
 exports[`MarkerTooltipContents renders tooltips for various markers: NotifyDidPaint-14.5 1`] = `
 <div
   className="tooltipMarker propClass"

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -335,6 +335,10 @@ export type TextMarkerPayload = {|
   name: string,
 |};
 
+/**
+ * Gecko includes rich log information. This marker payload is used to mirror that
+ * log information in the profile.
+ */
 export type LogMarkerPayload = {|
   type: 'Log',
   name: string,

--- a/src/types/markers.js
+++ b/src/types/markers.js
@@ -335,6 +335,12 @@ export type TextMarkerPayload = {|
   name: string,
 |};
 
+export type LogMarkerPayload = {|
+  type: 'Log',
+  name: string,
+  module: string,
+|};
+
 export type DOMEventMarkerPayload = {|
   type: 'tracing',
   category: 'DOMEvent',
@@ -429,6 +435,7 @@ export type MarkerPayload =
   | NetworkPayload
   | UserTimingMarkerPayload
   | TextMarkerPayload
+  | LogMarkerPayload
   | PaintProfilerMarkerTracing
   | DOMEventMarkerPayload
   | GCMinorMarkerPayload
@@ -448,6 +455,7 @@ export type MarkerPayload_Gecko =
   | NetworkPayload
   | UserTimingMarkerPayload
   | TextMarkerPayload
+  | LogMarkerPayload
   | PaintProfilerMarkerTracing_Gecko
   | DOMEventMarkerPayload
   | GCMinorMarkerPayload


### PR DESCRIPTION
Adds basic support for Log messages in markers.  Followup will be something to show only the log messages (like the MarkerTable, but for logs) and probably to save the log messages as a text file (or maybe just open as a text document in a new tab)