### PR TITLE
Add error boundaries for components, so errors don't unmount the entire applicaton

### DIFF
--- a/res/css/photon-components.css
+++ b/res/css/photon-components.css
@@ -79,3 +79,48 @@
   border: 1px solid var(--red-60);
   box-shadow: 0 0 0 1px var(--red-60), 0 0 0 4px rgba(251, 0, 34, 0.3);
 }
+
+/* https://design.firefox.com/photon/components/message-bars.html */
+.photon-message-bar {
+  display: flex;
+  width: 100%;
+  min-height: 32px;
+  box-sizing: border-box;
+  align-items: center;
+  padding: 0 4px;
+  border-radius: 4px;
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 1.4;
+}
+
+.photon-message-bar-error {
+  background-color: var(--red-60);
+  color: #fff;
+}
+
+.photon-message-bar-error > * {
+  margin: 0 4px;
+}
+
+.photon-message-bar-error-icon {
+  display: inline-block;
+  width: 15px;
+  height: 15px;
+  flex-shrink: 0;
+  background-image: url(../img/svg/error.svg);
+}
+
+.photon-message-bar-error-action {
+  padding: 6px;
+  margin-left: 8px;
+  border: none;
+  background-color: var(--red-70);
+  border-radius: 4px;
+  color: #fff;
+  font-size: 11px;
+}
+
+.photon-message-bar-error-action:hover {
+  background-color: var(--red-80);
+}

--- a/res/css/photon-components.css
+++ b/res/css/photon-components.css
@@ -12,6 +12,7 @@
   /* photon styles */
   background-color: var(--grey-90-a10);
   border-radius: 2px;
+  color: var(--grey-90);
   font: inherit;
 }
 
@@ -34,6 +35,15 @@
   background-color: var(--grey-90-a20);
 }
 
+.photon-message-bar-error .photon-button {
+  background-color: var(--red-70);
+  color: #fff;
+}
+
+.photon-message-bar .photon-button {
+  margin-left: 8px;
+}
+
 .photon-button:hover:active {
   background-color: var(--grey-90-a30);
 }
@@ -50,6 +60,10 @@
 
 .photon-button-ghost:hover:active {
   background-color: var(--grey-90-a20);
+}
+
+.photon-button-micro {
+  height: 24px;
 }
 
 /* --- Inputs --- */
@@ -80,7 +94,9 @@
   box-shadow: 0 0 0 1px var(--red-60), 0 0 0 4px rgba(251, 0, 34, 0.3);
 }
 
-/* https://design.firefox.com/photon/components/message-bars.html */
+/* --- Message bars --- */
+
+/* See https://design.firefox.com/photon/components/message-bars.html */
 .photon-message-bar {
   display: flex;
   width: 100%;
@@ -95,32 +111,22 @@
 }
 
 .photon-message-bar-error {
-  background-color: var(--red-60);
+  /* Note: 32px is: 4px (left padding for the message bar) + 4px (left padding
+   * for the icon) + 16px (icon width) + 4px (right padding for the icon) + 4px
+   * (space between icon and text) */
+  padding: 4px 4px 4px 32px;
+
+  /* Note: 8px is: 4px (left padding for the message bar) + 4px (left padding
+   * for the icon) */
+  background: url(../img/svg/error.svg) no-repeat 8px center / 16px 16px
+    var(--red-60);
   color: #fff;
 }
 
