### PR TITLE
Disable verbose test output

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,6 +146,6 @@
     "restoreMocks": true,
     "resetMocks": true,
     "setupTestFrameworkScriptFile": "./src/test/setup.js",
-    "verbose": true
+    "verbose": false
   }
 }


### PR DESCRIPTION
This increases the signal to noise ratio for our tests. I've been struggling with finding the relevant information for failing tests lately.

<img width="477" alt="image" src="https://user-images.githubusercontent.com/1588648/51488051-29690c80-1d6a-11e9-83e6-8fd99ecf10ad.png">
