### PR TITLE
Fix intermittent test failures

### DIFF
--- a/src/test/unit/profile-conversion.test.js
+++ b/src/test/unit/profile-conversion.test.js
@@ -33,7 +33,7 @@ describe('converting Google Chrome profile', function() {
   it('successfully imports', async function() {
     // Mock out image loading behavior as the screenshots rely on the Image loading
     // behavior.
-    jest
+    const spy = jest
       .spyOn(Image.prototype, 'addEventListener')
       .mockImplementation((name: string, callback: Function) => {
         if (name === 'load') {
@@ -51,5 +51,13 @@ describe('converting Google Chrome profile', function() {
       throw new Error('Unable to parse the profile.');
     }
     expect(profile).toMatchSnapshot();
+
+    // This is really odd behavior, but this spy was showing up in stack traces in
+    // an intermittent test failure. Adding this manually mock restore made the error
+    // go away. Generally spies should be removed with automatically because of the
+    // "resetMocks" configuration option.
+    //
+    // See https://github.com/facebook/jest/issues/7654
+    spy.mockRestore();
   });
 });


### PR DESCRIPTION
I verified this by running: `while jest; do :; done` from my terminal. I could consistently hit the intermittent after a minute or so of running that. If jest isn't on your path, `while yarn test; do :; done` should work.

Here is the error message:

```
  ● app/Home › renders the usage instructions for pages with the extension installed

    TypeError: Cannot read property 'target' of undefined

      41 |         }
      42 |       });
    > 43 |
         | ^
      44 |     const fs = require('fs');
      45 |     const zlib = require('zlib');
      46 |     const buffer = fs.readFileSync('src/test/fixtures/upgrades/test.chrome.gz');

      at getEventTarget (node_modules/react-dom/cjs/react-dom.development.js:2402:28)
      at dispatchEvent (node_modules/react-dom/cjs/react-dom.development.js:3406:27)
      at HTMLImageElement.jest.spyOn.mockImplementation (src/test/unit/profile-conversion.test.js:43:9)
      at Object.listen (node_modules/fbjs/lib/EventListener.js:29:14)
      at trapBubbledEvent (node_modules/react-dom/cjs/react-dom.development.js:3381:24)
      at setInitialProperties$1 (node_modules/react-dom/cjs/react-dom.development.js:13938:7)
      at finalizeInitialChildren (node_modules/react-dom/cjs/react-dom.development.js:14989:5)
      at completeWork (node_modules/react-dom/cjs/react-dom.development.js:8648:19)
      at completeUnitOfWork (node_modules/react-dom/cjs/react-dom.development.js:10132:18)
      at performUnitOfWork (node_modules/react-dom/cjs/react-dom.development.js:10234:14)
      at workLoop (node_modules/react-dom/cjs/react-dom.development.js:10288:26)
      at HTMLUnknownElement.callCallback (node_modules/react-dom/cjs/react-dom.development.js:542:14)
      at invokeEventListeners (node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:193:27)
      at HTMLUnknownElementImpl._dispatch (node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:119:9)
      at HTMLUnknownElementImpl.dispatchEvent (node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:82:17)
      at HTMLUnknownElementImpl.dispatchEvent (node_modules/jsdom/lib/jsdom/living/nodes/HTMLElement-impl.js:30:27)
      at HTMLUnknownElement.dispatchEvent (node_modules/jsdom/lib/jsdom/living/generated/EventTarget.js:157:21)
      at Object.invokeGuardedCallbackDev (node_modules/react-dom/cjs/react-dom.development.js:581:16)
      at invokeGuardedCallback (node_modules/react-dom/cjs/react-dom.development.js:438:27)
      at renderRoot (node_modules/react-dom/cjs/react-dom.development.js:10366:7)
      at performWorkOnRoot (node_modules/react-dom/cjs/react-dom.development.js:11014:24)
      at performWork (node_modules/react-dom/cjs/react-dom.development.js:10967:7)
      at requestWork (node_modules/react-dom/cjs/react-dom.development.js:10878:7)
      at scheduleWorkImpl (node_modules/react-dom/cjs/react-dom.development.js:10732:11)
      at scheduleWork (node_modules/react-dom/cjs/react-dom.development.js:10689:12)
      at scheduleTopLevelUpdate (node_modules/react-dom/cjs/react-dom.development.js:11193:5)
      at Object.updateContainer (node_modules/react-dom/cjs/react-dom.development.js:11231:7)
      at node_modules/react-dom/cjs/react-dom.development.js:15226:19
      at Object.unbatchedUpdates (node_modules/react-dom/cjs/react-dom.development.js:11102:12)
      at renderSubtreeIntoContainer (node_modules/react-dom/cjs/react-dom.development.js:15225:17)
      at Object.render (node_modules/react-dom/cjs/react-dom.development.js:15290:12)
      at render (node_modules/react-testing-library/dist/index.js:51:21)
      at Object.it (src/test/components/Home.test.js:68:41)
```

I think resetMocks is having some issues in jest, and for some reason the mock is outliving itself. Perhaps upgrading jest will help here? Otherwise this fixes it for now.