### PR TITLE
Truncate displayed URL strings to length 1000

### DIFF
--- a/src/profile-logic/call-tree.js
+++ b/src/profile-logic/call-tree.js
@@ -226,7 +226,7 @@ export class CallTree {
         selfTimeWithUnit: selfTime === 0 ? '—' : formattedSelfTime + 'ms',
         totalTimePercent: `${formatPercent(totalTimeRelative)}`,
         name: funcName,
-        lib: libName,
+        lib: libName.slice(0, 1000),
         // Dim platform pseudo-stacks.
         dim: !isJS && this._jsOnly,
         categoryName: this._categories[categoryIndex].name,


### PR DESCRIPTION
Fixes #1502.
Fixes the issue by slicing the URL to the required number of maximum characters (1000). Please review.