### PR TITLE
Add tests for the gzip functionality - worker_threads

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:8.9
+      - image: circleci/node:10.15
     steps:
       - checkout
       - restore_cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 clone_depth: 5
 environment:
-  nodejs_version: "8.9"
+  nodejs_version: "10.15"
 platform: x64 # flow needs 64b platforms
 # Install scripts. (runs after repo cloning)
 install:

--- a/bin/pre-install.js
+++ b/bin/pre-install.js
@@ -62,6 +62,15 @@ function checkNode(agents /*: AgentsVersion */) {
     console.error(
       'You can look at https://github.com/creationix/nvm to install this tool.\n'
     );
+    console.error(
+      'Once `nvm` is installed you can use the following commands to upgrade:\n' +
+        'nvm install ' +
+        expectedNodeVersion +
+        '\n' +
+        'nvm alias default ' +
+        expectedNodeVersion +
+        '\n'
+    );
     return false;
   }
   return true;

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "start-prod": "yarn build-prod && yarn serve-static",
     "start-examples": "ws -d examples/ -s index.html -p 4242",
     "start-docs": "docsify serve ./docs-user",
-    "test": "cross-env NODE_ENV=test jest",
+    "test": "cross-env NODE_ENV=test NODE_OPTIONS=--experimental-worker jest",
     "test-all": "run-p flow license-check lint test",
     "test-build-coverage": "jest --coverage --coverageReporters=html",
     "test-serve-coverage": "ws -d coverage/ -p 4343",
@@ -132,8 +132,7 @@
     "stylelint-config-standard": "^18.2.0",
     "webpack": "^4.26.1",
     "webpack-cli": "^3.1.0",
-    "webpack-dev-server": "^3.1.7",
-    "workerjs": "github:jasonLaster/workerjs"
+    "webpack-dev-server": "^3.1.7"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/src/components/app/MenuButtons.js
+++ b/src/components/app/MenuButtons.js
@@ -421,7 +421,7 @@ class ProfileSharingCompositeButton extends React.PureComponent<
 
       const typedArray = new TextEncoder().encode(jsonString);
 
