### PR TITLE
Attempt to deterministically mock prototypes

### DIFF
--- a/src/test/components/GlobalTrack.test.js
+++ b/src/test/components/GlobalTrack.test.js
@@ -20,6 +20,7 @@ import mockCanvasContext from '../fixtures/mocks/canvas-context';
 import { getProfileWithNiceTracks } from '../fixtures/profiles/tracks';
 import { storeWithProfile } from '../fixtures/stores';
 import { getBoundingBox } from '../fixtures/utils';
+import { mockPrototype } from '../fixtures/mocks/prototype';
 
 const LEFT_CLICK = 0;
 const RIGHT_CLICK = 2;
@@ -50,12 +51,12 @@ describe('timeline/GlobalTrack', function() {
     }
 
     // Some child components render to canvas.
-    jest
-      .spyOn(HTMLCanvasElement.prototype, 'getContext')
-      .mockImplementation(() => mockCanvasContext());
-    jest
-      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
-      .mockImplementation(() => getBoundingBox(400, 400));
+    mockPrototype(HTMLCanvasElement.prototype, 'getContext', () =>
+      mockCanvasContext()
+    );
+    mockPrototype(HTMLElement.prototype, 'getBoundingClientRect', () =>
+      getBoundingBox(400, 400)
+    );
 
     // The assertions are simpler if this thread is not already selected.
     dispatch(changeSelectedThread(threadIndex + 1));

--- a/src/test/components/JsTracer.test.js
+++ b/src/test/components/JsTracer.test.js
@@ -21,6 +21,8 @@ import {
 } from '../fixtures/utils';
 import { getProfileWithJsTracerEvents } from '../fixtures/profiles/processed-profile';
 import { getShowJsTracerSummary } from '../../selectors/url-state';
+import { mockPrototype } from '../fixtures/mocks/prototype';
+
 jest.useFakeTimers();
 
 const GRAPH_BASE_WIDTH = 200;
@@ -42,13 +44,10 @@ describe('StackChart', function() {
     const flushRafCalls = mockRaf();
     const ctx = mockCanvasContext();
 
-    jest
-      .spyOn(HTMLCanvasElement.prototype, 'getContext')
-      .mockImplementation(() => ctx);
-
-    jest
-      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
-      .mockImplementation(() => getBoundingBox(GRAPH_WIDTH, GRAPH_HEIGHT));
+    mockPrototype(HTMLCanvasElement.prototype, 'getContext', () => ctx);
+    mockPrototype(HTMLElement.prototype, 'getBoundingClientRect', () =>
+      getBoundingBox(GRAPH_WIDTH, GRAPH_HEIGHT)
+    );
 
     const profile = getProfileWithJsTracerEvents(events);
 

--- a/src/test/components/LocalTrack.test.js
+++ b/src/test/components/LocalTrack.test.js
@@ -34,6 +34,7 @@ import {
 import { getProfileWithNiceTracks } from '../fixtures/profiles/tracks';
 import { storeWithProfile } from '../fixtures/stores';
 import { getBoundingBox } from '../fixtures/utils';
+import { mockPrototype } from '../fixtures/mocks/prototype';
 
 // In getProfileWithNiceTracks, the two pids are 111 and 222 for the
 // "GeckoMain process" and "GeckoMain tab" respectively. Use 222 since it has
@@ -144,12 +145,12 @@ function setup(
   dispatch(changeSelectedThread(threadIndex + 1));
 
   // Some child components render to canvas.
-  jest
-    .spyOn(HTMLCanvasElement.prototype, 'getContext')
-    .mockImplementation(() => mockCanvasContext());
-  jest
-    .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
-    .mockImplementation(() => getBoundingBox(400, 400));
+  mockPrototype(HTMLCanvasElement.prototype, 'getContext', () =>
+    mockCanvasContext()
+  );
+  mockPrototype(HTMLElement.prototype, 'getBoundingClientRect', () =>
+    getBoundingBox(400, 400)
+  );
 
   const renderResult = render(
     <Provider store={store}>

--- a/src/test/components/MarkerChart.test.js
+++ b/src/test/components/MarkerChart.test.js
@@ -26,6 +26,7 @@ import {
   removeRootOverlayElement,
 } from '../fixtures/utils';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
+import { mockPrototype } from '../fixtures/mocks/prototype';
 
 const MARKERS = [
   ['Marker A', 0, { startTime: 0, endTime: 10 }],
@@ -65,17 +66,13 @@ const MARKERS = [
 function setupWithProfile(profile) {
   const flushRafCalls = mockRaf();
   const ctx = mockCanvasContext();
-  jest
-    .spyOn(HTMLCanvasElement.prototype, 'getContext')
-    .mockImplementation(() => ctx);
+  mockPrototype(HTMLCanvasElement.prototype, 'getContext', () => ctx);
 
   // Ideally we'd want this only on the Canvas and on ChartViewport, but this is
   // a lot easier to mock this everywhere.
-  jest
-    .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
-    .mockImplementation(() =>
-      getBoundingBox(200 + TIMELINE_MARGIN_LEFT + TIMELINE_MARGIN_RIGHT, 300)
-    );
+  mockPrototype(HTMLElement.prototype, 'getBoundingClientRect', () =>
+    getBoundingBox(200 + TIMELINE_MARGIN_LEFT + TIMELINE_MARGIN_RIGHT, 300)
+  );
 
   const store = storeWithProfile(profile);
   store.dispatch(changeSelectedTab('marker-chart'));

--- a/src/test/components/MarkerTable.test.js
+++ b/src/test/components/MarkerTable.test.js
@@ -10,13 +10,14 @@ import { Provider } from 'react-redux';
 import { storeWithProfile } from '../fixtures/stores';
 import { getProfileWithMarkers } from '../fixtures/profiles/processed-profile';
 import { getBoundingBox } from '../fixtures/utils';
+import { mockPrototype } from '../fixtures/mocks/prototype';
 
 describe('MarkerTable', function() {
   it('renders some basic markers', () => {
     // Set an arbitrary size that will not kick in any virtualization behavior.
-    jest
-      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
-      .mockImplementation(() => getBoundingBox(2000, 1000));
+    mockPrototype(HTMLElement.prototype, 'getBoundingClientRect', () =>
+      getBoundingBox(2000, 1000)
+    );
 
     // These were all taken from real-world values.
     const profile = getProfileWithMarkers(

--- a/src/test/components/NetworkChart.test.js
+++ b/src/test/components/NetworkChart.test.js
@@ -19,6 +19,8 @@ import {
 } from '../fixtures/profiles/processed-profile';
 import { getBoundingBox } from '../fixtures/utils';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
+import { mockPrototype } from '../fixtures/mocks/prototype';
+
 import { type NetworkPayload } from '../../types/markers';
 
 const NETWORK_MARKERS = Array(10)
@@ -28,15 +30,13 @@ const NETWORK_MARKERS = Array(10)
 function setupWithProfile(profile) {
   const flushRafCalls = mockRaf();
   const ctx = mockCanvasContext();
-  jest
-    .spyOn(HTMLCanvasElement.prototype, 'getContext')
-    .mockImplementation(() => ctx);
+  mockPrototype(HTMLCanvasElement.prototype, 'getContext', () => ctx);
 
   // Ideally we'd want this only on the Canvas and on ChartViewport, but this is
   // a lot easier to mock this everywhere.
-  jest
-    .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
-    .mockImplementation(() => getBoundingBox(200, 300));
+  mockPrototype(HTMLElement.prototype, 'getBoundingClientRect', () =>
+    getBoundingBox(200, 300)
+  );
 
   const store = storeWithProfile(profile);
   store.dispatch(changeSelectedTab('network-chart'));

--- a/src/test/components/ProfileCallTreeView.test.js
+++ b/src/test/components/ProfileCallTreeView.test.js
@@ -23,6 +23,7 @@ import {
   changeInvertCallstack,
   commitRange,
 } from '../../actions/profile-view';
+import { mockPrototype } from '../fixtures/mocks/prototype';
 
 describe('calltree/ProfileCallTreeView', function() {
   const { profile } = getProfileFromTextSamples(`
@@ -35,9 +36,9 @@ describe('calltree/ProfileCallTreeView', function() {
 
   beforeEach(() => {
     // Mock out the 2d canvas for the loupe view.
-    jest
-      .spyOn(HTMLCanvasElement.prototype, 'getContext')
-      .mockImplementation(() => mockCanvasContext());
+    mockPrototype(HTMLCanvasElement.prototype, 'getContext', () =>
+      mockCanvasContext()
+    );
   });
 
   it('renders an unfiltered call tree', () => {
@@ -117,9 +118,9 @@ describe('calltree/ProfileCallTreeView', function() {
 describe('calltree/ProfileCallTreeView EmptyReasons', function() {
   beforeEach(() => {
     // Mock out the 2d canvas for the loupe view.
-    jest
-      .spyOn(HTMLCanvasElement.prototype, 'getContext')
-      .mockImplementation(() => mockCanvasContext());
+    mockPrototype(HTMLCanvasElement.prototype, 'getContext', () =>
+      mockCanvasContext()
+    );
   });
 
   const { profile } = getProfileFromTextSamples(`
@@ -163,19 +164,17 @@ describe('calltree/ProfileCallTreeView EmptyReasons', function() {
 });
 
 describe('calltree/ProfileCallTreeView navigation keys', () => {
-  beforeEach(() => {
-    // Mock out the 2d canvas for the loupe view.
-    jest
-      .spyOn(HTMLCanvasElement.prototype, 'getContext')
-      .mockImplementation(() => mockCanvasContext());
-  });
-
   function setup(profileString: string, expectedRowsLength: number) {
+    // Mock out the 2d canvas for the loupe view.
+    mockPrototype(HTMLCanvasElement.prototype, 'getContext', () =>
+      mockCanvasContext()
+    );
+
     // This makes the bounding box large enough so that we don't trigger
     // VirtualList's virtualization. We assert this above.
-    jest
-      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
-      .mockImplementation(() => getBoundingBox(1000, 2000));
+    mockPrototype(HTMLElement.prototype, 'getBoundingClientRect', () =>
+      getBoundingBox(1000, 2000)
+    );
 
     const { profile } = getProfileFromTextSamples(profileString);
     const store = storeWithProfile(profile);

--- a/src/test/components/StackChart.test.js
+++ b/src/test/components/StackChart.test.js
@@ -26,6 +26,7 @@ import {
   removeRootOverlayElement,
 } from '../fixtures/utils';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
+import { mockPrototype } from '../fixtures/mocks/prototype';
 
 jest.useFakeTimers();
 
@@ -42,13 +43,11 @@ describe('StackChart', function() {
     const flushRafCalls = mockRaf();
     const ctx = mockCanvasContext();
 
-    jest
-      .spyOn(HTMLCanvasElement.prototype, 'getContext')
-      .mockImplementation(() => ctx);
+    mockPrototype(HTMLCanvasElement.prototype, 'getContext', () => ctx);
 
-    jest
-      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
-      .mockImplementation(() => getBoundingBox(GRAPH_WIDTH, GRAPH_HEIGHT));
+    mockPrototype(HTMLElement.prototype, 'getBoundingClientRect', () =>
+      getBoundingBox(GRAPH_WIDTH, GRAPH_HEIGHT)
+    );
 
     const {
       profile,

--- a/src/test/components/ThreadActivityGraph.test.js
+++ b/src/test/components/ThreadActivityGraph.test.js
@@ -20,7 +20,7 @@ import mockCanvasContext from '../fixtures/mocks/canvas-context';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
 import { storeWithProfile } from '../fixtures/stores';
 import { getBoundingBox, getMouseEvent } from '../fixtures/utils';
-
+import { mockPrototype } from '../fixtures/mocks/prototype';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
 
 // The following constants determine the size of the drawn graph.
@@ -58,13 +58,11 @@ describe('SelectedThreadActivityGraph', function() {
     const flushRafCalls = mockRaf();
     const ctx = mockCanvasContext();
 
-    jest
-      .spyOn(HTMLCanvasElement.prototype, 'getContext')
-      .mockImplementation(() => ctx);
+    mockPrototype(HTMLCanvasElement.prototype, 'getContext', () => ctx);
 
-    jest
-      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
-      .mockImplementation(() => getBoundingBox(GRAPH_WIDTH, GRAPH_HEIGHT));
+    mockPrototype(HTMLElement.prototype, 'getBoundingClientRect', () =>
+      getBoundingBox(GRAPH_WIDTH, GRAPH_HEIGHT)
+    );
 
     const viewport: Viewport = {
       containerWidth: GRAPH_WIDTH,

--- a/src/test/components/Timeline.test.js
+++ b/src/test/components/Timeline.test.js
@@ -13,6 +13,7 @@ import mockCanvasContext from '../fixtures/mocks/canvas-context';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
 import { getBoundingBox } from '../fixtures/utils';
 import ReactDOM from 'react-dom';
+import { mockPrototype } from '../fixtures/mocks/prototype';
 
 import type { Profile } from '../../types/profile';
 
@@ -74,18 +75,16 @@ describe('Timeline', function() {
       return mockEl;
     });
 
-    jest
-      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
-      .mockImplementation(() => getBoundingBox(200, 300));
+    mockPrototype(HTMLElement.prototype, 'getBoundingClientRect', () =>
+      getBoundingBox(200, 300)
+    );
   });
 
   it('renders the header', () => {
     const flushRafCalls = mockRaf();
     window.devicePixelRatio = 1;
     const ctx = mockCanvasContext();
-    jest
-      .spyOn(HTMLCanvasElement.prototype, 'getContext')
-      .mockImplementation(() => ctx);
+    mockPrototype(HTMLCanvasElement.prototype, 'getContext', () => ctx);
 
     const profile = _getProfileWithDroppedSamples();
 

--- a/src/test/components/TimelineTracingMarkersOverview.test.js
+++ b/src/test/components/TimelineTracingMarkersOverview.test.js
@@ -13,6 +13,7 @@ import { getProfileWithMarkers } from '../fixtures/profiles/processed-profile';
 import ReactDOM from 'react-dom';
 import { getBoundingBox } from '../fixtures/utils';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
+import { mockPrototype } from '../fixtures/mocks/prototype';
 
 describe('TimelineMarkersOverview', function() {
   beforeEach(() => {
@@ -30,12 +31,10 @@ describe('TimelineMarkersOverview', function() {
     const flushRafCalls = mockRaf();
     window.devicePixelRatio = 1;
     const ctx = mockCanvasContext();
-    jest
-      .spyOn(HTMLCanvasElement.prototype, 'getBoundingClientRect')
-      .mockImplementation(() => getBoundingBox(200, 300));
-    jest
-      .spyOn(HTMLCanvasElement.prototype, 'getContext')
-      .mockImplementation(() => ctx);
+    mockPrototype(HTMLCanvasElement.prototype, 'getBoundingClientRect', () =>
+      getBoundingBox(200, 300)
+    );
+    mockPrototype(HTMLCanvasElement.prototype, 'getContext', () => ctx);
 
     const profile = getProfileWithMarkers([
       ['GCMajor', 2, { startTime: 2, endTime: 12 }],

--- a/src/test/components/Tooltip.test.js
+++ b/src/test/components/Tooltip.test.js
@@ -13,6 +13,7 @@ import {
 } from '../fixtures/utils';
 
 import { ensureExists } from '../../utils/flow';
+import { mockPrototype } from '../fixtures/mocks/prototype';
 
 import Tooltip, { MOUSE_OFFSET } from '../../components/shared/Tooltip';
 
@@ -97,12 +98,8 @@ function setup({ box, mouse }: Setup) {
   // 1024x768. It wouldn't be so easy to mock, because given it's a simple value
   // in `window` we can't use Jest's `spyOn` on it and rely on Jest's easy mock
   // restore.
-  jest
-    .spyOn(HTMLElement.prototype, 'offsetWidth', 'get')
-    .mockImplementation(() => box.width);
-  jest
-    .spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
-    .mockImplementation(() => box.height);
+  mockPrototype(HTMLElement.prototype, 'offsetWidth', () => box.width, 'get');
+  mockPrototype(HTMLElement.prototype, 'offsetHeight', () => box.height, 'get');
 
   const { rerender } = render(
     <Tooltip mouseX={mouse.x} mouseY={mouse.y}>

--- a/src/test/components/TrackMemory.test.js
+++ b/src/test/components/TrackMemory.test.js
@@ -22,7 +22,7 @@ import {
   removeRootOverlayElement,
   getMouseEvent,
 } from '../fixtures/utils';
-
+import { mockPrototype } from '../fixtures/mocks/prototype';
 import {
   getProfileFromTextSamples,
   getCounterForThread,
@@ -59,13 +59,10 @@ describe('TrackMemory', function() {
     const flushRafCalls = mockRaf();
     const ctx = mockCanvasContext();
 
-    jest
-      .spyOn(HTMLCanvasElement.prototype, 'getContext')
-      .mockImplementation(() => ctx);
-
-    jest
-      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
-      .mockImplementation(() => getBoundingBox(GRAPH_WIDTH, GRAPH_HEIGHT));
+    mockPrototype(HTMLCanvasElement.prototype, 'getContext', () => ctx);
+    mockPrototype(HTMLElement.prototype, 'getBoundingClientRect', () =>
+      getBoundingBox(GRAPH_WIDTH, GRAPH_HEIGHT)
+    );
 
     const renderResult = render(
       <Provider store={store}>

--- a/src/test/components/TrackNetwork.test.js
+++ b/src/test/components/TrackNetwork.test.js
@@ -15,7 +15,7 @@ import mockCanvasContext from '../fixtures/mocks/canvas-context';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
 import { storeWithProfile } from '../fixtures/stores';
 import { getBoundingBox } from '../fixtures/utils';
-
+import { mockPrototype } from '../fixtures/mocks/prototype';
 import { getNetworkTrackProfile } from '../fixtures/profiles/processed-profile';
 
 // The graph is 400 pixels wide based on the getBoundingBox mock, and the graph height
@@ -56,13 +56,10 @@ function setup() {
   const { getState, dispatch } = store;
   const flushRafCalls = mockRaf();
   const ctx = mockCanvasContext();
-  jest
-    .spyOn(HTMLCanvasElement.prototype, 'getContext')
-    .mockImplementation(() => ctx);
-
-  jest
-    .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
-    .mockImplementation(() => getBoundingBox(GRAPH_WIDTH, GRAPH_HEIGHT));
+  mockPrototype(HTMLCanvasElement.prototype, 'getContext', () => ctx);
+  mockPrototype(HTMLElement.prototype, 'getBoundingClientRect', () =>
+    getBoundingBox(GRAPH_WIDTH, GRAPH_HEIGHT)
+  );
 
   const renderResult = render(
     <Provider store={store}>

--- a/src/test/components/TrackScreenshots.test.js
+++ b/src/test/components/TrackScreenshots.test.js
@@ -20,6 +20,7 @@ import TrackScreenshots, {
 import Timeline from '../../components/timeline';
 import { ensureExists } from '../../utils/flow';
 
+import { mockPrototype } from '../fixtures/mocks/prototype';
 import mockCanvasContext from '../fixtures/mocks/canvas-context';
 import mockRaf from '../fixtures/mocks/request-animation-frame';
 import { storeWithProfile } from '../fixtures/stores';
@@ -142,22 +143,18 @@ function setup(
   const { getState, dispatch } = store;
   const flushRafCalls = mockRaf();
   const ctx = mockCanvasContext();
-  jest
-    .spyOn(HTMLCanvasElement.prototype, 'getContext')
-    .mockImplementation(() => ctx);
-  jest
-    .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
-    .mockImplementation(() => {
-      const rect = getBoundingBox(TRACK_WIDTH, TRACK_HEIGHT);
-      // Add some arbitrary X offset.
-      rect.left += LEFT;
-      rect.right += LEFT;
-      rect.x += LEFT;
-      rect.y += TOP;
-      rect.top += TOP;
-      rect.bottom += TOP;
-      return rect;
-    });
+  mockPrototype(HTMLCanvasElement.prototype, 'getContext', () => ctx);
+  mockPrototype(HTMLElement.prototype, 'getBoundingClientRect', () => {
+    const rect = getBoundingBox(TRACK_WIDTH, TRACK_HEIGHT);
+    // Add some arbitrary X offset.
+    rect.left += LEFT;
+    rect.right += LEFT;
+    rect.x += LEFT;
+    rect.y += TOP;
+    rect.top += TOP;
+    rect.bottom += TOP;
+    return rect;
+  });
 
   const renderResult = render(<Provider store={store}>{component}</Provider>);
   const { container } = renderResult;

--- a/src/test/components/TrackThread.test.js
+++ b/src/test/components/TrackThread.test.js
@@ -26,7 +26,7 @@ import {
   addRootOverlayElement,
   removeRootOverlayElement,
 } from '../fixtures/utils';
-
+import { mockPrototype } from '../fixtures/mocks/prototype';
 import {
   getProfileFromTextSamples,
   getProfileWithMarkers,
@@ -78,13 +78,10 @@ describe('timeline/TrackThread', function() {
     const threadIndex = 0;
     const flushRafCalls = mockRaf();
     const ctx = mockCanvasContext();
-    jest
-      .spyOn(HTMLCanvasElement.prototype, 'getContext')
-      .mockImplementation(() => ctx);
-
-    jest
-      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
-      .mockImplementation(() => getBoundingBox(GRAPH_WIDTH, GRAPH_HEIGHT));
+    mockPrototype(HTMLCanvasElement.prototype, 'getContext', () => ctx);
+    mockPrototype(HTMLElement.prototype, 'getBoundingClientRect', () =>
+      getBoundingBox(GRAPH_WIDTH, GRAPH_HEIGHT)
+    );
 
     // Note: These tests were first written with the timeline using the ThreadStackGraph.
     // This is not the default view, so dispatch an action to change to the older default

--- a/src/test/components/Viewport.test.js
+++ b/src/test/components/Viewport.test.js
@@ -23,6 +23,7 @@ import mockRaf from '../fixtures/mocks/request-animation-frame';
 import { storeWithProfile } from '../fixtures/stores';
 import { getBoundingBox } from '../fixtures/utils';
 import { getProfileFromTextSamples } from '../fixtures/profiles/processed-profile';
+import { mockPrototype } from '../fixtures/mocks/prototype';
 
 import type { Milliseconds } from '../../types/units';
 
@@ -608,13 +609,10 @@ function setup(profileOverrides: Object = {}) {
   const flushRafCalls = mockRaf();
   const ctx = mockCanvasContext();
 
-  jest
-    .spyOn(HTMLCanvasElement.prototype, 'getContext')
-    .mockImplementation(() => ctx);
-
-  jest
-    .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
-    .mockImplementation(() => getBoundingBoxForViewport());
+  mockPrototype(HTMLCanvasElement.prototype, 'getContext', () => ctx);
+  mockPrototype(HTMLElement.prototype, 'getBoundingClientRect', () =>
+    getBoundingBoxForViewport()
+  );
 
   // Hook up a dummy chart with a viewport.
   const DummyChart = jest.fn(() => <div id="dummy-chart" />);

--- a/src/test/components/ZipFileTree.test.js
+++ b/src/test/components/ZipFileTree.test.js
@@ -14,6 +14,7 @@ import * as ZippedProfileSelectors from '../../selectors/zipped-profiles';
 import { storeWithZipFile } from '../fixtures/profiles/zip-file';
 import mockCanvasContext from '../fixtures/mocks/canvas-context';
 import { waitUntilState } from '../fixtures/utils';
+import { mockPrototype } from '../fixtures/mocks/prototype';
 
 describe('calltree/ZipFileTree', function() {
   async function setup() {
@@ -24,9 +25,9 @@ describe('calltree/ZipFileTree', function() {
     ]);
 
     // Some child components render to canvas.
-    jest
-      .spyOn(HTMLCanvasElement.prototype, 'getContext')
-      .mockImplementation(() => mockCanvasContext());
+    mockPrototype(HTMLCanvasElement.prototype, 'getContext', () =>
+      mockCanvasContext()
+    );
 
     const renderResult = render(
       <Provider store={store}>

--- a/src/test/components/__snapshots__/FlameGraph.test.js.snap
+++ b/src/test/components/__snapshots__/FlameGraph.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders FlameGraph correctly 1`] = `
+exports[`FlameGraph renders FlameGraph correctly 1`] = `
 <div
   aria-labelledby="flame-graph-tab-button"
   class="flameGraph"
@@ -140,7 +140,7 @@ exports[`renders FlameGraph correctly 1`] = `
 </div>
 `;
 
-exports[`renders FlameGraph correctly 2`] = `
+exports[`FlameGraph renders FlameGraph correctly 2`] = `
 Array [
   Array [
     "scale",
@@ -493,7 +493,7 @@ Array [
 ]
 `;
 
-exports[`renders a message instead of FlameGraph when call stack is inverted 1`] = `
+exports[`FlameGraph renders a message instead of FlameGraph when call stack is inverted 1`] = `
 <div
   aria-labelledby="flame-graph-tab-button"
   class="flameGraph"

--- a/src/test/fixtures/mocks/prototype.js
+++ b/src/test/fixtures/mocks/prototype.js
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+import { oneLine } from 'common-tags';
+
+type SpyReference = {| +methodName: string, +prototype: Object |};
+let _spies: SpyReference[] = [];
+
+/**
+ * We have run into issues with Jest's mocking of prototypes. The prototypes of jsdom
+ * are shared between various test runs, which all run in parallel. This means that if
+ * the mocks for prototypes aren't cleaned up properly, then it can cause intermittent
+ * failures. This was happening in our test suite.
+ *
+ * This function caches the spies on the prototype object itself, and then checks before
+ * adding a new one that any previous spies have been properly cleaned up.
+ */
+export function mockPrototype<Prototype: Object, MockImplementation: Function>(
+  prototype: Prototype,
+  methodName: string,
+  mockImplementation: MockImplementation,
+  getterSetter?: 'get' | 'set'
+) {
+  const spyKey = _getSpyKey(methodName);
+
+  if (prototype[spyKey]) {
+    const prototypeName = `${
+      HTMLElement.prototype.constructor.name
+    }.${methodName}`;
+    throw new Error(
+      oneLine`
+        A spy existed already on ${prototypeName}. Either a test is mistakenly adding
+        a mock multiple times to the prototype, or is an error in the parallel runner
+        of jest.
+      `
+    );
+  }
+
+  const spy = getterSetter
+    ? jest
+        .spyOn(prototype, methodName, 'get')
+        .mockImplementation(mockImplementation)
+    : jest.spyOn(prototype, methodName).mockImplementation(mockImplementation);
+
+  prototype[spyKey] = spy;
+  _spies.push({ methodName, prototype });
+}
+
+/**
+ * Go through the spy references, and clean them all up. This needs to be run after each
+ * test using the afterEach mechanism in src/test/setup.js file.
+ */
+export function cleanupPrototypeSpies() {
+  for (const { methodName, prototype } of _spies) {
+    const spyKey = _getSpyKey(methodName);
+    prototype[spyKey].mockRestore();
+    delete prototype[spyKey];
+  }
+  _spies = [];
+}
+
+function _getSpyKey(methodName: string) {
+  return `__perfHtmlSpy_${methodName}`;
+}

--- a/src/test/fixtures/mocks/prototype.js
+++ b/src/test/fixtures/mocks/prototype.js
@@ -40,7 +40,7 @@ export function mockPrototype<Prototype: Object, MockImplementation: Function>(
 
   const spy = getterSetter
     ? jest
-        .spyOn(prototype, methodName, 'get')
+        .spyOn(prototype, methodName, getterSetter)
         .mockImplementation(mockImplementation)
     : jest.spyOn(prototype, methodName).mockImplementation(mockImplementation);
 

--- a/src/test/setup.js
+++ b/src/test/setup.js
@@ -7,6 +7,7 @@ import { cleanup } from 'react-testing-library';
 
 jest.mock('../utils/worker-factory');
 import * as WorkerFactory from '../utils/worker-factory';
+import { cleanupPrototypeSpies } from './fixtures/mocks/prototype';
 
 afterEach(function() {
   // This `__shutdownWorkers` function only exists in the mocked test environment,
@@ -16,6 +17,7 @@ afterEach(function() {
 });
 
 afterEach(cleanup);
+afterEach(cleanupPrototypeSpies);
 
 afterEach(() => {
   // The configuration to restore and reset all of the mocks in tests does not seem


### PR DESCRIPTION
And throw errors if something weird happens.

Crazy stuff is happening, and I don't trust it. This caches the known spies on the prototype object itself. Then, after each test, it manually removes them, and clears the cache. If you attempt to mock a method when it's already mocked, it throws an explicit error.

The interesting bits happen in: https://github.com/devtools-html/perf.html/compare/master...gregtatum:mock-prototype?expand=1#diff-1d8b0169098756371378bb572465b563R1

I'd like your feedback on this @julienw. I feel like I shouldn't need to do this, but it's at least the sanest way I can think to trust that we're doing the right thing.