-.photon-message-bar-error > * {
-  margin: 0 4px;
-}
-
-.photon-message-bar-error-icon {
-  display: inline-block;
-  width: 15px;
-  height: 15px;
-  flex-shrink: 0;
-  background-image: url(../img/svg/error.svg);
-}
-
-.photon-message-bar-error-action {
-  padding: 6px;
-  margin-left: 8px;
-  border: none;
-  background-color: var(--red-70);
-  border-radius: 4px;
-  color: #fff;
-  font-size: 11px;
-}
-
-.photon-message-bar-error-action:hover {
+.photon-message-bar-error .photon-button:hover {
   background-color: var(--red-80);
+}
+
+.photon-message-bar-error .photon-button:hover:active {
+  background-color: var(--red-90);
 }

--- a/res/img/svg/error.svg
+++ b/res/img/svg/error.svg
@@ -1,0 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12" fill="#fff">
+  <path fill-rule="evenodd" d="M12 6A6 6 0 1 1 0 6a6 6 0 0 1 12 0zM5.75 8a.75.75 0 0 0-.75.75v.5c0 .41.34.75.75.75h.5c.41 0 .75-.34.75-.75v-.5A.75.75 0 0 0 6.25 8h-.5zM5 6c0 .54.46 1 1 1s1-.46 1-1V3.15c0-.54-.46-1-1-1s-1 .46-1 1V6z"/>
+</svg>

--- a/src/components/app/Details.js
+++ b/src/components/app/Details.js
@@ -9,6 +9,7 @@ import classNames from 'classnames';
 
 import explicitConnect from '../../utils/connect';
 import TabBar from './TabBar';
+import { ErrorBoundary } from './ErrorBoundary';
 import ProfileCallTreeView from '../calltree/ProfileCallTreeView';
 import MarkerTable from '../marker-table';
 import StackChart from '../stack-chart/';
@@ -91,17 +92,22 @@ class ProfileViewer extends PureComponent<Props> {
           onSelectTab={this._onSelectTab}
           extraElements={extraButton}
         />
-        {
+        <ErrorBoundary
+          key={selectedTab}
+          message="Uh oh, some unknown error happened in this panel."
+        >
           {
-            calltree: <ProfileCallTreeView />,
-            'flame-graph': <FlameGraph />,
-            'stack-chart': <StackChart />,
-            'marker-chart': <MarkerChart />,
-            'marker-table': <MarkerTable />,
-            'network-chart': <NetworkChart />,
-            'js-tracer': <JsTracer />,
-          }[selectedTab]
-        }
+            {
+              calltree: <ProfileCallTreeView />,
+              'flame-graph': <FlameGraph />,
+              'stack-chart': <StackChart />,
+              'marker-chart': <MarkerChart />,
+              'marker-table': <MarkerTable />,
+              'network-chart': <NetworkChart />,
+              'js-tracer': <JsTracer />,
+            }[selectedTab]
+          }
+        </ErrorBoundary>
         <CallNodeContextMenu />
         <MarkerTableContextMenu />
         <TimelineTrackContextMenu />

--- a/src/components/app/ErrorBoundary.css
+++ b/src/components/app/ErrorBoundary.css
@@ -1,0 +1,45 @@
+.appErrorBoundary {
+  display: flex;
+  overflow: hidden;
+  box-sizing: border-box;
+  flex: 1;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  background-color: var(--grey-20);
+}
+
+.appErrorBoundaryContents {
+  display: flex;
+  width: 100%;
+  max-width: 600px;
+  max-height: calc(100%);
+  box-sizing: border-box;
+  flex-direction: column;
+}
+
+@keyframes appErrorBoundaryDetailsFadeIn {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+.appErrorBoundaryDetails {
+  flex-shrink: 1;
+  padding: 25px;
+  margin: 12px 0;
+  animation-duration: 200ms;
+  animation-name: appErrorBoundaryDetailsFadeIn;
+  background: #fff;
+  border-radius: 4px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+  color: var(--grey-70);
+  font-family: monospace;
+  line-height: 1.3;
+  overflow-y: auto;
+  white-space: pre-wrap;
+}

--- a/src/components/app/ErrorBoundary.css
+++ b/src/components/app/ErrorBoundary.css
@@ -19,27 +19,29 @@
   flex-direction: column;
 }
 
-@keyframes appErrorBoundaryDetailsFadeIn {
-  0% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
-  }
-}
-
 .appErrorBoundaryDetails {
-  flex-shrink: 1;
   padding: 25px;
   margin: 12px 0;
-  animation-duration: 200ms;
-  animation-name: appErrorBoundaryDetailsFadeIn;
   background: #fff;
   border-radius: 4px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
   color: var(--grey-70);
   font-family: monospace;
   line-height: 1.3;
+  opacity: 1;
   overflow-y: auto;
+
+  /* Transition opacity, but do not delay changing the visibility. */
+  transition: opacity 200ms, visibility 0s;
+  visibility: visible;
   white-space: pre-wrap;
+}
+
+.appErrorBoundaryDetails.hide {
+  opacity: 0;
+
+  /* Transition opacity, and create a delay on hiding the visibility to allow
+     time for the fade out. */
+  transition: opacity 200ms, visibility 0s linear 200ms;
+  visibility: hidden;
 }

