### PR TITLE
Make the tests run faster by speeding up funcNames in getProfileFromTextSamples

### DIFF
--- a/src/test/fixtures/profiles/processed-profile.js
+++ b/src/test/fixtures/profiles/processed-profile.js
@@ -190,13 +190,17 @@ export function getProfileFromTextSamples(
   profile.threads = allTextSamples.map(textSamples => {
     // Process the text.
     const textOnlyStacks = _parseTextSamples(textSamples);
-    const funcNames = textOnlyStacks
-      // Flatten the arrays.
-      .reduce((memo, row) => [...memo, ...row], [])
-      // remove modifiers
-      .map(func => func.replace(/\[.*/, ''))
-      // Make the list unique.
-      .filter((item, index, array) => array.indexOf(item) === index);
+
+    // Flatten the textOnlyStacks into into a list of function names.
+    const funcNamesSet = new Set();
+    const removeModifiers = /\[.*/;
+    for (let i = 0; i < textOnlyStacks.length; i++) {
+      const textOnlyStack = textOnlyStacks[i];
+      for (let j = 0; j < textOnlyStack.length; j++) {
+        funcNamesSet.add(textOnlyStack[j].replace(removeModifiers, ''));
+      }
+    }
+    const funcNames = [...funcNamesSet];
 
     const funcNamesDict = funcNames.reduce((result, item, index) => {
       result[item] = index;


### PR DESCRIPTION
This patch removes the slow test warning for `src/test/components/ProfileCallTreeView.test.js`. However, it didn't noticeably speed up the overall test run.

<img width="505" alt="image" src="https://user-images.githubusercontent.com/1588648/51493078-af408400-1d79-11e9-8dc9-441979264afd.png">
