### PR TITLE
Add a Copy marker's cause option to the context menu for markers

### DIFF
--- a/src/components/marker-table/ContextMenu.js
+++ b/src/components/marker-table/ContextMenu.js
@@ -16,17 +16,29 @@ import copy from 'copy-to-clipboard';
 
 import type { Marker, IndexIntoMarkers } from '../../types/profile-derived';
 import type { StartEndRange } from '../../types/units';
-import type { PreviewSelection } from '../../types/actions';
+import type {
+  PreviewSelection,
+  ImplementationFilter,
+} from '../../types/actions';
 import type {
   ExplicitConnectOptions,
   ConnectedProps,
 } from '../../utils/connect';
+import { getImplementationFilter } from '../../selectors/url-state';
+import type { Thread, IndexIntoStackTable } from '../../types/profile';
+import { filterCallNodePathByImplementation } from '../../profile-logic/transforms';
+import {
+  convertStackToCallNodePath,
+  getFuncNamesAndOriginsForPath,
+} from '../../profile-logic/profile-data';
 
 type StateProps = {|
   +markers: Marker[],
   +previewSelection: PreviewSelection,
   +committedRange: StartEndRange,
   +selectedMarker: IndexIntoMarkers,
+  +thread: Thread,
+  +implementationFilter: ImplementationFilter,
 |};
 
 type DispatchProps = {|
@@ -81,6 +93,24 @@ class MarkersContextMenu extends PureComponent<Props> {
     });
   };
 
+  _convertStackToString(stack: IndexIntoStackTable): string {
+    const { thread, implementationFilter } = this.props;
+
+    const callNodePath = filterCallNodePathByImplementation(
+      thread,
+      implementationFilter,
+      convertStackToCallNodePath(thread, stack)
+    );
+
+    const funcNamesAndOrigins = getFuncNamesAndOriginsForPath(
+      callNodePath,
+      thread
+    );
+    return funcNamesAndOrigins
+      .map(({ funcName, origin }) => `${funcName} [${origin}]`)
+      .join('\n');
+  }
+
   copyMarkerJSON = () => {
     const { selectedMarker, markers } = this.props;
     copy(JSON.stringify(markers[selectedMarker]));
@@ -91,7 +121,19 @@ class MarkersContextMenu extends PureComponent<Props> {
     copy(markers[selectedMarker].name);
   };
 
+  copyMarkerCause = () => {
+    const { markers, selectedMarker } = this.props;
+    const marker = markers[selectedMarker];
+    if (marker && marker.data && marker.data.cause) {
+      const stack = this._convertStackToString(marker.data.cause.stack);
+      copy(stack);
+    }
+  };
+
   render() {
+    const { markers, selectedMarker } = this.props;
+    const marker = markers[selectedMarker];
+
     return (
       <ContextMenu id="MarkersContextMenu">
         <MenuItem onClick={this.setStartRange}>
@@ -102,6 +144,9 @@ class MarkersContextMenu extends PureComponent<Props> {
         </MenuItem>
         <MenuItem onClick={this.copyMarkerJSON}>Copy marker JSON</MenuItem>
         <MenuItem onClick={this.copyMarkerName}>Copy marker name</MenuItem>
+        {marker && marker.data && marker.data.cause ? (
+          <MenuItem onClick={this.copyMarkerCause}>Copy marker cause</MenuItem>
+        ) : null}
       </ContextMenu>
     );
   }
@@ -112,6 +157,8 @@ const options: ExplicitConnectOptions<{||}, StateProps, DispatchProps> = {
     markers: selectedThreadSelectors.getPreviewFilteredMarkers(state),
     previewSelection: getPreviewSelection(state),
     committedRange: getCommittedRange(state),
+    thread: selectedThreadSelectors.getThread(state),
+    implementationFilter: getImplementationFilter(state),
     selectedMarker: selectedThreadSelectors.getSelectedMarkerIndex(state),
   }),
   mapDispatchToProps: { updatePreviewSelection },

--- a/src/components/shared/Backtrace.js
+++ b/src/components/shared/Backtrace.js
@@ -7,7 +7,7 @@
 import React from 'react';
 import { filterCallNodePathByImplementation } from '../../profile-logic/transforms';
 import {
-  getOriginAnnotationForFunc,
+  getFuncNamesAndOriginsForPath,
   convertStackToCallNodePath,
 } from '../../profile-logic/profile-data';
 
@@ -25,27 +25,23 @@ type Props = {|
 
 function Backtrace(props: Props) {
   const { stackIndex, thread, implementationFilter, maxHeight } = props;
-  const { funcTable, stringTable } = thread;
   const callNodePath = filterCallNodePathByImplementation(
     thread,
     implementationFilter,
     convertStackToCallNodePath(thread, stackIndex)
   );
+  const funcNamesAndOrigins = getFuncNamesAndOriginsForPath(
+    callNodePath,
+    thread
+  ).reverse();
 
   return (
     <ol className="backtrace" style={{ '--max-height': maxHeight }}>
-      {callNodePath.length > 0 ? (
-        callNodePath.map((func, i) => (
+      {funcNamesAndOrigins.length > 0 ? (
+        funcNamesAndOrigins.map(({ funcName, origin }, i) => (
           <li key={i} className="backtraceStackFrame">
-            {stringTable.getString(funcTable.name[func])}
-            <em className="backtraceStackFrameOrigin">
-              {getOriginAnnotationForFunc(
-                func,
-                thread.funcTable,
-                thread.resourceTable,
-                thread.stringTable
-              )}
-            </em>
+            {funcName}
+            <em className="backtraceStackFrameOrigin">{origin}</em>
           </li>
         ))
       ) : (

--- a/src/profile-logic/profile-data.js
+++ b/src/profile-logic/profile-data.js
@@ -1247,7 +1247,7 @@ export function convertStackToCallNodePath(
   ) {
     path.push(frameTable.func[stackTable.frame[stackIndex]]);
   }
-  return path;
+  return path.reverse();
 }
 
 /**
@@ -1508,6 +1508,27 @@ export function getOriginAnnotationForFunc(
   }
 
   return '';
+}
+
+/**
+ * From a valid call node path, this function returns a list of information
+ * about each function in this path: their names and their origins.
+ */
+export function getFuncNamesAndOriginsForPath(
+  path: CallNodePath,
+  thread: Thread
+): Array<{ funcName: string, origin: string }> {
+  const { funcTable, stringTable, resourceTable } = thread;
+
+  return path.map(func => ({
+    funcName: stringTable.getString(funcTable.name[func]),
+    origin: getOriginAnnotationForFunc(
+      func,
+      funcTable,
+      resourceTable,
+      stringTable
+    ),
+  }));
 }
 
 /**

--- a/src/test/unit/profile-data.test.js
+++ b/src/test/unit/profile-data.test.js
@@ -768,9 +768,9 @@ describe('convertStackToCallNodePath', function() {
       throw new Error("stack shouldn't be null");
     }
     let callNodePath = convertStackToCallNodePath(thread, stack1);
-    expect(callNodePath).toEqual([4, 3, 2, 1, 0]);
+    expect(callNodePath).toEqual([0, 1, 2, 3, 4]);
     callNodePath = convertStackToCallNodePath(thread, stack2);
-    expect(callNodePath).toEqual([5, 3, 2, 1, 0]);
+    expect(callNodePath).toEqual([0, 1, 2, 3, 5]);
   });
 });
 


### PR DESCRIPTION
Fixes #770 

This is the work of @amelarbab in #1584 that I finished and tweaked a bit.
Note there's no test for this context menu yet, I plan to write one as part of my work to add it to the marker chart.