### PR TITLE
Mock out and hide extraneous console.log in the symbol store test

### DIFF
--- a/src/test/unit/symbol-store.test.js
+++ b/src/test/unit/symbol-store.test.js
@@ -160,6 +160,10 @@ describe('SymbolStore', function() {
   });
 
   it('should call requestSymbolsFromServer first', async function() {
+    // This test has some console output because of unrecognized mock data. This is
+    // fine, but hide it from the test runner.
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+
     const symbolTable = new Map();
     symbolTable.set(0, 'first symbol');
     symbolTable.set(0xf00, 'second symbol');


### PR DESCRIPTION
This patch hides this message from our test output:

<img width="997" alt="image" src="https://user-images.githubusercontent.com/1588648/51489804-f5dcb100-1d6e-11e9-8c0b-2176b0d04a37.png">