--- a/src/components/app/ErrorBoundary.css
+++ b/src/components/app/ErrorBoundary.css
@@ -32,7 +32,7 @@
   overflow-y: auto;
 
   /* Transition opacity, but do not delay changing the visibility. */
-  transition: opacity 200ms, visibility 0s;
+  transition: opacity 150ms, visibility 0s;
   visibility: visible;
   white-space: pre-wrap;
 }
@@ -42,6 +42,6 @@
 
   /* Transition opacity, and create a delay on hiding the visibility to allow
      time for the fade out. */
-  transition: opacity 200ms, visibility 0s linear 200ms;
+  transition: opacity 150ms, visibility 0s 150ms;
   visibility: hidden;
 }

--- a/src/components/app/ErrorBoundary.js
+++ b/src/components/app/ErrorBoundary.js
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+
+import React from 'react';
+import { reportError } from '../../utils/analytics';
+import './ErrorBoundary.css';
+
+type State = {|
+  hasError: boolean,
+  showDetails: boolean,
+  error?: Error,
+  componentStack?: string,
+|};
+
+type Props = {|
+  children: *,
+  message: string,
+|};
+
+/**
+ * This component will catch errors in components, and display a more friendly error
+ * message. This stops the entire app from unmounting and displaying an empty screen.
+ *
+ * See: https://reactjs.org/docs/error-boundaries.html
+ */
+export class ErrorBoundary extends React.Component<Props, State> {
+  state = {
+    hasError: false,
+    showDetails: false,
+  };
+
+  componentDidCatch(
+    error: any,
+    { componentStack }: { componentStack: string }
+  ) {
+    console.error(error, componentStack);
+    this.setState({ hasError: true, error, componentStack });
+    reportError({
+      exDescription: componentStack,
+      exFatal: true,
+    });
+  }
+
+  _toggleErrorDetails = () => {
+    this.setState(state => ({ showDetails: !state.showDetails }));
+  };
+
+  render() {
+    if (this.state.hasError) {
+      const { error, componentStack, showDetails } = this.state;
+      return (
+        <div className="appErrorBoundary">
+          <div className="appErrorBoundaryContents">
+            <div className="photon-message-bar photon-message-bar-error">
+              <span className="photon-message-bar-error-icon" />
+              {this.props.message}
+              <button
+                className="photon-message-bar-error-action"
+                type="button"
+                onClick={this._toggleErrorDetails}
+              >
+                {showDetails ? 'Hide error details' : 'View full error details'}
+              </button>
+            </div>
+            {showDetails ? (
+              <div className="appErrorBoundaryDetails">
+                {error ? <div>{error.toString()}</div> : null}
+                {componentStack ? <div>{componentStack}</div> : null}
+              </div>
+            ) : null}
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/components/app/ErrorBoundary.js
+++ b/src/components/app/ErrorBoundary.js
@@ -54,10 +54,9 @@ export class ErrorBoundary extends React.Component<Props, State> {
         <div className="appErrorBoundary">
           <div className="appErrorBoundaryContents">
             <div className="photon-message-bar photon-message-bar-error">
-              <span className="photon-message-bar-error-icon" />
               {this.props.message}
               <button
-                className="photon-message-bar-error-action"
+                className="photon-button photon-button-micro"
                 type="button"
                 onClick={this._toggleErrorDetails}
               >

--- a/src/components/app/ErrorBoundary.js
+++ b/src/components/app/ErrorBoundary.js
@@ -10,7 +10,7 @@ import './ErrorBoundary.css';
 type State = {|
   hasError: boolean,
   showDetails: boolean,
-  error?: Error,
+  errorString: string | null,
   componentStack?: string,
 |};
 
@@ -29,6 +29,7 @@ export class ErrorBoundary extends React.Component<Props, State> {
   state = {
     hasError: false,
     showDetails: false,
+    errorString: null,
   };
 
   componentDidCatch(
@@ -40,9 +41,22 @@ export class ErrorBoundary extends React.Component<Props, State> {
       error,
       componentStack
     );
-    this.setState({ hasError: true, componentStack });
+    let errorString = null;
+    if (
+      error &&
+      typeof error === 'object' &&
+      typeof error.toString === 'function'
+    ) {
+      const result = error.toString();
+      if (typeof result === 'string') {
+        errorString = result;
+      }
+    }
+    this.setState({ hasError: true, errorString, componentStack });
     reportError({
-      exDescription: componentStack,
+      exDescription: errorString
+        ? errorString + '\n' + componentStack
+        : componentStack,
       exFatal: true,
     });
   }
@@ -53,7 +67,7 @@ export class ErrorBoundary extends React.Component<Props, State> {
 
   render() {
     if (this.state.hasError) {
-      const { error, componentStack, showDetails } = this.state;
+      const { errorString, componentStack, showDetails } = this.state;
       return (
         <div className="appErrorBoundary">
           <div className="appErrorBoundaryContents">
@@ -72,7 +86,7 @@ export class ErrorBoundary extends React.Component<Props, State> {
               data-testid="error-technical-details"
               className={`appErrorBoundaryDetails ${showDetails ? '' : 'hide'}`}
             >
-              {error ? <div>{error.toString()}</div> : null}
+              {errorString ? <div>{errorString}</div> : null}
               {componentStack ? <div>{componentStack}</div> : null}
             </div>
           </div>

--- a/src/components/app/ErrorBoundary.js
+++ b/src/components/app/ErrorBoundary.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import { reportError } from '../../utils/analytics';
 import './ErrorBoundary.css';
 
@@ -15,8 +15,8 @@ type State = {|
 |};
 
 type Props = {|
-  children: *,
-  message: string,
+  +children: React.Node,
+  +message: string,
 |};
 
 /**
@@ -32,11 +32,15 @@ export class ErrorBoundary extends React.Component<Props, State> {
   };
 
   componentDidCatch(
-    error: any,
+    error: mixed,
     { componentStack }: { componentStack: string }
   ) {
-    console.error(error, componentStack);
-    this.setState({ hasError: true, error, componentStack });
+    console.error(
+      'An unhandled error was thrown in a React component.',
+      error,
+      componentStack
+    );
+    this.setState({ hasError: true, componentStack });
     reportError({
       exDescription: componentStack,
       exFatal: true,
@@ -59,16 +63,18 @@ export class ErrorBoundary extends React.Component<Props, State> {
                 className="photon-button photon-button-micro"
                 type="button"
                 onClick={this._toggleErrorDetails}
+                aria-expanded={showDetails ? 'true' : 'false'}
               >
                 {showDetails ? 'Hide error details' : 'View full error details'}
               </button>
             </div>
-            {showDetails ? (
-              <div className="appErrorBoundaryDetails">
-                {error ? <div>{error.toString()}</div> : null}
-                {componentStack ? <div>{componentStack}</div> : null}
-              </div>
-            ) : null}
+            <div
+              data-testid="error-technical-details"
+              className={`appErrorBoundaryDetails ${showDetails ? '' : 'hide'}`}
+            >
+              {error ? <div>{error.toString()}</div> : null}
+              {componentStack ? <div>{componentStack}</div> : null}
+            </div>
           </div>
         </div>
       );

--- a/src/components/app/Root.js
+++ b/src/components/app/Root.js
@@ -28,6 +28,7 @@ import {
 import UrlManager from './UrlManager';
 import ServiceWorkerManager from './ServiceWorkerManager';
 import FooterLinks from './FooterLinks';
+import { ErrorBoundary } from './ErrorBoundary';
 
 import type { Store } from '../../types/store';
 import type { AppViewState, State } from '../../types/state';
@@ -289,12 +290,14 @@ export default class Root extends PureComponent<RootProps> {
   render() {
     const { store } = this.props;
     return (
-      <Provider store={store}>
-        <UrlManager>
-          <ProfileViewWhenReady />
-          <FooterLinks />
-        </UrlManager>
-      </Provider>
+      <ErrorBoundary message="Uh oh, some error happened in perf.html.">
+        <Provider store={store}>
+          <UrlManager>
+            <ProfileViewWhenReady />
+            <FooterLinks />
+          </UrlManager>
+        </Provider>
+      </ErrorBoundary>
     );
   }
 }

--- a/src/test/components/ErrorBoundary.test.js
+++ b/src/test/components/ErrorBoundary.test.js
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+import * as React from 'react';
+import { render } from 'react-testing-library';
+
+import { ErrorBoundary } from '../../components/app/ErrorBoundary';
+import { withAnalyticsMock } from '../fixtures/mocks/analytics';
+
+describe('app/ErrorBoundary', function() {
+  const childComponentText = 'This is a child component';
+  const friendlyErrorMessage = 'Oops, there was an error';
+  const technicalErrorMessage = 'This is an error.';
+  const technicalErrorMatcher = /This is an error./;
+  const ThrowingComponent = () => {
+    throw new Error(technicalErrorMessage);
+  };
+
+  it('shows the component children when there is no error', () => {
+    const { getByText } = render(
+      <ErrorBoundary message={friendlyErrorMessage}>
+        {childComponentText}
+      </ErrorBoundary>
+    );
+    expect(getByText(childComponentText)).toBeTruthy();
+  });
+
+  it('shows the error message children when the component throws error', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const { getByText } = render(
+      <ErrorBoundary message={friendlyErrorMessage}>
+        <ThrowingComponent />
+      </ErrorBoundary>
+    );
+    expect(getByText(friendlyErrorMessage)).toBeTruthy();
+  });
+
+  it('can click the component to view the full details', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const { getByText } = render(
+      <ErrorBoundary message={friendlyErrorMessage}>
+        <ThrowingComponent />
+      </ErrorBoundary>
+    );
+    // The technical error doesn't exist
+    expect(() => getByText(technicalErrorMatcher)).toThrow();
+
+    // Click the button to expand the details.
+    getByText('View full error details').click();
+
+    // The technical error now exists.
+    expect(getByText(technicalErrorMatcher)).toBeTruthy();
+  });
+
+  it('reports errors to the analytics', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    withAnalyticsMock(() => {
+      render(
+        <ErrorBoundary message={friendlyErrorMessage}>
+          <ThrowingComponent />
+        </ErrorBoundary>
+      );
+      expect(self.ga.mock.calls).toEqual([
+        [
+          'send',
+          'exception',
+          {
+            exDescription: [
+              '',
+              '    in ThrowingComponent',
+              '    in ErrorBoundary',
+            ].join('\n'),
+            exFatal: true,
+          },
+        ],
+      ]);
+    });
+  });
+});

--- a/src/test/components/ErrorBoundary.test.js
+++ b/src/test/components/ErrorBoundary.test.js
@@ -27,20 +27,24 @@ describe('app/ErrorBoundary', function() {
     return { spy, ...results };
   }
 
+  it('matches the snapshot', () => {
+    const { container } = setupComponent(<ThrowingComponent />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
   it('shows the component children when there is no error', () => {
     const { getByText } = setupComponent(childComponentText);
     expect(getByText(childComponentText)).toBeTruthy();
   });
 
   it('shows the error message children when the component throws error', () => {
-    jest.spyOn(console, 'error').mockImplementation(() => {});
     const { getByText } = setupComponent(<ThrowingComponent />);
     expect(getByText(friendlyErrorMessage)).toBeTruthy();
   });
 
   it('surfaces the error via console.error', () => {
-    const { spy } = setupComponent(<ThrowingComponent />);
-    expect(spy).toHaveBeenCalled();
+    setupComponent(<ThrowingComponent />);
+    expect(console.error).toHaveBeenCalled();
   });
 
   it('can click the component to view the full details', () => {
@@ -65,6 +69,7 @@ describe('app/ErrorBoundary', function() {
       setupComponent(<ThrowingComponent />);
       expect(self.ga).toHaveBeenCalledWith('send', 'exception', {
         exDescription: [
+          'Error: This is an error.',
           '',
           '    in ThrowingComponent',
           '    in ErrorBoundary',

--- a/src/test/components/__snapshots__/ErrorBoundary.test.js.snap
+++ b/src/test/components/__snapshots__/ErrorBoundary.test.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`app/ErrorBoundary matches the snapshot 1`] = `
+<div
+  class="appErrorBoundary"
+>
+  <div
+    class="appErrorBoundaryContents"
+  >
+    <div
+      class="photon-message-bar photon-message-bar-error"
+    >
+      Oops, there was an error
+      <button
+        aria-expanded="false"
+        class="photon-button photon-button-micro"
+        type="button"
+      >
+        View full error details
+      </button>
+    </div>
+    <div
+      class="appErrorBoundaryDetails hide"
+      data-testid="error-technical-details"
+    >
+      <div>
+        Error: This is an error.
+      </div>
+      <div>
+        
+    in ThrowingComponent
+    in ErrorBoundary
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/utils/analytics.js
+++ b/src/utils/analytics.js
@@ -33,11 +33,27 @@ type GATiming = {|
 
 export type GAPayload = GAEvent | GAPageView | GATiming;
 
-export type GoogleAnalytics = ('send', GAPayload) => void;
+// Prettier breaks with multiple arrow functions and intersections, so name the arrow
+// functions.
+type _Send = ('send', GAPayload) => void;
+type _Exception = ('send', 'exception', GAErrorPayload) => void;
+export type GoogleAnalytics = _Send & _Exception;
 
 export function sendAnalytics(payload: GAPayload) {
   const ga: ?GoogleAnalytics = self.ga;
   if (ga) {
     ga('send', payload);
+  }
+}
+
+export type GAErrorPayload = {|
+  +exDescription: string,
+  +exFatal: boolean,
+|};
+
+export function reportError(errorPayload: GAErrorPayload) {
+  const ga: ?GoogleAnalytics = self.ga;
+  if (ga) {
+    ga('send', 'exception', errorPayload);
   }
 }

--- a/src/utils/analytics.js
+++ b/src/utils/analytics.js
@@ -33,6 +33,11 @@ type GATiming = {|
 
 export type GAPayload = GAEvent | GAPageView | GATiming;
 
+export type GAErrorPayload = {|
+  +exDescription: string,
+  +exFatal: boolean,
+|};
+
 // Prettier breaks with multiple arrow functions and intersections, so name the arrow
 // functions.
 type _Send = ('send', GAPayload) => void;
@@ -45,11 +50,6 @@ export function sendAnalytics(payload: GAPayload) {
     ga('send', payload);
   }
 }
-
-export type GAErrorPayload = {|
-  +exDescription: string,
-  +exFatal: boolean,
-|};
 
 export function reportError(errorPayload: GAErrorPayload) {
   const ga: ?GoogleAnalytics = self.ga;


### PR DESCRIPTION
Resolves #1503 
> Full app errors
> <img width="1047" alt="screen shot 2019-01-21 at 4 17 54 pm" src="https://user-images.githubusercontent.com/1588648/51503575-51279700-1da1-11e9-8182-ccde345cfbde.png">
> <img width="1047" alt="screen shot 2019-01-21 at 4 17 57 pm" src="https://user-images.githubusercontent.com/1588648/51503576-51279700-1da1-11e9-9c79-95124cb3dce3.png">

> Errors in DetailView
<img width="1056" alt="screen shot 2019-01-21 at 4 18 11 pm" src="https://user-images.githubusercontent.com/1588648/51503577-51279700-1da1-11e9-875f-5db55848d717.png">
<img width="1056" alt="screen shot 2019-01-21 at 4 18 13 pm" src="https://user-images.githubusercontent.com/1588648/51503578-51279700-1da1-11e9-8059-f308d4433678.png">
