### PR TITLE
Remove the gigantic Promise-then chain in profile sharing function

### DIFF
--- a/src/components/app/MenuButtons.js
+++ b/src/components/app/MenuButtons.js
@@ -454,19 +454,20 @@ class ProfileSharingCompositeButton extends React.PureComponent<
             };
           });
 
+          if (this._permalinkButton) {
+            this._permalinkButton.openPanel();
+          }
+
           sendAnalytics({
             hitType: 'event',
             eventCategory: 'profile upload',
             eventAction: 'succeeded',
           });
         });
-        const shortenUrlPromise = this._shortenUrlAndFocusTextFieldOnCompletion();
-        Promise.race([uploadPromise, shortenUrlPromise]).then(() => {
-          if (this._permalinkButton) {
-            this._permalinkButton.openPanel();
-          }
-        });
-        return Promise.all([uploadPromise, shortenUrlPromise]);
+        return Promise.all([
+          uploadPromise,
+          this._shortenUrlAndFocusTextFieldOnCompletion(),
+        ]);
       })
       .catch((error: Error) => {
         // To avoid any interaction with running transitions, we delay setting


### PR DESCRIPTION
Made the permalink panel show up after uploading process and removed the gigantic Promise-then chain using await.
The reason to change permalink panel behavior is not to confuse people. Previously people were thinking that upload process is finished when they see the permalink panel and closing the tab. Therefore, they were losing the profile for good.