-      const [gzipData, hash]: [string, string] = await Promise.all([
+      const [gzipData, hash]: [Uint8Array, string] = await Promise.all([
         compress(typedArray.slice(0)),
         sha1(typedArray),
       ]);

--- a/src/profile-logic/profile-store.js
+++ b/src/profile-logic/profile-store.js
@@ -4,7 +4,7 @@
 // @flow
 
 export function uploadBinaryProfileData(
-  data: string,
+  data: $TypedArray,
   progressChangeCallback?: number => mixed
 ): Promise<string> {
   return new Promise((resolve, reject) => {

--- a/src/test/unit/gz.test.js
+++ b/src/test/unit/gz.test.js
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// @flow
+
+import { compress, decompress } from '../../utils/gz';
+
+import { TextEncoder, TextDecoder } from 'util';
+
+beforeAll(function() {
+  if ((window: any).TextEncoder) {
+    throw new Error('A TextEncoder was already on the window object.');
+  }
+  (window: any).TextEncoder = TextEncoder;
+});
+
+afterAll(async function() {
+  delete (window: any).TextEncoder;
+});
+
+describe('utils/gz', function() {
+  it('compresses and decompresses properly', async () => {
+    const clearText = '42';
+    const gzipedData = await compress(clearText);
+    expect(gzipedData).toBeInstanceOf(Uint8Array);
+
+    const gunzippedDataBuffer = await decompress(gzipedData);
+    const decoder = new TextDecoder('utf-8');
+    const gunzippedData = decoder.decode(gunzippedDataBuffer);
+    expect(gunzippedData).toEqual(clearText);
+  });
+});

--- a/src/types/libdef/npm-custom/worker_threads_vx.x.x.js
+++ b/src/types/libdef/npm-custom/worker_threads_vx.x.x.js
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+
+declare module 'worker_threads' {
+  declare module.exports: {
+    parentPort: MessagePort,
+    workerData: mixed,
+  };
+}

--- a/src/utils/__mocks__/node-worker-contents.js
+++ b/src/utils/__mocks__/node-worker-contents.js
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 // @flow
-// $FlowExpectError Flow doesn't know about this module
+//
 const { parentPort, workerData } = require('worker_threads');
 const fs = require('fs');
 const vm = require('vm');
 
-if (!workerData) {
+if (typeof workerData !== 'string') {
   throw new Error(`Please pass a file name using the 'workerData' property.`);
 }
 

--- a/src/utils/__mocks__/node-worker-contents.js
+++ b/src/utils/__mocks__/node-worker-contents.js
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+// @flow
+// $FlowExpectError Flow doesn't know about this module
+const { parentPort, workerData } = require('worker_threads');
+const fs = require('fs');
+const vm = require('vm');
+
+if (!workerData) {
+  throw new Error(`Please pass a file name using the 'workerData' property.`);
+}
+
+const scriptContent = fs.readFileSync(workerData, 'utf8');
+
+const sandbox = {
+  importScripts: function() {
+    throw new Error(`The function 'importScripts' is not implemented.`);
+  },
+  postMessage: parentPort.postMessage.bind(parentPort),
+  onmessage: function() {},
+};
+
+vm.runInNewContext(scriptContent, sandbox, { filename: workerData });
+
+parentPort.onmessage = sandbox.onmessage.bind(null);

--- a/src/utils/gz.js
+++ b/src/utils/gz.js
@@ -30,7 +30,7 @@ function workerOnMessage(zeeWorker: Worker) {
 export function compress(
   data: string | Uint8Array,
   compressionLevel?: number
-): Promise<string> {
+): Promise<Uint8Array> {
   const zeeWorker = new WebWorker('zee-worker');
   workerOnMessage(zeeWorker);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,42 +63,11 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.0.0":
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.1.2.tgz#f8d2a9ceb6832887329a7b60f9d035791400ba4e"
-  integrity sha512-IFeSSnjXdhDaoysIlev//UzHZbdEmm7D0EIH2qtse9xK7mXEZQpYjs2P00XlP1qYsYvid79p+Zgg6tz1mp6iVw==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@babel/generator" "^7.1.2"
-    "@babel/helpers" "^7.1.2"
-    "@babel/parser" "^7.1.2"
-    "@babel/template" "^7.1.2"
-    "@babel/traverse" "^7.1.0"
-    "@babel/types" "^7.1.2"
-    convert-source-map "^1.1.0"
-    debug "^3.1.0"
-    json5 "^0.5.0"
-    lodash "^4.17.10"
-    resolve "^1.3.2"
-    semver "^5.4.1"
-    source-map "^0.5.0"
-
 "@babel/generator@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.0.0.tgz#1efd58bffa951dc846449e58ce3a1d7f02d393aa"
   dependencies:
     "@babel/types" "^7.0.0"
-    jsesc "^2.5.1"
-    lodash "^4.17.10"
-    source-map "^0.5.0"
-    trim-right "^1.0.1"
-
-"@babel/generator@^7.1.2", "@babel/generator@^7.1.3":
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.1.3.tgz#2103ec9c42d9bdad9190a6ad5ff2d456fd7b8673"
-  integrity sha512-ZoCZGcfIJFJuZBqxcY9OjC1KW2lWK64qrX1o4UYL3yshVhwKFYgzpWZ0vvtGMNJdTlvkw0W+HR1VnYN8q3QPFQ==
-  dependencies:
-    "@babel/types" "^7.1.3"
     jsesc "^2.5.1"
     lodash "^4.17.10"
     source-map "^0.5.0"
@@ -275,15 +244,6 @@
     "@babel/traverse" "^7.0.0"
     "@babel/types" "^7.0.0"
 
-"@babel/helpers@^7.1.2":
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.1.2.tgz#ab752e8c35ef7d39987df4e8586c63b8846234b5"
-  integrity sha512-Myc3pUE8eswD73aWcartxB16K6CGmHDv9KxOmD2CeOs/FaEAQodr3VYGmlvOmog60vNQ2w8QbatuahepZwrHiA==
-  dependencies:
-    "@babel/template" "^7.1.2"
-    "@babel/traverse" "^7.1.0"
-    "@babel/types" "^7.1.2"
-
 "@babel/helpers@^7.2.0":
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.3.1.tgz#949eec9ea4b45d3210feb7dc1c22db664c9e44b9"
@@ -305,7 +265,7 @@
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.0.0.tgz#697655183394facffb063437ddf52c0277698775"
 
-"@babel/parser@^7.1.2", "@babel/parser@^7.1.3":
+"@babel/parser@^7.1.2":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.1.3.tgz#2c92469bac2b7fbff810b67fca07bd138b48af77"
   integrity sha512-gqmspPZOMW3MIRb9HlrnbZHXI1/KHTOroBwN1NcLL6pWxzqzEKGvRTq0W/PxS45OtQGbaFikSQpkS5zbnsQm2w==
@@ -698,19 +658,6 @@
     "@babel/plugin-transform-react-jsx-self" "^7.0.0"
     "@babel/plugin-transform-react-jsx-source" "^7.0.0"
 
-"@babel/register@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.0.0.tgz#fa634bae1bfa429f60615b754fc1f1d745edd827"
-  integrity sha512-f/+CRmaCe7rVEvcvPvxeA8j5aJhHC3aJie7YuqcMDhUOuyWLA7J/aNrTaHIzoWPEhpHA54mec4Mm8fv8KBlv3g==
-  dependencies:
-    core-js "^2.5.7"
-    find-cache-dir "^1.0.0"
-    home-or-tmp "^3.0.0"
-    lodash "^4.17.10"
-    mkdirp "^0.5.1"
-    pirates "^4.0.0"
-    source-map-support "^0.5.9"
-
 "@babel/runtime@^7.1.5":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.2.0.tgz#b03e42eeddf5898e00646e4c840fa07ba8dcad7f"
@@ -758,21 +705,6 @@
     globals "^11.1.0"
     lodash "^4.17.10"
 
-"@babel/traverse@^7.1.0":
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.1.4.tgz#f4f83b93d649b4b2c91121a9087fa2fa949ec2b4"
-  integrity sha512-my9mdrAIGdDiSVBuMjpn/oXYpva0/EZwWL3sm3Wcy/AVWO2eXnsoZruOT9jOGNRXU8KbCIu5zsKnXcAJ6PcV6Q==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@babel/generator" "^7.1.3"
-    "@babel/helper-function-name" "^7.1.0"
-    "@babel/helper-split-export-declaration" "^7.0.0"
-    "@babel/parser" "^7.1.3"
-    "@babel/types" "^7.1.3"
-    debug "^3.1.0"
-    globals "^11.1.0"
-    lodash "^4.17.10"
-
 "@babel/traverse@^7.1.5", "@babel/traverse@^7.2.2":
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.2.3.tgz#7ff50cefa9c7c0bd2d81231fdac122f3957748d8"
@@ -796,7 +728,7 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.1.2", "@babel/types@^7.1.3":
+"@babel/types@^7.1.2":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.1.3.tgz#3a767004567060c2f40fca49a304712c525ee37d"
   integrity sha512-RpPOVfK+yatXyn8n4PB1NW6k9qjinrXrRR8ugBN8fD6hCy5RXI6PSbVqpOJBO9oSaY7Nom4ohj35feb0UR9hSA==
@@ -5058,11 +4990,6 @@ home-or-tmp@^2.0.0:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
 
-home-or-tmp@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-3.0.0.tgz#57a8fe24cf33cdd524860a15821ddc25c86671fb"
-  integrity sha1-V6j+JM8zzdUkhgoVgh3cJchmcfs=
-
 homedir-polyfill@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz#4c2bbc8a758998feebf5ed68580f76d46768b4bc"
@@ -7697,11 +7624,6 @@ node-libs-browser@^2.0.0:
     util "^0.10.3"
     vm-browserify "0.0.4"
 
-node-modules-regexp@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
-  integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
-
 node-notifier@^5.2.1:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.3.0.tgz#c77a4a7b84038733d5fb351aafd8a268bfe19a01"
@@ -8361,13 +8283,6 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
-
-pirates@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.0.tgz#850b18781b4ac6ec58a43c9ed9ec5fe6796addbd"
-  integrity sha512-8t5BsXy1LUIjn3WWOlOuFDuKswhQb/tkak641lvBgmPOBUQHXveORtlMCp6OdPV1dtuTaEahKA8VNz6uLfKBtA==
-  dependencies:
-    node-modules-regexp "^1.0.0"
 
 pkg-dir@^1.0.0:
   version "1.0.0"
@@ -10183,7 +10098,7 @@ source-map-support@^0.5.6:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map-support@^0.5.9, source-map-support@~0.5.6:
+source-map-support@~0.5.6:
   version "0.5.9"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.9.tgz#41bc953b2534267ea2d605bccfa7bfa3111ced5f"
   dependencies:
@@ -11810,13 +11725,6 @@ worker-farm@^1.5.2:
   resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.6.0.tgz#aecc405976fab5a95526180846f0dba288f3a4a0"
   dependencies:
     errno "~0.1.7"
-
-"workerjs@github:jasonLaster/workerjs":
-  version "0.1.3"
-  resolved "https://codeload.github.com/jasonLaster/workerjs/tar.gz/1944c8b753cc9e84b6ed0cb2fbcaa25600706446"
-  dependencies:
-    "@babel/core" "^7.0.0"
-    "@babel/register" "^7.0.0"
 
 wrap-ansi@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
In this PR we fake a web worker by using node's new `worker_threads` capability.

As you notice, with this PR we need to upgrade to node v10. This is the current LTS so I think we should eventually do it anyway.

Please compare with #1730 which doesn't have this requirement. My preference is this PR but I wanted to provide a choice :)