### PR TITLE
Work around unreliable first counter values, see Bug 1520587

### DIFF
--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -1038,14 +1038,30 @@ export function filterCounterToRange(
     sEnd++;
   }
 
+  const count = samples.count.slice(sBegin, sEnd);
+  const number = samples.number.slice(sBegin, sEnd);
+
+  if (sBegin === 0) {
+    // These lines zero out the first values of the counters, as they are unreliable. In
+    // addition, there are probably some missed counts in the memory counters, so the
+    // first memory number slowly creeps up over time, and becomes very unrealistic.
+    // In order to not be affected by these platform limitations, zero out the first
+    // counter values.
+    //
+    // "Memory counter in Gecko Profiler isn't cleared when starting a new capture"
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1520587
+    count[0] = 0;
+    number[0] = 0;
+  }
+
   return {
     ...counter,
     sampleGroups: {
       ...counter.sampleGroups,
       samples: {
         time: samples.time.slice(sBegin, sEnd),
-        number: samples.number.slice(sBegin, sEnd),
-        count: samples.count.slice(sBegin, sEnd),
+        number,
+        count,
         length: sEnd - sBegin,
       },
     },

--- a/src/selectors/profile.js
+++ b/src/selectors/profile.js
@@ -43,6 +43,7 @@ import type {
   SymbolicationStatus,
   ProfileSharingStatus,
 } from '../types/state';
+import type { $ReturnType } from '../types/utils';
 
 export const getProfileView: Selector<ProfileViewState> = state =>
   state.profileView;
@@ -109,8 +110,10 @@ export const getPreviewSelection: Selector<PreviewSelection> = state =>
 export const getCounter: Selector<Counter[] | null> = state =>
   getProfile(state).counters || null;
 
+type CounterSelectors = $ReturnType<typeof _createCounterSelectors>;
+
 const _counterSelectors = {};
-export const getCounterSelectors = (index: CounterIndex) => {
+export const getCounterSelectors = (index: CounterIndex): CounterSelectors => {
   let selectors = _counterSelectors[index];
   if (!selectors) {
     selectors = _createCounterSelectors(index);

--- a/src/test/store/profile-view.test.js
+++ b/src/test/store/profile-view.test.js
@@ -1321,7 +1321,10 @@ describe('counter selectors', function() {
   it('can accumulate samples', function() {
     const { getState, counterA } = setup();
     counterA.sampleGroups.samples.count = [
-      1,
+      // The first value gets zeroed out due to a work-around for Bug 1520587. It
+      // can be much larger than all the rest of the values, as it doesn't ever
+      // get reset.
+      10000,
       -2,
       3,
       -5,
@@ -1335,10 +1338,10 @@ describe('counter selectors', function() {
     expect(
       getCounterSelectors(0).getAccumulateCounterSamples(getState())
     ).toEqual({
-      accumulatedCounts: [1, -1, 2, -3, 4, -7, 6, -11, 8, 31],
+      accumulatedCounts: [0, -2, 1, -4, 3, -8, 5, -12, 7, 30],
       countRange: 42,
-      maxCount: 31,
-      minCount: -11,
+      maxCount: 30,
+      minCount: -12,
     });
   });
 });


### PR DESCRIPTION
https://perfht.ml/2Dg28x9

This fix makes the above profile render a more interesting memory graph.

@canaltinova have you looked at the counters before? Do you mind reviewing?